### PR TITLE
Add favorites alert diff engine

### DIFF
--- a/assets/js/favorites_alerts.js
+++ b/assets/js/favorites_alerts.js
@@ -1,0 +1,410 @@
+(function (root) {
+  const STORAGE_KEY = "closesnow_favorite_alert_state_v1";
+  const RULE_VERSION = "favorites_alert_rules_v1";
+  const MAX_ALERT_ITEMS = 200;
+
+  const normalizeText = (value) => String(value || "").trim();
+
+  const asFiniteNumber = (value) => {
+    if (value === null || value === undefined || value === "") return null;
+    const num = Number(value);
+    return Number.isFinite(num) ? num : null;
+  };
+
+  const asIsoString = (value, fallback = "") => {
+    const text = normalizeText(value);
+    if (!text) return fallback;
+    const dt = new Date(text);
+    return Number.isNaN(dt.getTime()) ? fallback : dt.toISOString();
+  };
+
+  const dayLabel = (value) => {
+    const text = normalizeText(value);
+    return text ? text.slice(0, 10) : "";
+  };
+
+  const firstDays = (report, count) => {
+    const daily = report && Array.isArray(report.daily) ? report.daily : [];
+    return daily.slice(0, count).filter((day) => day && typeof day === "object");
+  };
+
+  const sumMetric = (days, key) => days.reduce((total, day) => total + (asFiniteNumber(day[key]) || 0), 0);
+
+  const maxMetric = (days, key) => {
+    let maxValue = null;
+    days.forEach((day) => {
+      const value = asFiniteNumber(day[key]);
+      if (value === null) return;
+      maxValue = maxValue === null ? value : Math.max(maxValue, value);
+    });
+    return maxValue;
+  };
+
+  const countMatchingDays = (days, predicate) => {
+    let count = 0;
+    days.forEach((day) => {
+      if (predicate(day)) count += 1;
+    });
+    return count;
+  };
+
+  const firstMatchingDay = (days, predicate) => {
+    for (const day of days) {
+      if (predicate(day)) return dayLabel(day.date);
+    }
+    return "";
+  };
+
+  const resortName = (report) => (
+    normalizeText(report && (report.display_name || report.query || report.resort_id)) || "Favorite resort"
+  );
+
+  const formatNumber = (value) => {
+    const num = asFiniteNumber(value);
+    if (num === null) return "0";
+    return Number.isInteger(num) ? String(num) : num.toFixed(1);
+  };
+
+  const defaultState = () => ({
+    schema_version: STORAGE_KEY,
+    rule_version: RULE_VERSION,
+    updated_at: "",
+    snapshots_by_resort_id: {},
+    alerts: [],
+  });
+
+  const normalizeSnapshot = (raw) => {
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+    const resortId = normalizeText(raw.resort_id);
+    if (!resortId) return null;
+    return {
+      resort_id: resortId,
+      resort_name: normalizeText(raw.resort_name) || "Favorite resort",
+      payload_generated_at: asIsoString(raw.payload_generated_at),
+      snapshot_taken_at: asIsoString(raw.snapshot_taken_at),
+      today_snowfall_cm: asFiniteNumber(raw.today_snowfall_cm) || 0,
+      next3day_total_snowfall_cm: asFiniteNumber(raw.next3day_total_snowfall_cm) || 0,
+      week1_total_snowfall_cm: asFiniteNumber(raw.week1_total_snowfall_cm) || 0,
+      rain_total_next3d_mm: asFiniteNumber(raw.rain_total_next3d_mm) || 0,
+      rain_day_count_next3d: asFiniteNumber(raw.rain_day_count_next3d) || 0,
+      warm_day_count_next3d: asFiniteNumber(raw.warm_day_count_next3d) || 0,
+      max_temp_next3d_c: asFiniteNumber(raw.max_temp_next3d_c),
+      first_rain_day: normalizeText(raw.first_rain_day),
+      first_warm_day: normalizeText(raw.first_warm_day),
+    };
+  };
+
+  const normalizeAlertItem = (raw) => {
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+    const id = normalizeText(raw.id);
+    const resortId = normalizeText(raw.resort_id);
+    const severity = normalizeText(raw.severity);
+    const type = normalizeText(raw.type);
+    if (!id || !resortId || !severity || !type) return null;
+    const metrics = raw.metrics && typeof raw.metrics === "object" && !Array.isArray(raw.metrics)
+      ? {
+          window: normalizeText(raw.metrics.window),
+          unit: normalizeText(raw.metrics.unit),
+          previous: asFiniteNumber(raw.metrics.previous),
+          current: asFiniteNumber(raw.metrics.current),
+          delta: asFiniteNumber(raw.metrics.delta),
+        }
+      : null;
+    return {
+      id,
+      resort_id: resortId,
+      resort_name: normalizeText(raw.resort_name) || "Favorite resort",
+      severity,
+      type,
+      created_at: asIsoString(raw.created_at),
+      payload_generated_at: asIsoString(raw.payload_generated_at),
+      previous_payload_generated_at: asIsoString(raw.previous_payload_generated_at),
+      title: normalizeText(raw.title),
+      message: normalizeText(raw.message),
+      metrics,
+    };
+  };
+
+  const normalizeState = (raw) => {
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) return defaultState();
+    const state = defaultState();
+    state.updated_at = asIsoString(raw.updated_at);
+    const snapshots = raw.snapshots_by_resort_id && typeof raw.snapshots_by_resort_id === "object"
+      ? raw.snapshots_by_resort_id
+      : {};
+    Object.entries(snapshots).forEach(([resortId, snapshot]) => {
+      const normalized = normalizeSnapshot({ resort_id: resortId, ...snapshot });
+      if (normalized) state.snapshots_by_resort_id[normalized.resort_id] = normalized;
+    });
+    const alerts = Array.isArray(raw.alerts) ? raw.alerts : [];
+    state.alerts = alerts.map(normalizeAlertItem).filter(Boolean).slice(0, MAX_ALERT_ITEMS);
+    return state;
+  };
+
+  const loadState = (storage = root.localStorage) => {
+    if (!storage || typeof storage.getItem !== "function") return defaultState();
+    try {
+      const raw = storage.getItem(STORAGE_KEY);
+      if (!raw) return defaultState();
+      return normalizeState(JSON.parse(raw));
+    } catch (error) {
+      return defaultState();
+    }
+  };
+
+  const persistState = (state, storage = root.localStorage) => {
+    const normalized = normalizeState(state);
+    if (!storage || typeof storage.setItem !== "function") return normalized;
+    try {
+      storage.setItem(STORAGE_KEY, JSON.stringify(normalized));
+    } catch (error) {
+      // Ignore storage failures.
+    }
+    return normalized;
+  };
+
+  const buildSnapshot = (report, payloadGeneratedAt = "") => {
+    if (!report || typeof report !== "object") return null;
+    const resortId = normalizeText(report.resort_id);
+    if (!resortId) return null;
+    const next3Days = firstDays(report, 3);
+    return {
+      resort_id: resortId,
+      resort_name: resortName(report),
+      payload_generated_at: asIsoString(payloadGeneratedAt),
+      snapshot_taken_at: new Date().toISOString(),
+      today_snowfall_cm: asFiniteNumber(next3Days[0] && next3Days[0].snowfall_cm) || 0,
+      next3day_total_snowfall_cm: sumMetric(next3Days, "snowfall_cm"),
+      week1_total_snowfall_cm: asFiniteNumber(report.week1_total_snowfall_cm) || 0,
+      rain_total_next3d_mm: sumMetric(next3Days, "rain_mm"),
+      rain_day_count_next3d: countMatchingDays(next3Days, (day) => (asFiniteNumber(day.rain_mm) || 0) >= 2),
+      warm_day_count_next3d: countMatchingDays(next3Days, (day) => (asFiniteNumber(day.temperature_max_c) || Number.NEGATIVE_INFINITY) >= 2),
+      max_temp_next3d_c: maxMetric(next3Days, "temperature_max_c"),
+      first_rain_day: firstMatchingDay(next3Days, (day) => (asFiniteNumber(day.rain_mm) || 0) >= 2),
+      first_warm_day: firstMatchingDay(next3Days, (day) => (asFiniteNumber(day.temperature_max_c) || Number.NEGATIVE_INFINITY) >= 2),
+    };
+  };
+
+  const buildAlert = ({
+    type,
+    severity,
+    current,
+    previous,
+    title,
+    message,
+    windowName,
+    unit,
+    previousValue,
+    currentValue,
+    delta,
+  }) => ({
+    id: [
+      type,
+      current.resort_id,
+      current.payload_generated_at,
+      formatNumber(delta),
+    ].join(":"),
+    resort_id: current.resort_id,
+    resort_name: current.resort_name,
+    severity,
+    type,
+    created_at: current.payload_generated_at || new Date().toISOString(),
+    payload_generated_at: current.payload_generated_at,
+    previous_payload_generated_at: previous.payload_generated_at,
+    title,
+    message,
+    metrics: {
+      window: windowName,
+      unit,
+      previous: previousValue,
+      current: currentValue,
+      delta,
+    },
+  });
+
+  const compareSnapshots = (previousRaw, currentRaw) => {
+    const previous = normalizeSnapshot(previousRaw);
+    const current = normalizeSnapshot(currentRaw);
+    if (!previous || !current) return [];
+
+    const alerts = [];
+    const next3SnowGain = current.next3day_total_snowfall_cm - previous.next3day_total_snowfall_cm;
+    const week1SnowGain = current.week1_total_snowfall_cm - previous.week1_total_snowfall_cm;
+    if (next3SnowGain >= 10 || week1SnowGain >= 15) {
+      const useNext3 = next3SnowGain >= 10;
+      const delta = useNext3 ? next3SnowGain : week1SnowGain;
+      const previousValue = useNext3 ? previous.next3day_total_snowfall_cm : previous.week1_total_snowfall_cm;
+      const currentValue = useNext3 ? current.next3day_total_snowfall_cm : current.week1_total_snowfall_cm;
+      alerts.push(buildAlert({
+        type: "snowfall_gain",
+        severity: delta >= 20 || currentValue >= 25 ? "high" : "medium",
+        current,
+        previous,
+        title: `Snowfall jumped at ${current.resort_name}`,
+        message: `${current.resort_name} gained ${formatNumber(delta)} cm compared with your last snapshot.`,
+        windowName: useNext3 ? "next_3_days" : "week_1",
+        unit: "cm",
+        previousValue,
+        currentValue,
+        delta,
+      }));
+    }
+
+    const next3SnowLoss = previous.next3day_total_snowfall_cm - current.next3day_total_snowfall_cm;
+    const week1SnowLoss = previous.week1_total_snowfall_cm - current.week1_total_snowfall_cm;
+    if (next3SnowLoss >= 12 || week1SnowLoss >= 18) {
+      const useNext3 = next3SnowLoss >= 12;
+      const delta = useNext3 ? next3SnowLoss : week1SnowLoss;
+      const previousValue = useNext3 ? previous.next3day_total_snowfall_cm : previous.week1_total_snowfall_cm;
+      const currentValue = useNext3 ? current.next3day_total_snowfall_cm : current.week1_total_snowfall_cm;
+      alerts.push(buildAlert({
+        type: "snowfall_loss",
+        severity: delta >= 20 || (previousValue >= 15 && currentValue <= 3) ? "high" : "medium",
+        current,
+        previous,
+        title: `Snowfall backed off at ${current.resort_name}`,
+        message: `${current.resort_name} lost ${formatNumber(delta)} cm from the forecast since your last snapshot.`,
+        windowName: useNext3 ? "next_3_days" : "week_1",
+        unit: "cm",
+        previousValue,
+        currentValue,
+        delta,
+      }));
+    }
+
+    const rainIncrease = current.rain_total_next3d_mm - previous.rain_total_next3d_mm;
+    if (
+      current.rain_total_next3d_mm >= 5 &&
+      current.warm_day_count_next3d > 0 &&
+      (
+        previous.rain_total_next3d_mm < 2 ||
+        rainIncrease >= 4 ||
+        current.rain_day_count_next3d > previous.rain_day_count_next3d
+      )
+    ) {
+      alerts.push(buildAlert({
+        type: "rain_crossover",
+        severity: current.rain_total_next3d_mm >= 10 || current.rain_day_count_next3d >= 2 ? "high" : "medium",
+        current,
+        previous,
+        title: `Rain risk moved into ${current.resort_name}`,
+        message: current.first_rain_day
+          ? `${current.resort_name} now shows ${formatNumber(current.rain_total_next3d_mm)} mm of rain starting around ${current.first_rain_day}.`
+          : `${current.resort_name} now shows ${formatNumber(current.rain_total_next3d_mm)} mm of rain in the next 3 days.`,
+        windowName: "next_3_days",
+        unit: "mm",
+        previousValue: previous.rain_total_next3d_mm,
+        currentValue: current.rain_total_next3d_mm,
+        delta: rainIncrease,
+      }));
+    }
+
+    const previousMaxTemp = asFiniteNumber(previous.max_temp_next3d_c);
+    const currentMaxTemp = asFiniteNumber(current.max_temp_next3d_c);
+    const warmingDelta = currentMaxTemp !== null && previousMaxTemp !== null ? currentMaxTemp - previousMaxTemp : null;
+    if (warmingDelta !== null && currentMaxTemp >= 3 && warmingDelta >= 4) {
+      alerts.push(buildAlert({
+        type: "warming_shift",
+        severity: currentMaxTemp >= 6 || warmingDelta >= 7 ? "high" : "medium",
+        current,
+        previous,
+        title: `Warmer temperatures are moving into ${current.resort_name}`,
+        message: current.first_warm_day
+          ? `${current.resort_name} warmed by ${formatNumber(warmingDelta)} C, with above-freezing highs showing up around ${current.first_warm_day}.`
+          : `${current.resort_name} warmed by ${formatNumber(warmingDelta)} C in the next 3 days.`,
+        windowName: "next_3_days",
+        unit: "c",
+        previousValue: previousMaxTemp,
+        currentValue: currentMaxTemp,
+        delta: warmingDelta,
+      }));
+    }
+
+    return alerts;
+  };
+
+  const syncPayload = ({ payload, favoriteResortIds, storage = root.localStorage } = {}) => {
+    const state = loadState(storage);
+    const payloadGeneratedAt = asIsoString(
+      payload && payload.generated_at_utc,
+      new Date().toISOString(),
+    );
+    const favoriteIds = Array.from(new Set(
+      (Array.isArray(favoriteResortIds) ? favoriteResortIds : [])
+        .map((value) => normalizeText(value))
+        .filter(Boolean),
+    ));
+    const reports = payload && Array.isArray(payload.reports) ? payload.reports : [];
+    const reportsByResortId = {};
+    reports.forEach((report) => {
+      const resortId = normalizeText(report && report.resort_id);
+      if (resortId) reportsByResortId[resortId] = report;
+    });
+
+    const nextSnapshots = {};
+    const nextAlerts = Array.isArray(state.alerts) ? state.alerts.slice() : [];
+    const knownAlertIds = new Set(nextAlerts.map((alert) => alert.id));
+    const newAlerts = [];
+
+    favoriteIds.forEach((resortId) => {
+      const previous = state.snapshots_by_resort_id[resortId] || null;
+      const report = reportsByResortId[resortId];
+      if (!report) {
+        if (previous) nextSnapshots[resortId] = previous;
+        return;
+      }
+
+      const current = buildSnapshot(report, payloadGeneratedAt);
+      if (!current) return;
+
+      if (
+        previous &&
+        previous.payload_generated_at &&
+        current.payload_generated_at &&
+        current.payload_generated_at < previous.payload_generated_at
+      ) {
+        nextSnapshots[resortId] = previous;
+        return;
+      }
+
+      if (
+        previous &&
+        previous.payload_generated_at &&
+        current.payload_generated_at &&
+        current.payload_generated_at > previous.payload_generated_at
+      ) {
+        compareSnapshots(previous, current).forEach((alert) => {
+          if (knownAlertIds.has(alert.id)) return;
+          knownAlertIds.add(alert.id);
+          nextAlerts.unshift(alert);
+          newAlerts.push(alert);
+        });
+      }
+
+      nextSnapshots[resortId] = current;
+    });
+
+    const nextState = {
+      schema_version: STORAGE_KEY,
+      rule_version: RULE_VERSION,
+      updated_at: payloadGeneratedAt,
+      snapshots_by_resort_id: nextSnapshots,
+      alerts: nextAlerts.slice(0, MAX_ALERT_ITEMS),
+    };
+
+    return {
+      state: persistState(nextState, storage),
+      newAlerts,
+    };
+  };
+
+  root.CloseSnowFavoritesAlerts = {
+    STORAGE_KEY,
+    RULE_VERSION,
+    buildSnapshot,
+    compareSnapshots,
+    loadState,
+    persistState,
+    syncPayload,
+  };
+})(typeof window !== "undefined" ? window : globalThis);

