### PR TITLE
Add US snowfall map shell scaffold

### DIFF
--- a/assets/css/us_snowfall_map.css
+++ b/assets/css/us_snowfall_map.css
@@ -1,0 +1,216 @@
+.us-snowfall-map-section {
+  margin: 18px 0 28px;
+  padding: 18px;
+  border: 1px solid rgba(15, 118, 110, 0.18);
+  border-radius: 24px;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.96) 0%, rgba(239, 246, 255, 0.94) 100%);
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.08);
+}
+
+.us-snowfall-map-header {
+  margin: 0 0 14px;
+  align-items: flex-start;
+}
+
+.us-snowfall-map-heading-wrap {
+  display: grid;
+  gap: 6px;
+}
+
+.us-snowfall-map-heading-wrap h2 {
+  margin: 0;
+}
+
+.us-snowfall-map-subtitle {
+  margin: 0;
+  max-width: 640px;
+  font-size: 13px;
+  color: #475569;
+  font-weight: 500;
+}
+
+.us-snowfall-map-metric-toggle .unit-btn {
+  width: 60px;
+}
+
+.us-snowfall-map-shell {
+  display: grid;
+  grid-template-columns: minmax(0, 1.7fr) minmax(250px, 0.85fr);
+  grid-template-areas: "map meta";
+  gap: 16px;
+  align-items: stretch;
+}
+
+.us-snowfall-map-meta {
+  grid-area: meta;
+  display: grid;
+  gap: 12px;
+  align-content: start;
+}
+
+.us-snowfall-map-status {
+  margin: 0;
+  padding: 14px 16px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.86);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  color: #334155;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.5;
+}
+
+.us-snowfall-map-legend {
+  display: grid;
+  gap: 8px;
+}
+
+.us-snowfall-map-legend-chip {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 12px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.78);
+  border: 1px solid rgba(148, 163, 184, 0.26);
+  font-size: 12px;
+  color: #334155;
+  font-weight: 700;
+}
+
+.us-snowfall-map-legend-chip::before {
+  content: "";
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  flex: 0 0 auto;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.06);
+}
+
+.us-snowfall-map-legend-chip[data-map-legend-stop="low"]::before {
+  background: #dbeafe;
+}
+
+.us-snowfall-map-legend-chip[data-map-legend-stop="mid"]::before {
+  background: #93c5fd;
+}
+
+.us-snowfall-map-legend-chip[data-map-legend-stop="high"]::before {
+  background: #2563eb;
+}
+
+.us-snowfall-map-root {
+  grid-area: map;
+  position: relative;
+  min-height: clamp(260px, 34vw, 400px);
+  border-radius: 22px;
+  overflow: hidden;
+  border: 1px solid rgba(15, 118, 110, 0.2);
+  background: linear-gradient(135deg, #dff4ff 0%, #c8e2ff 34%, #8ec5ff 100%);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.55);
+}
+
+.us-snowfall-map-root::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 18% 22%, rgba(255, 255, 255, 0.62) 0, rgba(255, 255, 255, 0) 20%),
+    radial-gradient(circle at 76% 34%, rgba(255, 255, 255, 0.36) 0, rgba(255, 255, 255, 0) 22%),
+    linear-gradient(120deg, rgba(15, 118, 110, 0.16) 12%, rgba(15, 118, 110, 0) 40%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, rgba(8, 47, 73, 0.22) 100%);
+}
+
+.us-snowfall-map-root::after {
+  content: "";
+  position: absolute;
+  inset: 18px;
+  border-radius: 18px;
+  background:
+    linear-gradient(rgba(255, 255, 255, 0.34) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.34) 1px, transparent 1px);
+  background-size: 46px 46px;
+  opacity: 0.62;
+  mix-blend-mode: screen;
+}
+
+.us-snowfall-map-root[data-active-metric="week_snow"] {
+  background: linear-gradient(135deg, #e8f7ff 0%, #d9e7ff 30%, #95b8ff 100%);
+}
+
+.us-snowfall-map-placeholder {
+  position: absolute;
+  left: 20px;
+  right: auto;
+  bottom: 20px;
+  z-index: 1;
+  display: grid;
+  gap: 6px;
+  max-width: 300px;
+  padding: 14px 16px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.88);
+  color: #0f172a;
+  box-shadow: 0 10px 22px rgba(15, 23, 42, 0.12);
+}
+
+.us-snowfall-map-placeholder strong {
+  font-size: 18px;
+  line-height: 1.2;
+}
+
+.us-snowfall-map-placeholder span:last-child {
+  font-size: 12px;
+  line-height: 1.5;
+  color: #475569;
+  font-weight: 600;
+}
+
+.us-snowfall-map-placeholder-kicker {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #0f766e;
+  font-weight: 800;
+}
+
+@media (max-width: 980px) {
+  .us-snowfall-map-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .us-snowfall-map-metric-toggle {
+    align-self: flex-start;
+  }
+
+  .us-snowfall-map-shell {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "meta"
+      "map";
+  }
+}
+
+@media (max-width: 640px) {
+  .us-snowfall-map-section {
+    padding: 14px;
+    border-radius: 18px;
+  }
+
+  .us-snowfall-map-root {
+    min-height: 220px;
+    border-radius: 18px;
+  }
+
+  .us-snowfall-map-root::after {
+    inset: 12px;
+  }
+
+  .us-snowfall-map-placeholder {
+    left: 14px;
+    right: 14px;
+    bottom: 14px;
+    max-width: none;
+  }
+}

