### PR TITLE
Add compare selection state

### DIFF
--- a/assets/css/weather_page.css
+++ b/assets/css/weather_page.css
@@ -112,6 +112,119 @@
       color: #475569;
       font-weight: 600;
     }
+    .compare-toolbar[hidden] {
+      display: none;
+    }
+    .compare-toolbar {
+      margin: -4px 0 18px;
+      padding: 12px 14px;
+      border: 1px solid #cbd5e1;
+      border-radius: 14px;
+      background: linear-gradient(135deg, #ecfeff 0%, #f8fafc 100%);
+      box-shadow: 0 10px 28px rgba(15, 23, 42, 0.08);
+      display: grid;
+      gap: 10px;
+    }
+    .compare-toolbar-head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+    .compare-toolbar-title {
+      font-size: 13px;
+      font-weight: 700;
+      color: #0f172a;
+    }
+    .compare-toolbar-title strong {
+      color: #0f766e;
+    }
+    .compare-toolbar-actions {
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+    .compare-toolbar-btn {
+      border: 1px solid #99f6e4;
+      background: #fff;
+      color: #115e59;
+      border-radius: 999px;
+      padding: 6px 11px;
+      font-size: 12px;
+      font-weight: 700;
+      cursor: pointer;
+    }
+    .compare-toolbar-btn:hover {
+      border-color: #14b8a6;
+      color: #0f766e;
+    }
+    .compare-toolbar-list {
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+    .compare-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 5px 8px 5px 10px;
+      border-radius: 999px;
+      background: #0f172a;
+      color: #f8fafc;
+      font-size: 12px;
+      font-weight: 600;
+    }
+    .compare-pill-remove {
+      border: 0;
+      background: transparent;
+      color: #99f6e4;
+      cursor: pointer;
+      font-size: 11px;
+      font-weight: 700;
+      padding: 0;
+    }
+    .compare-pill-remove:hover {
+      color: #fff;
+    }
+    .compare-toolbar-note {
+      font-size: 12px;
+      color: #475569;
+      font-weight: 500;
+    }
+    .resort-actions {
+      margin-top: 5px;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      flex-wrap: wrap;
+    }
+    .compare-select-btn {
+      border: 1px solid #cbd5e1;
+      background: #f8fafc;
+      color: #334155;
+      border-radius: 999px;
+      padding: 3px 8px;
+      font-size: 11px;
+      font-weight: 700;
+      cursor: pointer;
+      white-space: nowrap;
+    }
+    .compare-select-btn[data-compare-active="1"] {
+      border-color: #14b8a6;
+      background: #ccfbf1;
+      color: #115e59;
+    }
+    .compare-select-btn:hover {
+      border-color: #14b8a6;
+      color: #0f766e;
+    }
+    .compare-toolbar-btn:focus-visible,
+    .compare-pill-remove:focus-visible,
+    .compare-select-btn:focus-visible {
+      outline: 2px solid #0f766e;
+      outline-offset: 2px;
+    }
     .section-loading,
     .page-load-error {
       margin: 0;
@@ -983,5 +1096,13 @@
     }
     body.mobile-simple .plain-table {
       min-width: 0;
+    }
+    @media (max-width: 720px) {
+      .compare-toolbar {
+        padding: 10px 12px;
+      }
+      .compare-toolbar-head {
+        align-items: flex-start;
+      }
     }
   

--- a/assets/js/compare_selection.js
+++ b/assets/js/compare_selection.js
@@ -1,0 +1,102 @@
+(() => {
+  const DEFAULT_QUERY_KEY = "compare";
+  const DEFAULT_MAX_SELECTION = 4;
+
+  const normalizeResortId = (value) => String(value || "").trim();
+
+  const _positiveIntOr = (value, fallback) => {
+    const num = Number(value);
+    return Number.isInteger(num) && num > 0 ? num : fallback;
+  };
+
+  const normalizeResortIds = (values) => {
+    const input = Array.isArray(values) ? values : [values];
+    const seen = new Set();
+    const out = [];
+    input.forEach((raw) => {
+      String(raw || "")
+        .split(",")
+        .map(normalizeResortId)
+        .filter(Boolean)
+        .forEach((resortId) => {
+          if (seen.has(resortId)) return;
+          seen.add(resortId);
+          out.push(resortId);
+        });
+    });
+    return out;
+  };
+
+  const sanitizeSelection = (values, options = {}) => {
+    const validIds = new Set(normalizeResortIds(options.validResortIds || []));
+    const normalized = normalizeResortIds(values);
+    const filtered = validIds.size ? normalized.filter((resortId) => validIds.has(resortId)) : normalized;
+    return filtered.slice(0, _positiveIntOr(options.maxSelection, DEFAULT_MAX_SELECTION));
+  };
+
+  const parseSelectionFromParams = (params, options = {}) => {
+    const queryKey = normalizeResortId(options.queryKey || DEFAULT_QUERY_KEY) || DEFAULT_QUERY_KEY;
+    const searchParams = params instanceof URLSearchParams ? params : new URLSearchParams(params || "");
+    return sanitizeSelection(searchParams.getAll(queryKey), options);
+  };
+
+  const parseSelectionFromSearch = (search, options = {}) => {
+    const normalizedSearch = String(search || "").replace(/^\?/, "");
+    return parseSelectionFromParams(new URLSearchParams(normalizedSearch), options);
+  };
+
+  const withSelectionInParams = (params, values, options = {}) => {
+    const queryKey = normalizeResortId(options.queryKey || DEFAULT_QUERY_KEY) || DEFAULT_QUERY_KEY;
+    const searchParams = params instanceof URLSearchParams ? new URLSearchParams(params.toString()) : new URLSearchParams(params || "");
+    searchParams.delete(queryKey);
+    sanitizeSelection(values, options).forEach((resortId) => {
+      searchParams.append(queryKey, resortId);
+    });
+    return searchParams;
+  };
+
+  const toggleSelection = (selection, resortId, options = {}) => {
+    const current = sanitizeSelection(selection, options);
+    const normalizedId = normalizeResortId(resortId);
+    const validIds = new Set(normalizeResortIds(options.validResortIds || []));
+    const maxSelection = _positiveIntOr(options.maxSelection, DEFAULT_MAX_SELECTION);
+
+    if (!normalizedId || (validIds.size && !validIds.has(normalizedId))) {
+      return { selection: current, changed: false, added: false, removed: false, reason: "invalid" };
+    }
+
+    if (current.includes(normalizedId)) {
+      return {
+        selection: current.filter((value) => value !== normalizedId),
+        changed: true,
+        added: false,
+        removed: true,
+        reason: "removed",
+      };
+    }
+
+    if (current.length >= maxSelection) {
+      return { selection: current, changed: false, added: false, removed: false, reason: "max" };
+    }
+
+    return {
+      selection: [...current, normalizedId],
+      changed: true,
+      added: true,
+      removed: false,
+      reason: "added",
+    };
+  };
+
+  window.CloseSnowCompareSelection = {
+    DEFAULT_QUERY_KEY,
+    DEFAULT_MAX_SELECTION,
+    normalizeResortId,
+    normalizeResortIds,
+    sanitizeSelection,
+    parseSelectionFromParams,
+    parseSelectionFromSearch,
+    withSelectionInParams,
+    toggleSelection,
+  };
+})();

--- a/assets/js/weather_page.js
+++ b/assets/js/weather_page.js
@@ -29,13 +29,30 @@ const filterIncludeAllInput = document.getElementById("filter-include-all");
 const filterSearchAllInput = document.getElementById("filter-search-all");
 const favoritesOnlyToggle = document.getElementById("favorites-only-toggle");
 const filterFavoritesOnlyInput = document.getElementById("filter-favorites-only");
+const compareToolbar = document.getElementById("compare-toolbar");
 const filterPassTypeInputs = Array.from(document.querySelectorAll("input[name='filter-pass-type']"));
+
+const _positiveIntOr = (value, fallback) => {
+  const num = Number(value);
+  return Number.isInteger(num) && num > 0 ? num : fallback;
+};
+
+const compareSelectionBootstrap =
+  pageBootstrap.compareSelection && typeof pageBootstrap.compareSelection === "object" && !Array.isArray(pageBootstrap.compareSelection)
+    ? pageBootstrap.compareSelection
+    : {};
+const compareSelectionApi = window.CloseSnowCompareSelection || {};
 
 const UNIT_STORAGE_KEY_PREFIX = "closesnow_unit_mode_";
 const FILTER_STORAGE_KEY = "closesnow_filter_state_v1";
 const FAVORITES_STORAGE_KEY = "closesnow_favorite_resorts_v1";
 const VALID_UNIT_KINDS = new Set(["snow", "rain", "temp"]);
 const DEFAULT_AVAILABLE_FILTERS = { pass_type: {}, region: {}, country: {} };
+const COMPARE_SELECTION_QUERY_KEY = String(compareSelectionBootstrap.queryKey || compareSelectionApi.DEFAULT_QUERY_KEY || "compare").trim() || "compare";
+const COMPARE_SELECTION_MAX_RESORTS = _positiveIntOr(
+  compareSelectionBootstrap.maxResorts || compareSelectionApi.DEFAULT_MAX_SELECTION,
+  4,
+);
 const MAX_DISPLAY_DAYS = 14;
 const MIN_DESKTOP_SNOW_3DAY_PX = 554;
 const compactDailySummary = window.CloseSnowCompactDailySummary || {};
@@ -46,7 +63,11 @@ const appState = {
   payload: null,
   reports: [],
   availableFilters: DEFAULT_AVAILABLE_FILTERS,
+  knownResortIds: new Set(),
+  resortNamesById: {},
   favoriteResortIds: new Set(),
+  compareResortIds: [],
+  compareMessage: "",
   filterState: {
     passTypes: new Set(),
     region: "",
@@ -245,6 +266,19 @@ const _favoriteAllButtonHtml = (reports) => {
   return `<button type='button' class='favorite-btn favorite-all-btn' data-favorite-all='1' data-favorite-active='${allFavorited ? "1" : "0"}' aria-pressed='${allFavorited ? "true" : "false"}' aria-label='${label}'><svg class='favorite-btn-icon favorite-btn-outline' aria-hidden='true' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round'><path d='M12 21s-6.9-4.35-9.2-8.45C.9 9.18 2.03 5.5 5.58 4.6c2.12-.54 4.4.24 5.82 1.98 1.42-1.74 3.7-2.52 5.82-1.98 3.55.9 4.68 4.58 2.78 7.95C18.9 16.65 12 21 12 21Z'/></svg><svg class='favorite-btn-icon favorite-btn-filled' aria-hidden='true' viewBox='0 0 24 24' fill='currentColor'><path d='M12 21s-6.9-4.35-9.2-8.45C.9 9.18 2.03 5.5 5.58 4.6c2.12-.54 4.4.24 5.82 1.98 1.42-1.74 3.7-2.52 5.82-1.98 3.55.9 4.68 4.58 2.78 7.95C18.9 16.65 12 21 12 21Z'/></svg></button>`;
 };
 
+const _compareSelectionIndex = (resortId) => appState.compareResortIds.indexOf(String(resortId || "").trim());
+const _isCompareResortId = (resortId) => _compareSelectionIndex(resortId) >= 0;
+
+const _compareButtonHtml = (report) => {
+  const resortId = String(report?.resort_id || "").trim();
+  if (!resortId) return "";
+  const index = _compareSelectionIndex(resortId);
+  const active = index >= 0;
+  const text = active ? `Selected #${index + 1}` : "Compare";
+  const label = active ? "Remove resort from compare set" : "Add resort to compare set";
+  return `<button type='button' class='compare-select-btn' data-compare-resort-id='${_escapeHtml(resortId)}' data-compare-active='${active ? "1" : "0"}' aria-pressed='${active ? "true" : "false"}' aria-label='${label}'>${_escapeHtml(text)}</button>`;
+};
+
 const _displayName = (report) => String(report?.display_name || report?.query || "").trim();
 
 const _resortCellHtml = (report) => {
@@ -253,7 +287,8 @@ const _resortCellHtml = (report) => {
   const linkHtml = resortId
     ? `<a class='resort-link' href='resort/${encodeURIComponent(resortId)}'>${text}</a>`
     : text;
-  return `<td class='favorite-col'>${_favoriteButtonHtml(report)}</td><td class='query-col'><div class='resort-cell'><div class='resort-link-wrap'>${linkHtml}</div></div></td>`;
+  const compareButtonHtml = _compareButtonHtml(report);
+  return `<td class='favorite-col'>${_favoriteButtonHtml(report)}</td><td class='query-col'><div class='resort-cell'><div class='resort-link-wrap'>${linkHtml}</div>${compareButtonHtml ? `<div class='resort-actions'>${compareButtonHtml}</div>` : ""}</div></td>`;
 };
 
 const _displayDays = () => {
@@ -571,6 +606,182 @@ const _payloadReports = () => {
   return reports.filter((report) => report && typeof report === "object");
 };
 
+const _indexKnownResorts = (reports) => {
+  (reports || []).forEach((report) => {
+    const resortId = String(report?.resort_id || "").trim();
+    if (!resortId) return;
+    appState.knownResortIds.add(resortId);
+    const label = _displayName(report);
+    if (label && !appState.resortNamesById[resortId]) {
+      appState.resortNamesById[resortId] = label;
+    }
+  });
+};
+
+const _knownCompareResortIds = () => (
+  appState.knownResortIds.size > 0
+    ? Array.from(appState.knownResortIds)
+    : Array.from(new Set(_payloadReports().map((report) => String(report?.resort_id || "").trim()).filter(Boolean)))
+);
+
+const _normalizeCompareSelection = (values) => {
+  const input = Array.isArray(values) ? values : [values];
+  const seen = new Set();
+  const out = [];
+  input.forEach((raw) => {
+    String(raw || "")
+      .split(",")
+      .map((value) => String(value || "").trim())
+      .filter(Boolean)
+      .forEach((resortId) => {
+        if (seen.has(resortId)) return;
+        seen.add(resortId);
+        out.push(resortId);
+      });
+  });
+  return out;
+};
+
+const _sanitizeCompareSelection = (values, validResortIds = _knownCompareResortIds()) => {
+  if (typeof compareSelectionApi.sanitizeSelection === "function") {
+    const parsed = compareSelectionApi.sanitizeSelection(values, {
+      queryKey: COMPARE_SELECTION_QUERY_KEY,
+      validResortIds,
+      maxSelection: COMPARE_SELECTION_MAX_RESORTS,
+    });
+    return Array.isArray(parsed) ? parsed : [];
+  }
+  const normalized = _normalizeCompareSelection(values);
+  const validSet = new Set(_normalizeCompareSelection(validResortIds));
+  const filtered = validSet.size ? normalized.filter((resortId) => validSet.has(resortId)) : normalized;
+  return filtered.slice(0, COMPARE_SELECTION_MAX_RESORTS);
+};
+
+const _parseCompareSelectionFromLocation = (search = window.location.search) => {
+  const validResortIds = _knownCompareResortIds();
+  if (typeof compareSelectionApi.parseSelectionFromSearch === "function") {
+    const parsed = compareSelectionApi.parseSelectionFromSearch(search, {
+      queryKey: COMPARE_SELECTION_QUERY_KEY,
+      validResortIds,
+      maxSelection: COMPARE_SELECTION_MAX_RESORTS,
+    });
+    return Array.isArray(parsed) ? parsed : [];
+  }
+  const params = new URLSearchParams(String(search || "").replace(/^\?/, ""));
+  return _sanitizeCompareSelection(params.getAll(COMPARE_SELECTION_QUERY_KEY), validResortIds);
+};
+
+const _withCompareSelectionInParams = (params, compareResortIds) => {
+  if (typeof compareSelectionApi.withSelectionInParams === "function") {
+    return compareSelectionApi.withSelectionInParams(params, compareResortIds, {
+      queryKey: COMPARE_SELECTION_QUERY_KEY,
+      validResortIds: _knownCompareResortIds(),
+      maxSelection: COMPARE_SELECTION_MAX_RESORTS,
+    });
+  }
+  const nextParams = params instanceof URLSearchParams ? new URLSearchParams(params.toString()) : new URLSearchParams(params || "");
+  nextParams.delete(COMPARE_SELECTION_QUERY_KEY);
+  _sanitizeCompareSelection(compareResortIds).forEach((resortId) => {
+    nextParams.append(COMPARE_SELECTION_QUERY_KEY, resortId);
+  });
+  return nextParams;
+};
+
+const restoreCompareSelectionFromLocation = () => {
+  appState.compareResortIds = _parseCompareSelectionFromLocation();
+  appState.compareMessage = "";
+};
+
+const _compareDisplayName = (resortId) => String(appState.resortNamesById[String(resortId || "").trim()] || resortId || "").trim();
+
+const toggleCompareResortId = (resortId) => {
+  const current = appState.compareResortIds.slice();
+  let result;
+  if (typeof compareSelectionApi.toggleSelection === "function") {
+    result = compareSelectionApi.toggleSelection(current, resortId, {
+      queryKey: COMPARE_SELECTION_QUERY_KEY,
+      validResortIds: _knownCompareResortIds(),
+      maxSelection: COMPARE_SELECTION_MAX_RESORTS,
+    });
+  } else {
+    const normalizedId = String(resortId || "").trim();
+    const validIds = new Set(_knownCompareResortIds());
+    if (!normalizedId || (validIds.size && !validIds.has(normalizedId))) {
+      result = { selection: current, changed: false, reason: "invalid" };
+    } else if (current.includes(normalizedId)) {
+      result = { selection: current.filter((value) => value !== normalizedId), changed: true, reason: "removed" };
+    } else if (current.length >= COMPARE_SELECTION_MAX_RESORTS) {
+      result = { selection: current, changed: false, reason: "max" };
+    } else {
+      result = { selection: [...current, normalizedId], changed: true, reason: "added" };
+    }
+  }
+
+  appState.compareResortIds = _sanitizeCompareSelection(result.selection || current);
+  if (result.reason === "max") {
+    appState.compareMessage = `Compare up to ${COMPARE_SELECTION_MAX_RESORTS} resorts at a time.`;
+  } else if (result.reason === "invalid") {
+    appState.compareMessage = "Only known resort ids can be added to compare.";
+  } else {
+    appState.compareMessage = "";
+  }
+  syncUrlFromFilterState();
+};
+
+const clearCompareSelection = () => {
+  appState.compareResortIds = [];
+  appState.compareMessage = "";
+  syncUrlFromFilterState();
+};
+
+const buildCompareShareUrl = () => {
+  const url = new URL(window.location.href);
+  url.search = _withCompareSelectionInParams(new URLSearchParams(window.location.search), appState.compareResortIds).toString();
+  return url.toString();
+};
+
+const copyCompareShareUrl = async () => {
+  const url = buildCompareShareUrl();
+  if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+    try {
+      await navigator.clipboard.writeText(url);
+      appState.compareMessage = "Compare link copied.";
+      renderCompareToolbar();
+      return;
+    } catch (error) {
+      // Fall through to the non-clipboard message below.
+    }
+  }
+  appState.compareMessage = "Share this page URL from the address bar.";
+  renderCompareToolbar();
+};
+
+const renderCompareToolbar = () => {
+  if (!compareToolbar) return;
+  const selected = appState.compareResortIds.slice();
+  if (!selected.length) {
+    compareToolbar.hidden = true;
+    compareToolbar.innerHTML = "";
+    return;
+  }
+  const chips = selected.map((resortId, index) => (
+    `<span class='compare-pill'><span>${_escapeHtml(_compareDisplayName(resortId))} <strong>#${index + 1}</strong></span><button type='button' class='compare-pill-remove' data-compare-remove-id='${_escapeHtml(resortId)}' aria-label='Remove ${_escapeHtml(_compareDisplayName(resortId))} from compare'>Remove</button></span>`
+  )).join("");
+  const note = appState.compareMessage || "Share this page URL to restore the same compare set on the static site.";
+  compareToolbar.hidden = false;
+  compareToolbar.innerHTML = `
+    <div class='compare-toolbar-head'>
+      <div class='compare-toolbar-title'>Compare selection <strong>${selected.length}/${COMPARE_SELECTION_MAX_RESORTS}</strong></div>
+      <div class='compare-toolbar-actions'>
+        <button type='button' class='compare-toolbar-btn' data-compare-copy='1'>Copy link</button>
+        <button type='button' class='compare-toolbar-btn' data-compare-clear='1'>Clear</button>
+      </div>
+    </div>
+    <div class='compare-toolbar-list'>${chips}</div>
+    <div class='compare-toolbar-note'>${_escapeHtml(note)}</div>
+  `;
+};
+
 const _deriveAvailableFiltersFromReports = (reports) => {
   const out = { pass_type: {}, region: {}, country: {} };
   reports.forEach((report) => {
@@ -837,7 +1048,14 @@ const applyFilterStateFromControls = () => {
 };
 
 const syncUrlFromFilterState = () => {
-  return false;
+  const currentSearch = String(window.location.search || "").replace(/^\?/, "");
+  const nextParams = _withCompareSelectionInParams(new URLSearchParams(window.location.search), appState.compareResortIds);
+  const nextSearch = nextParams.toString();
+  if (nextSearch === currentSearch) return false;
+  const nextUrl = new URL(window.location.href);
+  nextUrl.search = nextSearch;
+  window.history.replaceState({}, "", nextUrl.toString());
+  return true;
 };
 
 const buildServerQueryParams = () => {
@@ -1579,6 +1797,7 @@ const renderPage = () => {
   applyLayout();
   observeLayoutContainers();
   pageContentRoot.removeAttribute("data-loading");
+  renderCompareToolbar();
   syncFilterSummary(visibleReports.length, totalReports);
   renderReportDate();
   applyUnitModes();
@@ -1707,6 +1926,7 @@ const reloadDynamicPayloadForFilters = async () => {
   const payload = await loadPayload(endpoint.toString());
   appState.payload = payload;
   appState.reports = _payloadReports();
+  _indexKnownResorts(appState.reports);
   appState.availableFilters = _availableFilters();
   updateFilterLabels();
 };
@@ -1787,6 +2007,33 @@ const bindControls = () => {
     if (event.key === "Escape" && filterModal && !filterModal.hidden) closeFilterModal();
   });
   document.addEventListener("click", (event) => {
+    const compareCopyButton = event.target.closest("[data-compare-copy='1']");
+    if (compareCopyButton) {
+      event.preventDefault();
+      void copyCompareShareUrl();
+      return;
+    }
+    const compareClearButton = event.target.closest("[data-compare-clear='1']");
+    if (compareClearButton) {
+      event.preventDefault();
+      clearCompareSelection();
+      renderPagePreservingScroll();
+      return;
+    }
+    const compareRemoveButton = event.target.closest(".compare-pill-remove[data-compare-remove-id]");
+    if (compareRemoveButton) {
+      event.preventDefault();
+      toggleCompareResortId(compareRemoveButton.getAttribute("data-compare-remove-id"));
+      renderPagePreservingScroll();
+      return;
+    }
+    const compareButton = event.target.closest(".compare-select-btn[data-compare-resort-id]");
+    if (compareButton) {
+      event.preventDefault();
+      toggleCompareResortId(compareButton.getAttribute("data-compare-resort-id"));
+      renderPagePreservingScroll();
+      return;
+    }
     const favoriteAllButton = event.target.closest(".favorite-all-btn[data-favorite-all='1']");
     if (favoriteAllButton) {
       event.preventDefault();
@@ -1844,9 +2091,11 @@ const initialize = async () => {
   try {
     appState.payload = await loadPayload();
     appState.reports = _payloadReports();
+    _indexKnownResorts(appState.reports);
     appState.availableFilters = _availableFilters();
     updateFilterLabels();
     applyControlsFromQueryOrMeta();
+    restoreCompareSelectionFromLocation();
     renderPage();
   } catch (error) {
     if (pageContentRoot) {

--- a/src/web/templates/weather_page.html
+++ b/src/web/templates/weather_page.html
@@ -95,6 +95,7 @@
         </div>
       </div>
     </div>
+    <div id="compare-toolbar" class="compare-toolbar" hidden></div>
     <div id="page-content-root" data-loading="1">
       {{page_shell_placeholder}}
     </div>
@@ -106,6 +107,7 @@
     window.CLOSESNOW_FILTER_META = {{filter_meta_json}};
     window.CLOSESNOW_PAGE_BOOTSTRAP = {{page_bootstrap_json}};
   </script>
+  <script src="assets/js/compare_selection.js"></script>
   <script src="assets/js/compact_daily_summary.js"></script>
   <script src="assets/js/weather_page.js"></script>
 </body>

--- a/src/web/weather_html_renderer.py
+++ b/src/web/weather_html_renderer.py
@@ -7,6 +7,10 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 _PAGE_TEMPLATE = (Path(__file__).resolve().parent / "templates" / "weather_page.html").read_text(encoding="utf-8")
+_COMPARE_SELECTION_BOOTSTRAP = {
+    "queryKey": "compare",
+    "maxResorts": 4,
+}
 
 _PAGE_SHELL_PLACEHOLDER = """
     <section><h2>Daily Summary</h2><p class="section-loading">Loading forecast...</p></section>
@@ -36,7 +40,13 @@ def build_html(
         "applied_filters": applied_filters or {},
     }
     filter_meta_json = json.dumps(filter_meta, ensure_ascii=False)
-    page_bootstrap_json = json.dumps({"dataUrl": data_url}, ensure_ascii=False)
+    page_bootstrap_json = json.dumps(
+        {
+            "dataUrl": data_url,
+            "compareSelection": _COMPARE_SELECTION_BOOTSTRAP,
+        },
+        ensure_ascii=False,
+    )
     return (
         _PAGE_TEMPLATE.replace("{{generated_utc_iso}}", generated_utc_iso)
         .replace("{{filter_meta_json}}", filter_meta_json)

--- a/src/web/weather_page_assets.py
+++ b/src/web/weather_page_assets.py
@@ -9,6 +9,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 ASSET_MIME_TYPES: Dict[str, str] = {
     "assets/css/weather_page.css": "text/css; charset=utf-8",
     "assets/js/compact_daily_summary.js": "application/javascript; charset=utf-8",
+    "assets/js/compare_selection.js": "application/javascript; charset=utf-8",
     "assets/js/weather_page.js": "application/javascript; charset=utf-8",
     "assets/css/resort_hourly.css": "text/css; charset=utf-8",
     "assets/js/resort_hourly.js": "application/javascript; charset=utf-8",

--- a/tests/frontend/test_assets.py
+++ b/tests/frontend/test_assets.py
@@ -8,11 +8,13 @@ from src.web.weather_page_assets import ASSET_MIME_TYPES, asset_path, read_asset
 def test_asset_path_points_to_repo_assets():
     css_path = asset_path("assets/css/weather_page.css")
     compact_js_path = asset_path("assets/js/compact_daily_summary.js")
+    compare_js_path = asset_path("assets/js/compare_selection.js")
     js_path = asset_path("assets/js/weather_page.js")
     hourly_css_path = asset_path("assets/css/resort_hourly.css")
     hourly_js_path = asset_path("assets/js/resort_hourly.js")
     assert str(css_path).endswith("assets/css/weather_page.css")
     assert str(compact_js_path).endswith("assets/js/compact_daily_summary.js")
+    assert str(compare_js_path).endswith("assets/js/compare_selection.js")
     assert str(js_path).endswith("assets/js/weather_page.js")
     assert str(hourly_css_path).endswith("assets/css/resort_hourly.css")
     assert str(hourly_js_path).endswith("assets/js/resort_hourly.js")
@@ -21,21 +23,25 @@ def test_asset_path_points_to_repo_assets():
 def test_read_asset_bytes_reads_known_assets():
     css = read_asset_bytes("assets/css/weather_page.css")
     compact_js = read_asset_bytes("assets/js/compact_daily_summary.js")
+    compare_js = read_asset_bytes("assets/js/compare_selection.js")
     js = read_asset_bytes("assets/js/weather_page.js")
     hourly_css = read_asset_bytes("assets/css/resort_hourly.css")
     hourly_js = read_asset_bytes("assets/js/resort_hourly.js")
     assert len(css) > 100
     assert len(compact_js) > 100
+    assert len(compare_js) > 100
     assert len(js) > 100
     assert len(hourly_css) > 100
     assert len(hourly_js) > 100
     assert ASSET_MIME_TYPES["assets/css/weather_page.css"].startswith("text/css")
     assert ASSET_MIME_TYPES["assets/js/compact_daily_summary.js"].startswith("application/javascript")
+    assert ASSET_MIME_TYPES["assets/js/compare_selection.js"].startswith("application/javascript")
     assert ASSET_MIME_TYPES["assets/js/weather_page.js"].startswith("application/javascript")
     assert ASSET_MIME_TYPES["assets/css/resort_hourly.css"].startswith("text/css")
     assert ASSET_MIME_TYPES["assets/js/resort_hourly.js"].startswith("application/javascript")
     css_text = css.decode("utf-8", errors="ignore")
     compact_js_text = compact_js.decode("utf-8", errors="ignore")
+    compare_js_text = compare_js.decode("utf-8", errors="ignore")
     hourly_css_text = hourly_css.decode("utf-8", errors="ignore")
     hourly_js_text = hourly_js.decode("utf-8", errors="ignore")
     js_text = js.decode("utf-8", errors="ignore")
@@ -65,6 +71,9 @@ def test_read_asset_bytes_reads_known_assets():
     assert "data-compact-today-anchor" in compact_js_text
     assert "compact-day-head-phase-start" not in compact_js_text
     assert "compact-day-cell-phase-start" not in compact_js_text
+    assert "window.CloseSnowCompareSelection" in compare_js_text
+    assert "parseSelectionFromSearch" in compare_js_text
+    assert "toggleSelection" in compare_js_text
     assert "window.CLOSESNOW_PAGE_BOOTSTRAP" in js_text
     assert "No resorts match the current filters." in js_text
     assert 'return "Today";' in js_text

--- a/tests/frontend/test_renderers.py
+++ b/tests/frontend/test_renderers.py
@@ -271,6 +271,11 @@ def test_build_html_contains_meta_sections():
     assert "window.CLOSESNOW_FILTER_META" in html
     assert "window.CLOSESNOW_PAGE_BOOTSTRAP" in html
     assert '"dataUrl": "./data.json"' in html
+    assert '"compareSelection"' in html
+    assert '"queryKey": "compare"' in html
+    assert '"maxResorts": 4' in html
+    assert 'id="compare-toolbar"' in html
+    assert 'assets/js/compare_selection.js' in html
     assert 'id="page-content-root"' in html
     assert "include_all" in html
     assert 'data-generated-utc="' in html

--- a/tests/integration/test_gateway_render_integration.py
+++ b/tests/integration/test_gateway_render_integration.py
@@ -21,6 +21,7 @@ def test_file_gateway_to_renderer_integration(tmp_path, valid_payload):
     assert 'id="page-content-root"' in html
     assert "window.CLOSESNOW_PAGE_BOOTSTRAP" in html
     assert '"dataUrl": "./data.json"' in html
+    assert '"compareSelection"' in html
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary
- add a shared compare-selection asset with stable query-param parsing and max-count enforcement
- wire homepage compare add/remove controls, compare summary toolbar, and share-link URL sync
- expose compare bootstrap config and cover the new asset/render wiring in tests

## Validation
- python3 -m pytest -q tests/frontend/test_assets.py tests/frontend/test_renderers.py tests/frontend/test_static_site_pipeline.py tests/integration/test_web_server.py tests/integration/test_gateway_render_integration.py
- python3 -m src.cli static --output-dir /tmp/closesnow-resort-compare-selection --max-workers 8