--- a/assets/js/weather_page.js
+++ b/assets/js/weather_page.js
@@ -39,6 +39,7 @@ const DEFAULT_AVAILABLE_FILTERS = { pass_type: {}, region: {}, country: {} };
 const MAX_DISPLAY_DAYS = 14;
 const MIN_DESKTOP_SNOW_3DAY_PX = 554;
 const compactDailySummary = window.CloseSnowCompactDailySummary || {};
+const favoriteAlertsApi = window.CloseSnowFavoritesAlerts || null;
 const COMPACT_SUMMARY_UNIT_KIND = "compact_summary";
 const SUN_TIME_TOGGLE_KIND = "sun_time";
 
@@ -64,6 +65,8 @@ const appState = {
   },
   compactSummaryUnitMode: "metric",
   sunTimeToggleMode: "metric",
+  favoriteAlertState: null,
+  newFavoriteAlerts: [],
 };
 
 const _normalizeSearch = (value) => String(value || "").trim().toLowerCase();
@@ -618,6 +621,30 @@ const normalizeSortBy = (value) => {
 
 const _dailySnowfall = (report, index = 0) => _asFiniteNumber(_dailyAt(report, index).snowfall_cm);
 const _weeklySnowfall = (report) => _asFiniteNumber(report && report.week1_total_snowfall_cm);
+
+const publishFavoriteAlertState = (state, newAlerts) => {
+  appState.favoriteAlertState = state;
+  appState.newFavoriteAlerts = Array.isArray(newAlerts) ? newAlerts : [];
+  window.CLOSESNOW_FAVORITE_ALERT_STATE = state;
+  window.CLOSESNOW_FAVORITE_ALERTS = state && Array.isArray(state.alerts) ? state.alerts : [];
+  window.CLOSESNOW_NEW_FAVORITE_ALERTS = appState.newFavoriteAlerts;
+};
+
+const syncFavoriteAlertState = () => {
+  if (!favoriteAlertsApi || typeof favoriteAlertsApi.syncPayload !== "function" || !appState.payload) {
+    publishFavoriteAlertState(null, []);
+    return null;
+  }
+  const result = favoriteAlertsApi.syncPayload({
+    payload: appState.payload,
+    favoriteResortIds: Array.from(appState.favoriteResortIds),
+  });
+  publishFavoriteAlertState(
+    result && result.state ? result.state : null,
+    result && Array.isArray(result.newAlerts) ? result.newAlerts : [],
+  );
+  return result;
+};
 
 const _compareBySnowDesc = (a, b, valueFn) => {
   const aValue = valueFn(a);
@@ -1708,6 +1735,7 @@ const reloadDynamicPayloadForFilters = async () => {
   appState.payload = payload;
   appState.reports = _payloadReports();
   appState.availableFilters = _availableFilters();
+  syncFavoriteAlertState();
   updateFilterLabels();
 };
 
@@ -1792,6 +1820,7 @@ const bindControls = () => {
       event.preventDefault();
       const visibleReports = _filteredReports();
       toggleFavoriteVisibleReports(visibleReports);
+      syncFavoriteAlertState();
       if (favoriteInteractionNeedsFullRender()) {
         renderPagePreservingScroll();
       } else {
@@ -1804,6 +1833,7 @@ const bindControls = () => {
       event.preventDefault();
       const visibleReports = _filteredReports();
       toggleFavoriteResortId(favoriteButton.getAttribute("data-resort-id"));
+      syncFavoriteAlertState();
       if (favoriteInteractionNeedsFullRender()) {
         renderPagePreservingScroll();
       } else {
@@ -1845,6 +1875,7 @@ const initialize = async () => {
     appState.payload = await loadPayload();
     appState.reports = _payloadReports();
     appState.availableFilters = _availableFilters();
+    syncFavoriteAlertState();
     updateFilterLabels();
     applyControlsFromQueryOrMeta();
     renderPage();

--- a/src/web/templates/weather_page.html
+++ b/src/web/templates/weather_page.html
@@ -107,6 +107,7 @@
     window.CLOSESNOW_PAGE_BOOTSTRAP = {{page_bootstrap_json}};
   </script>
   <script src="assets/js/compact_daily_summary.js"></script>
+  <script src="assets/js/favorites_alerts.js"></script>
   <script src="assets/js/weather_page.js"></script>
 </body>
 </html>

--- a/src/web/weather_page_assets.py
+++ b/src/web/weather_page_assets.py
@@ -9,6 +9,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 ASSET_MIME_TYPES: Dict[str, str] = {
     "assets/css/weather_page.css": "text/css; charset=utf-8",
     "assets/js/compact_daily_summary.js": "application/javascript; charset=utf-8",
+    "assets/js/favorites_alerts.js": "application/javascript; charset=utf-8",
     "assets/js/weather_page.js": "application/javascript; charset=utf-8",
     "assets/css/resort_hourly.css": "text/css; charset=utf-8",
     "assets/js/resort_hourly.js": "application/javascript; charset=utf-8",

--- a/tests/frontend/test_assets.py
+++ b/tests/frontend/test_assets.py
@@ -8,11 +8,13 @@ from src.web.weather_page_assets import ASSET_MIME_TYPES, asset_path, read_asset
 def test_asset_path_points_to_repo_assets():
     css_path = asset_path("assets/css/weather_page.css")
     compact_js_path = asset_path("assets/js/compact_daily_summary.js")
+    favorites_js_path = asset_path("assets/js/favorites_alerts.js")
     js_path = asset_path("assets/js/weather_page.js")
     hourly_css_path = asset_path("assets/css/resort_hourly.css")
     hourly_js_path = asset_path("assets/js/resort_hourly.js")
     assert str(css_path).endswith("assets/css/weather_page.css")
     assert str(compact_js_path).endswith("assets/js/compact_daily_summary.js")
+    assert str(favorites_js_path).endswith("assets/js/favorites_alerts.js")
     assert str(js_path).endswith("assets/js/weather_page.js")
     assert str(hourly_css_path).endswith("assets/css/resort_hourly.css")
     assert str(hourly_js_path).endswith("assets/js/resort_hourly.js")
@@ -21,21 +23,25 @@ def test_asset_path_points_to_repo_assets():
 def test_read_asset_bytes_reads_known_assets():
     css = read_asset_bytes("assets/css/weather_page.css")
     compact_js = read_asset_bytes("assets/js/compact_daily_summary.js")
+    favorites_js = read_asset_bytes("assets/js/favorites_alerts.js")
     js = read_asset_bytes("assets/js/weather_page.js")
     hourly_css = read_asset_bytes("assets/css/resort_hourly.css")
     hourly_js = read_asset_bytes("assets/js/resort_hourly.js")
     assert len(css) > 100
     assert len(compact_js) > 100
+    assert len(favorites_js) > 100
     assert len(js) > 100
     assert len(hourly_css) > 100
     assert len(hourly_js) > 100
     assert ASSET_MIME_TYPES["assets/css/weather_page.css"].startswith("text/css")
     assert ASSET_MIME_TYPES["assets/js/compact_daily_summary.js"].startswith("application/javascript")
+    assert ASSET_MIME_TYPES["assets/js/favorites_alerts.js"].startswith("application/javascript")
     assert ASSET_MIME_TYPES["assets/js/weather_page.js"].startswith("application/javascript")
     assert ASSET_MIME_TYPES["assets/css/resort_hourly.css"].startswith("text/css")
     assert ASSET_MIME_TYPES["assets/js/resort_hourly.js"].startswith("application/javascript")
     css_text = css.decode("utf-8", errors="ignore")
     compact_js_text = compact_js.decode("utf-8", errors="ignore")
+    favorites_js_text = favorites_js.decode("utf-8", errors="ignore")
     hourly_css_text = hourly_css.decode("utf-8", errors="ignore")
     hourly_js_text = hourly_js.decode("utf-8", errors="ignore")
     js_text = js.decode("utf-8", errors="ignore")
@@ -65,7 +71,16 @@ def test_read_asset_bytes_reads_known_assets():
     assert "data-compact-today-anchor" in compact_js_text
     assert "compact-day-head-phase-start" not in compact_js_text
     assert "compact-day-cell-phase-start" not in compact_js_text
+    assert "CloseSnowFavoritesAlerts" in favorites_js_text
+    assert "closesnow_favorite_alert_state_v1" in favorites_js_text
+    assert "favorites_alert_rules_v1" in favorites_js_text
+    assert "snowfall_gain" in favorites_js_text
+    assert "rain_crossover" in favorites_js_text
+    assert "warming_shift" in favorites_js_text
+    assert "syncPayload" in favorites_js_text
     assert "window.CLOSESNOW_PAGE_BOOTSTRAP" in js_text
+    assert "window.CLOSESNOW_FAVORITE_ALERT_STATE" in js_text
+    assert "syncFavoriteAlertState();" in js_text
     assert "No resorts match the current filters." in js_text
     assert 'return "Today";' in js_text
     assert "renderHourlyCharts" in hourly_js_text

--- a/tests/integration/test_gateway_render_integration.py
+++ b/tests/integration/test_gateway_render_integration.py
@@ -21,6 +21,7 @@ def test_file_gateway_to_renderer_integration(tmp_path, valid_payload):
     assert 'id="page-content-root"' in html
     assert "window.CLOSESNOW_PAGE_BOOTSTRAP" in html
     assert '"dataUrl": "./data.json"' in html
+    assert "assets/js/favorites_alerts.js" in html
 
 
 @pytest.mark.integration
@@ -48,6 +49,7 @@ def test_api_gateway_to_renderer_integration(valid_payload):
         assert payload["schema_version"] == valid_payload["schema_version"]
         assert "Ski Resorts Weather Forecast" in html
         assert "./data.json" in html
+        assert "assets/js/favorites_alerts.js" in html
     finally:
         server.shutdown()
         server.server_close()

--- a/tests/integration/test_web_server.py
+++ b/tests/integration/test_web_server.py
@@ -35,7 +35,11 @@ def test_server_api_root_and_asset(monkeypatch):
     }
     monkeypatch.setattr("src.web.weather_page_server.load_payload", lambda **kwargs: sample_payload)
     monkeypatch.setattr("src.web.weather_page_server.render_payload_html", lambda payload, **kwargs: "<html>ok</html>")
-    monkeypatch.setattr("src.web.weather_page_server.read_asset_bytes", lambda name: b"body{}")
+    asset_bodies = {
+        "assets/css/weather_page.css": b"body{}",
+        "assets/js/favorites_alerts.js": b"window.CloseSnowFavoritesAlerts={};",
+    }
+    monkeypatch.setattr("src.web.weather_page_server.read_asset_bytes", lambda name: asset_bodies.get(name, b"body{}"))
 
     handler = make_handler(
         cache_file=".cache/x.json",
@@ -57,6 +61,8 @@ def test_server_api_root_and_asset(monkeypatch):
         assert asset == b"body{}"
         asset_with_prefix = urllib.request.urlopen(f"{base}/CloseSnow/assets/css/weather_page.css", timeout=3).read()
         assert asset_with_prefix == b"body{}"
+        favorites_asset = urllib.request.urlopen(f"{base}/assets/js/favorites_alerts.js", timeout=3).read()
+        assert favorites_asset == b"window.CloseSnowFavoritesAlerts={};"
     finally:
         server.shutdown()
         server.server_close()


### PR DESCRIPTION
## Summary
- add a browser-only favorites alert diff engine with snapshot persistence and normalized alert items
- wire the engine into homepage payload refreshes and favorite toggles
- cover the new asset registration and rendered script tags in frontend/integration tests

## Validation
- python3 -m pytest -q tests/frontend/test_assets.py tests/integration/test_web_server.py tests/integration/test_data_sources.py tests/integration/test_gateway_render_integration.py
- python3 -m src.cli static --output-dir /tmp/closesnow-favorites-alert-engine --max-workers 8