--- a/assets/js/us_snowfall_map.js
+++ b/assets/js/us_snowfall_map.js
@@ -1,0 +1,131 @@
+(() => {
+  const rootScope = typeof window !== "undefined" ? window : globalThis;
+  const DEFAULT_METRIC_KEY = "today_snow";
+  const METRIC_LABELS = {
+    today_snow: "24h snowfall",
+    week_snow: "7-day snowfall",
+  };
+
+  const _element = (value) => (
+    value && typeof value === "object" && typeof value.querySelector === "function" ? value : null
+  );
+
+  const _text = (value) => String(value || "").trim();
+
+  const _normalizeMetricKey = (value) => {
+    const text = _text(value);
+    return text || DEFAULT_METRIC_KEY;
+  };
+
+  const _metricLabel = (metricKey) => METRIC_LABELS[metricKey] || metricKey || METRIC_LABELS[DEFAULT_METRIC_KEY];
+
+  const _visibleResortIds = (reports) => {
+    if (!Array.isArray(reports)) return [];
+    const seen = new Set();
+    const out = [];
+    reports.forEach((report) => {
+      const resortId = typeof report === "string" ? report : _text(report && report.resort_id);
+      if (!resortId || seen.has(resortId)) return;
+      seen.add(resortId);
+      out.push(resortId);
+    });
+    return out;
+  };
+
+  const create = (options = {}) => {
+    const section = _element(options.section) || document.getElementById("us-snowfall-map-section");
+    const metricToggle = _element(options.metricToggle) || document.getElementById("us-snowfall-map-metric-toggle");
+    const statusElement = _element(options.statusElement) || document.getElementById("us-snowfall-map-status");
+    const legendElement = _element(options.legendElement) || document.getElementById("us-snowfall-map-legend");
+    const mapRoot = _element(options.mapRoot) || document.getElementById("us-snowfall-map-root");
+    const buttons = metricToggle ? Array.from(metricToggle.querySelectorAll("[data-map-metric-key]")) : [];
+    const state = {
+      destroyed: false,
+      metricKey: _normalizeMetricKey(options.metricKey),
+      selectedResortId: _text(options.selectedResortId),
+      visibleResortIds: _visibleResortIds(options.reports),
+    };
+
+    const render = () => {
+      if (state.destroyed) return;
+      const metricLabel = _metricLabel(state.metricKey);
+      const visibleCount = state.visibleResortIds.length;
+      if (metricToggle) {
+        metricToggle.setAttribute("data-mode", state.metricKey === "week_snow" ? "imperial" : "metric");
+      }
+      buttons.forEach((button) => {
+        const active = _text(button.getAttribute("data-map-metric-key")) === state.metricKey;
+        button.classList.toggle("is-active", active);
+        button.setAttribute("aria-pressed", active ? "true" : "false");
+      });
+      if (section) {
+        section.setAttribute("data-map-ready", "1");
+        section.setAttribute("data-map-metric-key", state.metricKey);
+        section.classList.toggle("us-snowfall-map-compact", Boolean(mapRoot && mapRoot.clientWidth > 0 && mapRoot.clientWidth < 640));
+      }
+      if (legendElement) {
+        legendElement.setAttribute("data-map-metric-key", state.metricKey);
+      }
+      if (mapRoot) {
+        mapRoot.setAttribute("data-active-metric", state.metricKey);
+      }
+      if (statusElement) {
+        const countText = visibleCount > 0
+          ? `${visibleCount} resort${visibleCount === 1 ? "" : "s"} staged for future markers.`
+          : "Waiting for marker data to attach.";
+        const selectionText = state.selectedResortId ? ` Focused resort: ${state.selectedResortId}.` : "";
+        statusElement.textContent = `Map shell ready for ${metricLabel}. ${countText}${selectionText}`;
+      }
+    };
+
+    const onToggleClick = (event) => {
+      const button = event.target.closest("[data-map-metric-key]");
+      if (!button) return;
+      event.preventDefault();
+      api.setMetric(button.getAttribute("data-map-metric-key"));
+    };
+
+    if (metricToggle) {
+      metricToggle.addEventListener("click", onToggleClick);
+    }
+
+    const api = {
+      setVisibleReports(reports) {
+        if (state.destroyed) return;
+        state.visibleResortIds = _visibleResortIds(reports);
+        render();
+      },
+      setMetric(metricKey) {
+        if (state.destroyed) return;
+        state.metricKey = _normalizeMetricKey(metricKey);
+        render();
+      },
+      setSelectedResort(resortId) {
+        if (state.destroyed) return;
+        state.selectedResortId = _text(resortId);
+        render();
+      },
+      resize() {
+        if (state.destroyed) return;
+        render();
+      },
+      destroy() {
+        if (state.destroyed) return;
+        state.destroyed = true;
+        if (metricToggle) {
+          metricToggle.removeEventListener("click", onToggleClick);
+        }
+      },
+    };
+
+    render();
+    return api;
+  };
+
+  const api = { create };
+  if (typeof window !== "undefined") {
+    window.CloseSnowUsSnowfallMap = api;
+  } else {
+    rootScope.CloseSnowUsSnowfallMap = api;
+  }
+})();

--- a/assets/js/weather_page.js
+++ b/assets/js/weather_page.js
@@ -66,6 +66,8 @@ const appState = {
   sunTimeToggleMode: "metric",
 };
 
+let usSnowfallMapController = null;
+
 const _normalizeSearch = (value) => String(value || "").trim().toLowerCase();
 const _escapeHtml = (value) => String(value || "")
   .replaceAll("&", "&amp;")
@@ -277,6 +279,37 @@ const _dayLabelFor = (report, index) => {
 const _fallbackDayLabels = (count) => Array.from({ length: count }, (_, idx) => (idx === 0 ? "Today" : `day ${idx + 1}`));
 
 const _emptyStateRow = (colspan, message) => `<tr><td class="empty-state-cell" colspan="${colspan}">${_escapeHtml(message)}</td></tr>`;
+
+const _renderUsSnowfallMapSection = () => `
+  <section id="us-snowfall-map-section" class="us-snowfall-map-section" aria-labelledby="us-snowfall-map-title" data-map-shell="1">
+    <div class="section-header us-snowfall-map-header">
+      <div class="us-snowfall-map-heading-wrap">
+        <h2 id="us-snowfall-map-title">US Snowfall Map</h2>
+        <p class="us-snowfall-map-subtitle">Preview the upcoming nationwide snowfall view without displacing the resort tables below.</p>
+      </div>
+      <div id="us-snowfall-map-metric-toggle" class="unit-toggle us-snowfall-map-metric-toggle" role="group" aria-label="Snowfall map metric" data-map-metric-toggle="1" data-mode="metric">
+        <button type="button" class="unit-btn is-active" data-map-metric-key="today_snow" aria-pressed="true">24h</button>
+        <button type="button" class="unit-btn" data-map-metric-key="week_snow" aria-pressed="false">7d</button>
+      </div>
+    </div>
+    <div class="us-snowfall-map-shell">
+      <div class="us-snowfall-map-meta">
+        <p id="us-snowfall-map-status" class="us-snowfall-map-status" role="status">Map shell ready. Marker layers and page-state sync land in a follow-up slice.</p>
+        <div id="us-snowfall-map-legend" class="us-snowfall-map-legend" aria-label="Snowfall legend">
+          <span class="us-snowfall-map-legend-chip" data-map-legend-stop="low">0-10 cm</span>
+          <span class="us-snowfall-map-legend-chip" data-map-legend-stop="mid">10-30 cm</span>
+          <span class="us-snowfall-map-legend-chip" data-map-legend-stop="high">30+ cm</span>
+        </div>
+      </div>
+      <div id="us-snowfall-map-root" class="us-snowfall-map-root" role="img" aria-label="Snowfall map preview area">
+        <div class="us-snowfall-map-placeholder">
+          <span class="us-snowfall-map-placeholder-kicker">Map canvas</span>
+          <strong>Interactive snowfall map preview</strong>
+          <span>Stable DOM hooks are live. Marker rendering arrives next.</span>
+        </div>
+      </div>
+    </div>
+  </section>`;
 
 const _renderCompactGridSection = (reports, emptyMessage = "No resorts match the current filters.") => {
   const displayDays = _displayDays();
@@ -546,6 +579,7 @@ const _renderSunSection = (reports, emptyMessage = "No resorts match the current
 };
 
 const _renderSections = (reports, emptyMessage = "No resorts match the current filters.") => [
+  _renderUsSnowfallMapSection(),
   _renderCompactGridSection(reports, emptyMessage),
   _renderPrecipSection("Snowfall", "snow", "cm", "in", reports, {
     prefix: "snowfall",
@@ -1346,6 +1380,36 @@ const syncSplitTableHeights = () => {
 let layoutFrame = 0;
 let layoutObserver = null;
 
+const destroyUsSnowfallMapController = () => {
+  if (!usSnowfallMapController || typeof usSnowfallMapController.destroy !== "function") {
+    usSnowfallMapController = null;
+    return;
+  }
+  try {
+    usSnowfallMapController.destroy();
+  } catch (error) {
+    // Ignore scaffold cleanup failures.
+  }
+  usSnowfallMapController = null;
+};
+
+const mountUsSnowfallMapController = () => {
+  destroyUsSnowfallMapController();
+  const api = window.CloseSnowUsSnowfallMap;
+  if (!api || typeof api.create !== "function") return;
+  try {
+    usSnowfallMapController = api.create({
+      section: document.getElementById("us-snowfall-map-section"),
+      metricToggle: document.getElementById("us-snowfall-map-metric-toggle"),
+      statusElement: document.getElementById("us-snowfall-map-status"),
+      legendElement: document.getElementById("us-snowfall-map-legend"),
+      mapRoot: document.getElementById("us-snowfall-map-root"),
+    }) || null;
+  } catch (error) {
+    usSnowfallMapController = null;
+  }
+};
+
 const applyLayout = () => {
   if (layoutFrame) cancelAnimationFrame(layoutFrame);
   layoutFrame = requestAnimationFrame(() => {
@@ -1354,6 +1418,9 @@ const applyLayout = () => {
     autoSizeSplitTables();
     syncSplitTableHeights();
     attachSplitScrollSync();
+    if (usSnowfallMapController && typeof usSnowfallMapController.resize === "function") {
+      usSnowfallMapController.resize();
+    }
   });
 };
 
@@ -1575,7 +1642,9 @@ const renderPage = () => {
     : (appState.filterState.favoritesOnly
       ? "No favorite resorts match the current filters."
       : "No resorts match the current filters.");
+  destroyUsSnowfallMapController();
   pageContentRoot.innerHTML = _renderSections(visibleReports, emptyMessage);
+  mountUsSnowfallMapController();
   applyLayout();
   observeLayoutContainers();
   pageContentRoot.removeAttribute("data-loading");
@@ -1849,6 +1918,7 @@ const initialize = async () => {
     applyControlsFromQueryOrMeta();
     renderPage();
   } catch (error) {
+    destroyUsSnowfallMapController();
     if (pageContentRoot) {
       pageContentRoot.innerHTML = `<div class="page-load-error">${_escapeHtml(error instanceof Error ? error.message : String(error))}</div>`;
     }

--- a/src/web/templates/weather_page.html
+++ b/src/web/templates/weather_page.html
@@ -13,6 +13,7 @@
   </script>
   <title>Ski Resorts Weather Forecast</title>
   <link rel="stylesheet" href="assets/css/weather_page.css" />
+  <link rel="stylesheet" href="assets/css/us_snowfall_map.css" />
 </head>
 <body class="units-pending">
   <main>
@@ -107,6 +108,7 @@
     window.CLOSESNOW_PAGE_BOOTSTRAP = {{page_bootstrap_json}};
   </script>
   <script src="assets/js/compact_daily_summary.js"></script>
+  <script src="assets/js/us_snowfall_map.js"></script>
   <script src="assets/js/weather_page.js"></script>
 </body>
 </html>

--- a/src/web/weather_html_renderer.py
+++ b/src/web/weather_html_renderer.py
@@ -9,6 +9,35 @@ from typing import Any, Dict, List
 _PAGE_TEMPLATE = (Path(__file__).resolve().parent / "templates" / "weather_page.html").read_text(encoding="utf-8")
 
 _PAGE_SHELL_PLACEHOLDER = """
+    <section id="us-snowfall-map-section" class="us-snowfall-map-section" aria-labelledby="us-snowfall-map-title" data-map-shell="1">
+      <div class="section-header us-snowfall-map-header">
+        <div class="us-snowfall-map-heading-wrap">
+          <h2 id="us-snowfall-map-title">US Snowfall Map</h2>
+          <p class="us-snowfall-map-subtitle">Preview the upcoming nationwide snowfall view without displacing the resort tables below.</p>
+        </div>
+        <div id="us-snowfall-map-metric-toggle" class="unit-toggle us-snowfall-map-metric-toggle" role="group" aria-label="Snowfall map metric" data-map-metric-toggle="1" data-mode="metric">
+          <button type="button" class="unit-btn is-active" data-map-metric-key="today_snow" aria-pressed="true">24h</button>
+          <button type="button" class="unit-btn" data-map-metric-key="week_snow" aria-pressed="false">7d</button>
+        </div>
+      </div>
+      <div class="us-snowfall-map-shell">
+        <div class="us-snowfall-map-meta">
+          <p id="us-snowfall-map-status" class="us-snowfall-map-status" role="status">Map shell ready. Marker layers and page-state sync land in a follow-up slice.</p>
+          <div id="us-snowfall-map-legend" class="us-snowfall-map-legend" aria-label="Snowfall legend">
+            <span class="us-snowfall-map-legend-chip" data-map-legend-stop="low">0-10 cm</span>
+            <span class="us-snowfall-map-legend-chip" data-map-legend-stop="mid">10-30 cm</span>
+            <span class="us-snowfall-map-legend-chip" data-map-legend-stop="high">30+ cm</span>
+          </div>
+        </div>
+        <div id="us-snowfall-map-root" class="us-snowfall-map-root" role="img" aria-label="Snowfall map preview area">
+          <div class="us-snowfall-map-placeholder">
+            <span class="us-snowfall-map-placeholder-kicker">Map canvas</span>
+            <strong>Interactive snowfall map preview</strong>
+            <span>Stable DOM hooks are live. Marker rendering arrives next.</span>
+          </div>
+        </div>
+      </div>
+    </section>
     <section><h2>Daily Summary</h2><p class="section-loading">Loading forecast...</p></section>
     <section><h2>Snowfall</h2><p class="section-loading">Loading forecast...</p></section>
     <section><h2>Rainfall</h2><p class="section-loading">Loading forecast...</p></section>

--- a/src/web/weather_page_assets.py
+++ b/src/web/weather_page_assets.py
@@ -8,7 +8,9 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 
 ASSET_MIME_TYPES: Dict[str, str] = {
     "assets/css/weather_page.css": "text/css; charset=utf-8",
+    "assets/css/us_snowfall_map.css": "text/css; charset=utf-8",
     "assets/js/compact_daily_summary.js": "application/javascript; charset=utf-8",
+    "assets/js/us_snowfall_map.js": "application/javascript; charset=utf-8",
     "assets/js/weather_page.js": "application/javascript; charset=utf-8",
     "assets/css/resort_hourly.css": "text/css; charset=utf-8",
     "assets/js/resort_hourly.js": "application/javascript; charset=utf-8",

--- a/tests/frontend/test_assets.py
+++ b/tests/frontend/test_assets.py
@@ -7,12 +7,16 @@ from src.web.weather_page_assets import ASSET_MIME_TYPES, asset_path, read_asset
 
 def test_asset_path_points_to_repo_assets():
     css_path = asset_path("assets/css/weather_page.css")
+    map_css_path = asset_path("assets/css/us_snowfall_map.css")
     compact_js_path = asset_path("assets/js/compact_daily_summary.js")
+    map_js_path = asset_path("assets/js/us_snowfall_map.js")
     js_path = asset_path("assets/js/weather_page.js")
     hourly_css_path = asset_path("assets/css/resort_hourly.css")
     hourly_js_path = asset_path("assets/js/resort_hourly.js")
     assert str(css_path).endswith("assets/css/weather_page.css")
+    assert str(map_css_path).endswith("assets/css/us_snowfall_map.css")
     assert str(compact_js_path).endswith("assets/js/compact_daily_summary.js")
+    assert str(map_js_path).endswith("assets/js/us_snowfall_map.js")
     assert str(js_path).endswith("assets/js/weather_page.js")
     assert str(hourly_css_path).endswith("assets/css/resort_hourly.css")
     assert str(hourly_js_path).endswith("assets/js/resort_hourly.js")
@@ -20,26 +24,37 @@ def test_asset_path_points_to_repo_assets():
 
 def test_read_asset_bytes_reads_known_assets():
     css = read_asset_bytes("assets/css/weather_page.css")
+    map_css = read_asset_bytes("assets/css/us_snowfall_map.css")
     compact_js = read_asset_bytes("assets/js/compact_daily_summary.js")
+    map_js = read_asset_bytes("assets/js/us_snowfall_map.js")
     js = read_asset_bytes("assets/js/weather_page.js")
     hourly_css = read_asset_bytes("assets/css/resort_hourly.css")
     hourly_js = read_asset_bytes("assets/js/resort_hourly.js")
     assert len(css) > 100
+    assert len(map_css) > 100
     assert len(compact_js) > 100
+    assert len(map_js) > 100
     assert len(js) > 100
     assert len(hourly_css) > 100
     assert len(hourly_js) > 100
     assert ASSET_MIME_TYPES["assets/css/weather_page.css"].startswith("text/css")
+    assert ASSET_MIME_TYPES["assets/css/us_snowfall_map.css"].startswith("text/css")
     assert ASSET_MIME_TYPES["assets/js/compact_daily_summary.js"].startswith("application/javascript")
+    assert ASSET_MIME_TYPES["assets/js/us_snowfall_map.js"].startswith("application/javascript")
     assert ASSET_MIME_TYPES["assets/js/weather_page.js"].startswith("application/javascript")
     assert ASSET_MIME_TYPES["assets/css/resort_hourly.css"].startswith("text/css")
     assert ASSET_MIME_TYPES["assets/js/resort_hourly.js"].startswith("application/javascript")
     css_text = css.decode("utf-8", errors="ignore")
+    map_css_text = map_css.decode("utf-8", errors="ignore")
     compact_js_text = compact_js.decode("utf-8", errors="ignore")
+    map_js_text = map_js.decode("utf-8", errors="ignore")
     hourly_css_text = hourly_css.decode("utf-8", errors="ignore")
     hourly_js_text = hourly_js.decode("utf-8", errors="ignore")
     js_text = js.decode("utf-8", errors="ignore")
     assert ".compact-grid-wrap" in css_text
+    assert ".us-snowfall-map-section" in map_css_text
+    assert ".us-snowfall-map-root" in map_css_text
+    assert "@media (max-width: 980px)" in map_css_text
     assert ".hourly-charts" in hourly_css_text
     assert ".resort-local-time" in hourly_css_text
     assert ".resort-timeline-section" in hourly_css_text
@@ -56,6 +71,11 @@ def test_read_asset_bytes_reads_known_assets():
     assert "width: 100%;" in hourly_css_text
     assert "min-width: 0;" in hourly_css_text
     assert "window.CloseSnowCompactDailySummary" in compact_js_text
+    assert "window.CloseSnowUsSnowfallMap" in map_js_text
+    assert "setVisibleReports" in map_js_text
+    assert "setMetric" in map_js_text
+    assert "setSelectedResort" in map_js_text
+    assert "destroy" in map_js_text
     assert "renderSingleResortHtml" in compact_js_text
     assert "labelMode" in compact_js_text
     assert 'return "Today";' in compact_js_text

--- a/tests/frontend/test_renderers.py
+++ b/tests/frontend/test_renderers.py
@@ -246,6 +246,14 @@ def test_build_html_contains_meta_sections():
     assert "Powered by" in html
     assert "https://open-meteo.com/en/docs/ecmwf-api" in html
     assert "Feature requests" in html
+    assert 'assets/css/us_snowfall_map.css' in html
+    assert 'assets/js/us_snowfall_map.js' in html
+    assert 'id="us-snowfall-map-section"' in html
+    assert 'id="us-snowfall-map-metric-toggle"' in html
+    assert 'id="us-snowfall-map-legend"' in html
+    assert 'id="us-snowfall-map-status"' in html
+    assert 'id="us-snowfall-map-root"' in html
+    assert html.index('id="us-snowfall-map-section"') < html.index("<h2>Daily Summary</h2>")
     assert "<h2>Daily Summary</h2>" in html
     assert "<h2>Sunrise / Sunset</h2>" in html
     assert html.index("<h2>Temperature</h2>") < html.index("<h2>Weather</h2>")

--- a/tests/integration/test_web_server.py
+++ b/tests/integration/test_web_server.py
@@ -55,8 +55,12 @@ def test_server_api_root_and_asset(monkeypatch):
 
         asset = urllib.request.urlopen(f"{base}/assets/css/weather_page.css", timeout=3).read()
         assert asset == b"body{}"
+        map_asset = urllib.request.urlopen(f"{base}/assets/js/us_snowfall_map.js", timeout=3).read()
+        assert map_asset == b"body{}"
         asset_with_prefix = urllib.request.urlopen(f"{base}/CloseSnow/assets/css/weather_page.css", timeout=3).read()
         assert asset_with_prefix == b"body{}"
+        map_asset_with_prefix = urllib.request.urlopen(f"{base}/CloseSnow/assets/js/us_snowfall_map.js", timeout=3).read()
+        assert map_asset_with_prefix == b"body{}"
     finally:
         server.shutdown()
         server.server_close()


### PR DESCRIPTION
## Summary
- add a dedicated US snowfall map shell ahead of the homepage daily summary
- register the new map CSS/JS assets and mount a no-throw controller scaffold
- cover the new shell with asset, renderer, and web-server tests

## Validation
- python3 -m pytest -q tests/frontend/test_assets.py tests/frontend/test_renderers.py tests/frontend/test_static_site_pipeline.py tests/integration/test_web_server.py
- python3 -m src.cli static --output-dir /tmp/closesnow-us-snowfall-map-shell --max-workers 8