### PR TITLE
Add home base location contract

### DIFF
--- a/assets/css/weather_page.css
+++ b/assets/css/weather_page.css
@@ -47,6 +47,88 @@
       display: grid;
       gap: 8px;
     }
+    .home-base-controls {
+      display: grid;
+      gap: 10px;
+      padding: 12px 14px;
+      border: 1px solid #cbd5e1;
+      border-radius: 14px;
+      background: rgba(255, 255, 255, 0.86);
+      box-shadow: 0 10px 22px rgba(15, 23, 42, 0.06);
+    }
+    .home-base-head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+    .home-base-title {
+      font-size: 11px;
+      font-weight: 800;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: #0f172a;
+    }
+    .home-base-summary {
+      margin-top: 2px;
+      font-size: 14px;
+      font-weight: 700;
+      color: #1e293b;
+    }
+    .home-base-lookup-row,
+    .home-base-manual-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+    .home-base-lookup-row label,
+    .home-base-manual-row label {
+      font-size: 12px;
+      font-weight: 700;
+      color: #334155;
+    }
+    .home-base-controls input {
+      padding: 7px 10px;
+      border: 1px solid #cbd5e1;
+      border-radius: 8px;
+      background: #fff;
+      font-size: 13px;
+      color: #1f2937;
+    }
+    #home-base-lookup-input {
+      min-width: 260px;
+      flex: 1 1 260px;
+    }
+    #home-base-lat-input,
+    #home-base-lon-input {
+      width: 130px;
+    }
+    .home-base-controls button {
+      border: 1px solid #94a3b8;
+      background: #f8fafc;
+      color: #1f2937;
+      border-radius: 8px;
+      padding: 7px 12px;
+      font-size: 12px;
+      font-weight: 700;
+      cursor: pointer;
+    }
+    #home-base-geolocate-btn {
+      border-color: #0f766e;
+      background: #ecfeff;
+      color: #0f766e;
+    }
+    .home-base-status {
+      margin: 0;
+      font-size: 12px;
+      font-weight: 600;
+      color: #475569;
+    }
+    .home-base-status[data-state="error"] {
+      color: #b91c1c;
+    }
     .resort-search {
       display: flex;
       align-items: center;
@@ -138,6 +220,16 @@
       justify-content: center;
       z-index: 50;
       padding: 14px;
+    }
+    @media (max-width: 820px) {
+      #home-base-lookup-input {
+        min-width: 0;
+        width: 100%;
+      }
+      #home-base-lat-input,
+      #home-base-lon-input {
+        width: min(100%, 160px);
+      }
     }
     .filter-panel {
       width: min(460px, 100%);

--- a/assets/js/home_base.js
+++ b/assets/js/home_base.js
@@ -1,0 +1,267 @@
+// Shared home-base contract used by the follow-on distance and UI slices.
+(() => {
+  const CONTRACT_VERSION = 1;
+  const STORAGE_KEY = "closesnow_home_base_v1";
+  const QUERY_KEYS = Object.freeze({
+    source: "home_base_source",
+    label: "home_base_label",
+    latitude: "home_base_lat",
+    longitude: "home_base_lon",
+    placeId: "home_base_place",
+    city: "home_base_city",
+    region: "home_base_region",
+    postalCode: "home_base_zip",
+    countryCode: "home_base_cc",
+  });
+
+  const _text = (value) => String(value || "").trim();
+  const _norm = (value) => _text(value).toLowerCase();
+  const _upper = (value) => _text(value).toUpperCase();
+  const _asFiniteNumber = (value) => {
+    if (value === null || value === undefined || value === "") return null;
+    const num = Number(value);
+    return Number.isFinite(num) ? num : null;
+  };
+  const _validLatitude = (value) => value !== null && value >= -90 && value <= 90;
+  const _validLongitude = (value) => value !== null && value >= -180 && value <= 180;
+  const _roundCoord = (value) => Number(value.toFixed(6));
+  const _coordinateLabel = (latitude, longitude) => `${latitude.toFixed(4)}, ${longitude.toFixed(4)}`;
+
+  const RAW_LOOKUP_ENTRIES = [
+    ["salt-lake-city-ut-84101", "Salt Lake City, UT", "Salt Lake City", "UT", "84101", 40.760779, -111.891045],
+    ["park-city-ut-84060", "Park City, UT", "Park City", "UT", "84060", 40.646063, -111.497972],
+    ["denver-co-80202", "Denver, CO", "Denver", "CO", "80202", 39.752998, -104.999226],
+    ["boulder-co-80302", "Boulder, CO", "Boulder", "CO", "80302", 40.017544, -105.279297],
+    ["frisco-co-80443", "Frisco, CO", "Frisco", "CO", "80443", 39.57443, -106.09752],
+    ["breckenridge-co-80424", "Breckenridge, CO", "Breckenridge", "CO", "80424", 39.481654, -106.038352],
+    ["steamboat-springs-co-80487", "Steamboat Springs, CO", "Steamboat Springs", "CO", "80487", 40.485013, -106.831715],
+    ["aspen-co-81611", "Aspen, CO", "Aspen", "CO", "81611", 39.191098, -106.817539],
+    ["reno-nv-89501", "Reno, NV", "Reno", "NV", "89501", 39.527768, -119.81348],
+    ["truckee-ca-96161", "Truckee, CA", "Truckee", "CA", "96161", 39.327962, -120.183253],
+    ["south-lake-tahoe-ca-96150", "South Lake Tahoe, CA", "South Lake Tahoe", "CA", "96150", 38.939926, -119.977186],
+    ["mammoth-lakes-ca-93546", "Mammoth Lakes, CA", "Mammoth Lakes", "CA", "93546", 37.648546, -118.972079],
+    ["sacramento-ca-95814", "Sacramento, CA", "Sacramento", "CA", "95814", 38.581572, -121.4944],
+    ["seattle-wa-98101", "Seattle, WA", "Seattle", "WA", "98101", 47.606209, -122.332071],
+    ["enumclaw-wa-98022", "Enumclaw, WA", "Enumclaw", "WA", "98022", 47.204266, -121.9915],
+    ["spokane-wa-99201", "Spokane, WA", "Spokane", "WA", "99201", 47.65878, -117.426047],
+    ["bend-or-97701", "Bend, OR", "Bend", "OR", "97701", 44.058173, -121.31531],
+    ["boise-id-83702", "Boise, ID", "Boise", "ID", "83702", 43.615019, -116.202313],
+    ["jackson-wy-83001", "Jackson, WY", "Jackson", "WY", "83001", 43.479929, -110.762428],
+    ["bozeman-mt-59715", "Bozeman, MT", "Bozeman", "MT", "59715", 45.679653, -111.044048],
+    ["burlington-vt-05401", "Burlington, VT", "Burlington", "VT", "05401", 44.475883, -73.212072],
+    ["killington-vt-05751", "Killington, VT", "Killington", "VT", "05751", 43.678126, -72.779541],
+    ["stowe-vt-05672", "Stowe, VT", "Stowe", "VT", "05672", 44.465433, -72.687402],
+    ["north-conway-nh-03860", "North Conway, NH", "North Conway", "NH", "03860", 44.05368, -71.128403],
+    ["portland-me-04101", "Portland, ME", "Portland", "ME", "04101", 43.659099, -70.256819],
+    ["lake-placid-ny-12946", "Lake Placid, NY", "Lake Placid", "NY", "12946", 44.279491, -73.979871],
+    ["albany-ny-12207", "Albany, NY", "Albany", "NY", "12207", 42.65258, -73.756232],
+    ["boston-ma-02108", "Boston, MA", "Boston", "MA", "02108", 42.357159, -71.063698],
+    ["minneapolis-mn-55401", "Minneapolis, MN", "Minneapolis", "MN", "55401", 44.977753, -93.265011],
+    ["duluth-mn-55802", "Duluth, MN", "Duluth", "MN", "55802", 46.786672, -92.100485],
+    ["traverse-city-mi-49684", "Traverse City, MI", "Traverse City", "MI", "49684", 44.763057, -85.620632],
+    ["detroit-mi-48226", "Detroit, MI", "Detroit", "MI", "48226", 42.331427, -83.045754],
+    ["cleveland-oh-44113", "Cleveland, OH", "Cleveland", "OH", "44113", 41.49932, -81.694361],
+    ["pittsburgh-pa-15222", "Pittsburgh, PA", "Pittsburgh", "PA", "15222", 40.440625, -79.995886],
+    ["philadelphia-pa-19103", "Philadelphia, PA", "Philadelphia", "PA", "19103", 39.952584, -75.165222],
+    ["new-york-ny-10001", "New York, NY", "New York", "NY", "10001", 40.750633, -73.997177],
+    ["washington-dc-20001", "Washington, DC", "Washington", "DC", "20001", 38.907192, -77.036871],
+  ];
+
+  const LOOKUP_ENTRIES = Object.freeze(
+    RAW_LOOKUP_ENTRIES.map(([placeId, label, city, region, postalCode, latitude, longitude]) => Object.freeze({
+      placeId,
+      label,
+      display: `${label} (${postalCode})`,
+      city,
+      region,
+      postalCode,
+      countryCode: "US",
+      latitude,
+      longitude,
+    }))
+  );
+
+  const LOOKUP_INDEX = LOOKUP_ENTRIES.map((entry) => {
+    const cityRegion = `${entry.city}, ${entry.region}`;
+    return {
+      entry,
+      exactKeys: new Set([
+        _norm(entry.display),
+        _norm(entry.label),
+        _norm(entry.city),
+        _norm(cityRegion),
+        _norm(entry.postalCode),
+        _norm(entry.placeId),
+      ]),
+      searchKeys: [
+        _norm(entry.display),
+        _norm(entry.label),
+        _norm(entry.city),
+        _norm(cityRegion),
+        _norm(entry.postalCode),
+        _norm(entry.region),
+      ],
+    };
+  });
+
+  const normalizeHomeBase = (raw) => {
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+    const latitude = _asFiniteNumber(raw.latitude);
+    const longitude = _asFiniteNumber(raw.longitude);
+    if (!_validLatitude(latitude) || !_validLongitude(longitude)) return null;
+
+    const sourceText = _norm(raw.source);
+    const source = sourceText === "geolocation" || sourceText === "lookup" || sourceText === "manual"
+      ? sourceText
+      : "manual";
+    const city = _text(raw.city);
+    const region = _upper(raw.region);
+    const postalCode = _text(raw.postalCode);
+    const countryCode = _upper(raw.countryCode || (source === "lookup" ? "US" : ""));
+    const placeId = _text(raw.placeId);
+    const label = _text(raw.label) || (
+      city && region
+        ? `${city}, ${region}`
+        : (city || _coordinateLabel(latitude, longitude))
+    );
+    const query = _text(raw.query) || label;
+    const updatedAt = _text(raw.updatedAt) || new Date().toISOString();
+
+    return Object.freeze({
+      version: CONTRACT_VERSION,
+      source,
+      label,
+      latitude: _roundCoord(latitude),
+      longitude: _roundCoord(longitude),
+      query,
+      placeId,
+      city,
+      region,
+      postalCode,
+      countryCode,
+      updatedAt,
+    });
+  };
+
+  const parseHomeBaseFromSearchParams = (params) => normalizeHomeBase({
+    source: params.get(QUERY_KEYS.source) || "",
+    label: params.get(QUERY_KEYS.label) || "",
+    latitude: params.get(QUERY_KEYS.latitude) || "",
+    longitude: params.get(QUERY_KEYS.longitude) || "",
+    placeId: params.get(QUERY_KEYS.placeId) || "",
+    city: params.get(QUERY_KEYS.city) || "",
+    region: params.get(QUERY_KEYS.region) || "",
+    postalCode: params.get(QUERY_KEYS.postalCode) || "",
+    countryCode: params.get(QUERY_KEYS.countryCode) || "",
+  });
+
+  const parseHomeBaseFromQuery = (rawQuery) => {
+    const query = _text(rawQuery).replace(/^\?/, "");
+    return parseHomeBaseFromSearchParams(new URLSearchParams(query));
+  };
+
+  const loadStoredHomeBase = () => {
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      if (!raw) return null;
+      return normalizeHomeBase(JSON.parse(raw));
+    } catch (error) {
+      return null;
+    }
+  };
+
+  const persistHomeBase = (homeBase) => {
+    const normalized = normalizeHomeBase(homeBase);
+    if (!normalized) return null;
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(normalized));
+    } catch (error) {
+      // Ignore storage failures.
+    }
+    return normalized;
+  };
+
+  const clearStoredHomeBase = () => {
+    try {
+      window.localStorage.removeItem(STORAGE_KEY);
+    } catch (error) {
+      // Ignore storage failures.
+    }
+  };
+
+  const removeHomeBaseSearchParams = (params) => {
+    Object.values(QUERY_KEYS).forEach((key) => params.delete(key));
+    return params;
+  };
+
+  const writeHomeBaseToSearchParams = (params, homeBase) => {
+    removeHomeBaseSearchParams(params);
+    const normalized = normalizeHomeBase(homeBase);
+    if (!normalized) return params;
+    params.set(QUERY_KEYS.source, normalized.source);
+    params.set(QUERY_KEYS.label, normalized.label);
+    params.set(QUERY_KEYS.latitude, String(normalized.latitude));
+    params.set(QUERY_KEYS.longitude, String(normalized.longitude));
+    if (normalized.placeId) params.set(QUERY_KEYS.placeId, normalized.placeId);
+    if (normalized.city) params.set(QUERY_KEYS.city, normalized.city);
+    if (normalized.region) params.set(QUERY_KEYS.region, normalized.region);
+    if (normalized.postalCode) params.set(QUERY_KEYS.postalCode, normalized.postalCode);
+    if (normalized.countryCode) params.set(QUERY_KEYS.countryCode, normalized.countryCode);
+    return params;
+  };
+
+  const _rankLookupMatch = (query, indexEntry) => {
+    if (!query) return 0;
+    if (indexEntry.exactKeys.has(query)) return 0;
+    if (indexEntry.searchKeys.some((key) => key.startsWith(query))) return 1;
+    if (indexEntry.searchKeys.some((key) => key.includes(query))) return 2;
+    return 99;
+  };
+
+  const findLookupMatches = (rawQuery, options = {}) => {
+    const query = _norm(rawQuery);
+    const limit = Math.max(1, Number(options.limit) || 8);
+    return LOOKUP_INDEX
+      .map((indexEntry) => ({ rank: _rankLookupMatch(query, indexEntry), entry: indexEntry.entry }))
+      .filter((item) => item.rank < 99)
+      .sort((a, b) => {
+        if (a.rank !== b.rank) return a.rank - b.rank;
+        return a.entry.label.localeCompare(b.entry.label);
+      })
+      .slice(0, limit)
+      .map((item) => item.entry);
+  };
+
+  const resolveLookupEntry = (rawQuery) => {
+    const query = _norm(rawQuery);
+    if (!query) return null;
+    const exact = LOOKUP_INDEX.find((indexEntry) => indexEntry.exactKeys.has(query));
+    if (exact) return exact.entry;
+    const [first] = findLookupMatches(query, { limit: 1 });
+    return first || null;
+  };
+
+  const describeHomeBase = (homeBase) => {
+    const normalized = normalizeHomeBase(homeBase);
+    if (!normalized) return "Home base not set";
+    return `${normalized.label} (${normalized.latitude.toFixed(4)}, ${normalized.longitude.toFixed(4)})`;
+  };
+
+  window.CloseSnowHomeBase = Object.freeze({
+    CONTRACT_VERSION,
+    STORAGE_KEY,
+    QUERY_KEYS,
+    LOOKUP_ENTRIES,
+    clearStoredHomeBase,
+    describeHomeBase,
+    findLookupMatches,
+    loadStoredHomeBase,
+    normalizeHomeBase,
+    parseHomeBaseFromQuery,
+    parseHomeBaseFromSearchParams,
+    persistHomeBase,
+    removeHomeBaseSearchParams,
+    resolveLookupEntry,
+    writeHomeBaseToSearchParams,
+  });
+})();

--- a/assets/js/weather_page.js
+++ b/assets/js/weather_page.js
@@ -15,6 +15,16 @@ const filterMetaApplied =
 
 const pageContentRoot = document.getElementById("page-content-root");
 const reportDateEl = document.getElementById("report-date");
+const homeBaseSummary = document.getElementById("home-base-summary");
+const homeBaseStatus = document.getElementById("home-base-status");
+const homeBaseLookupInput = document.getElementById("home-base-lookup-input");
+const homeBaseLookupList = document.getElementById("home-base-lookup-list");
+const homeBaseLookupApply = document.getElementById("home-base-lookup-apply");
+const homeBaseGeolocateBtn = document.getElementById("home-base-geolocate-btn");
+const homeBaseClearBtn = document.getElementById("home-base-clear");
+const homeBaseLatInput = document.getElementById("home-base-lat-input");
+const homeBaseLonInput = document.getElementById("home-base-lon-input");
+const homeBaseManualApply = document.getElementById("home-base-manual-apply");
 const resortSearchInput = document.getElementById("resort-search-input");
 const resortSearchClear = document.getElementById("resort-search-clear");
 const filterOpenBtn = document.getElementById("filter-open-btn");
@@ -39,6 +49,9 @@ const DEFAULT_AVAILABLE_FILTERS = { pass_type: {}, region: {}, country: {} };
 const MAX_DISPLAY_DAYS = 14;
 const MIN_DESKTOP_SNOW_3DAY_PX = 554;
 const compactDailySummary = window.CloseSnowCompactDailySummary || {};
+const homeBaseApi = window.CloseSnowHomeBase && typeof window.CloseSnowHomeBase.normalizeHomeBase === "function"
+  ? window.CloseSnowHomeBase
+  : null;
 const COMPACT_SUMMARY_UNIT_KIND = "compact_summary";
 const SUN_TIME_TOGGLE_KIND = "sun_time";
 
@@ -47,6 +60,7 @@ const appState = {
   reports: [],
   availableFilters: DEFAULT_AVAILABLE_FILTERS,
   favoriteResortIds: new Set(),
+  homeBase: null,
   filterState: {
     passTypes: new Set(),
     region: "",
@@ -758,6 +772,203 @@ const persistFilterState = () => {
   } catch (error) {
     // Ignore storage failures.
   }
+};
+
+const _formatCoordinateSummary = (value) => {
+  const num = _asFiniteNumber(value);
+  return num === null ? "" : num.toFixed(4);
+};
+
+const _homeBaseSourceLabel = (source) => {
+  if (source === "geolocation") return "browser geolocation";
+  if (source === "lookup") return "lookup";
+  if (source === "manual") return "manual coordinates";
+  return "custom source";
+};
+
+const _homeBaseSummaryText = (homeBase) => {
+  if (!homeBaseApi) return "Home base unavailable";
+  if (!homeBase) return "Not set";
+  return `${homeBase.label} (${_formatCoordinateSummary(homeBase.latitude)}, ${_formatCoordinateSummary(homeBase.longitude)})`;
+};
+
+const syncHomeBaseControls = () => {
+  const homeBase = appState.homeBase;
+  if (homeBaseSummary) {
+    homeBaseSummary.textContent = _homeBaseSummaryText(homeBase);
+  }
+  if (homeBaseLookupInput) {
+    homeBaseLookupInput.value = homeBase && homeBase.source === "lookup"
+      ? (homeBase.placeId ? `${homeBase.label} (${homeBase.postalCode || ""})`.replace(/\s+\(\)$/, "") : homeBase.label)
+      : "";
+  }
+  if (homeBaseLatInput) homeBaseLatInput.value = homeBase ? _formatCoordinateSummary(homeBase.latitude) : "";
+  if (homeBaseLonInput) homeBaseLonInput.value = homeBase ? _formatCoordinateSummary(homeBase.longitude) : "";
+};
+
+const setHomeBaseStatus = (message = "", isError = false) => {
+  if (!homeBaseStatus) return;
+  homeBaseStatus.textContent = message;
+  homeBaseStatus.dataset.state = isError ? "error" : (message ? "ready" : "");
+};
+
+const syncHomeBaseToUrl = () => {
+  if (!homeBaseApi || !window.history || !window.location) return;
+  const url = new URL(window.location.href);
+  homeBaseApi.writeHomeBaseToSearchParams(url.searchParams, appState.homeBase);
+  window.history.replaceState({}, "", `${url.pathname}${url.search}${url.hash}`);
+};
+
+const notifyHomeBaseChanged = () => {
+  window.CLOSESNOW_HOME_BASE_STATE = appState.homeBase;
+  window.dispatchEvent(new CustomEvent("closesnow:home-base-changed", {
+    detail: appState.homeBase,
+  }));
+};
+
+const setHomeBaseState = (rawHomeBase, options = {}) => {
+  const normalized = homeBaseApi && rawHomeBase ? homeBaseApi.normalizeHomeBase(rawHomeBase) : null;
+  appState.homeBase = normalized;
+  if (homeBaseApi) {
+    if (normalized) {
+      const persisted = homeBaseApi.persistHomeBase(normalized);
+      appState.homeBase = persisted || normalized;
+    } else {
+      homeBaseApi.clearStoredHomeBase();
+    }
+    if (options.updateUrl !== false) syncHomeBaseToUrl();
+  }
+  syncHomeBaseControls();
+  notifyHomeBaseChanged();
+  if (options.statusMessage) {
+    setHomeBaseStatus(options.statusMessage, Boolean(options.isError));
+    return;
+  }
+  if (appState.homeBase) {
+    setHomeBaseStatus(`Home base ready from ${_homeBaseSourceLabel(appState.homeBase.source)}.`, false);
+    return;
+  }
+  setHomeBaseStatus("Set a home base from lookup, geolocation, or coordinates.", false);
+};
+
+const refreshHomeBaseLookupOptions = () => {
+  if (!homeBaseApi || !homeBaseLookupList) return;
+  const matches = homeBaseApi.findLookupMatches(homeBaseLookupInput ? homeBaseLookupInput.value : "", { limit: 8 });
+  homeBaseLookupList.replaceChildren(
+    ...matches.map((entry) => {
+      const option = document.createElement("option");
+      option.value = entry.display || entry.label;
+      return option;
+    }),
+  );
+};
+
+const applyLookupHomeBase = () => {
+  if (!homeBaseApi || !homeBaseLookupInput) return;
+  const lookupText = String(homeBaseLookupInput.value || "").trim();
+  const entry = homeBaseApi.resolveLookupEntry(lookupText);
+  if (!entry) {
+    setHomeBaseStatus("No bundled lookup matched that city or ZIP. Try another entry or manual coordinates.", true);
+    return;
+  }
+  setHomeBaseState({
+    ...entry,
+    source: "lookup",
+    query: lookupText || entry.label,
+  }, {
+    statusMessage: `Home base set from lookup: ${entry.label}.`,
+  });
+  if (homeBaseLookupInput) homeBaseLookupInput.value = entry.display || entry.label;
+  refreshHomeBaseLookupOptions();
+};
+
+const applyManualHomeBase = () => {
+  const latitude = _asFiniteNumber(homeBaseLatInput ? homeBaseLatInput.value : "");
+  const longitude = _asFiniteNumber(homeBaseLonInput ? homeBaseLonInput.value : "");
+  if (latitude === null || longitude === null || latitude < -90 || latitude > 90 || longitude < -180 || longitude > 180) {
+    setHomeBaseStatus("Manual coordinates must be valid latitude and longitude values.", true);
+    return;
+  }
+  setHomeBaseState({
+    source: "manual",
+    label: `Custom coordinates ${_formatCoordinateSummary(latitude)}, ${_formatCoordinateSummary(longitude)}`,
+    latitude,
+    longitude,
+    query: `${latitude},${longitude}`,
+  }, {
+    statusMessage: "Home base set from manual coordinates.",
+  });
+  refreshHomeBaseLookupOptions();
+};
+
+const applyGeolocationHomeBase = () => {
+  if (!navigator.geolocation) {
+    setHomeBaseStatus("Browser geolocation is unavailable here. Use lookup or manual coordinates instead.", true);
+    return;
+  }
+  if (homeBaseGeolocateBtn) homeBaseGeolocateBtn.disabled = true;
+  setHomeBaseStatus("Resolving browser location...", false);
+  navigator.geolocation.getCurrentPosition(
+    (position) => {
+      if (homeBaseGeolocateBtn) homeBaseGeolocateBtn.disabled = false;
+      setHomeBaseState({
+        source: "geolocation",
+        label: "Current location",
+        latitude: position.coords.latitude,
+        longitude: position.coords.longitude,
+        query: "Current location",
+      }, {
+        statusMessage: "Home base set from browser geolocation.",
+      });
+      refreshHomeBaseLookupOptions();
+    },
+    (error) => {
+      if (homeBaseGeolocateBtn) homeBaseGeolocateBtn.disabled = false;
+      const message = error && error.message ? error.message : "Unable to read browser geolocation.";
+      setHomeBaseStatus(message, true);
+    },
+    {
+      enableHighAccuracy: true,
+      timeout: 10000,
+      maximumAge: 300000,
+    },
+  );
+};
+
+const clearHomeBaseState = () => {
+  setHomeBaseState(null, {
+    statusMessage: "Home base cleared.",
+  });
+  if (homeBaseLookupInput) homeBaseLookupInput.value = "";
+  if (homeBaseLatInput) homeBaseLatInput.value = "";
+  if (homeBaseLonInput) homeBaseLonInput.value = "";
+  refreshHomeBaseLookupOptions();
+};
+
+const initializeHomeBase = () => {
+  if (!homeBaseApi) {
+    setHomeBaseStatus("Home base tools unavailable on this page build.", true);
+    return;
+  }
+  const urlHomeBase = homeBaseApi.parseHomeBaseFromQuery(window.location.search);
+  if (urlHomeBase) {
+    appState.homeBase = homeBaseApi.persistHomeBase(urlHomeBase) || urlHomeBase;
+    syncHomeBaseControls();
+    notifyHomeBaseChanged();
+    setHomeBaseStatus(`Home base restored from shared URL: ${urlHomeBase.label}.`, false);
+    refreshHomeBaseLookupOptions();
+    return;
+  }
+  appState.homeBase = homeBaseApi.loadStoredHomeBase();
+  syncHomeBaseControls();
+  notifyHomeBaseChanged();
+  setHomeBaseStatus(
+    appState.homeBase
+      ? `Home base restored from ${_homeBaseSourceLabel(appState.homeBase.source)}.`
+      : "Set a home base from lookup, geolocation, or coordinates.",
+    false,
+  );
+  refreshHomeBaseLookupOptions();
 };
 
 const applyControlsFromQueryOrMeta = () => {
@@ -1738,7 +1949,51 @@ const applyFiltersImmediately = async () => {
   renderPage();
 };
 
+const bindHomeBaseControls = () => {
+  if (homeBaseLookupInput) {
+    homeBaseLookupInput.addEventListener("input", () => {
+      refreshHomeBaseLookupOptions();
+    });
+    homeBaseLookupInput.addEventListener("keydown", (event) => {
+      if (event.key === "Enter") {
+        event.preventDefault();
+        applyLookupHomeBase();
+      }
+    });
+  }
+  if (homeBaseLookupApply) {
+    homeBaseLookupApply.addEventListener("click", () => {
+      applyLookupHomeBase();
+    });
+  }
+  if (homeBaseManualApply) {
+    homeBaseManualApply.addEventListener("click", () => {
+      applyManualHomeBase();
+    });
+  }
+  [homeBaseLatInput, homeBaseLonInput].forEach((input) => {
+    if (!input) return;
+    input.addEventListener("keydown", (event) => {
+      if (event.key === "Enter") {
+        event.preventDefault();
+        applyManualHomeBase();
+      }
+    });
+  });
+  if (homeBaseGeolocateBtn) {
+    homeBaseGeolocateBtn.addEventListener("click", () => {
+      applyGeolocationHomeBase();
+    });
+  }
+  if (homeBaseClearBtn) {
+    homeBaseClearBtn.addEventListener("click", () => {
+      clearHomeBaseState();
+    });
+  }
+};
+
 const bindControls = () => {
+  bindHomeBaseControls();
   if (resortSearchInput) {
     resortSearchInput.addEventListener("input", () => {
       applyFiltersImmediately();
@@ -1847,6 +2102,7 @@ const initialize = async () => {
     appState.availableFilters = _availableFilters();
     updateFilterLabels();
     applyControlsFromQueryOrMeta();
+    initializeHomeBase();
     renderPage();
   } catch (error) {
     if (pageContentRoot) {

--- a/src/web/templates/weather_page.html
+++ b/src/web/templates/weather_page.html
@@ -24,6 +24,36 @@
       <div id="report-date" class="report-generated" data-generated-utc="{{generated_utc_iso}}">Generated At: loading...</div>
     </div>
     <div class="resort-controls">
+      <div class="home-base-controls">
+        <div class="home-base-head">
+          <div>
+            <div class="home-base-title">Home Base</div>
+            <div id="home-base-summary" class="home-base-summary">Not set</div>
+          </div>
+          <button id="home-base-geolocate-btn" type="button">Use My Location</button>
+        </div>
+        <div class="home-base-lookup-row">
+          <label for="home-base-lookup-input">City or ZIP</label>
+          <input
+            id="home-base-lookup-input"
+            type="search"
+            list="home-base-lookup-list"
+            placeholder="Salt Lake City, UT or 84101"
+            autocomplete="off"
+          />
+          <datalist id="home-base-lookup-list"></datalist>
+          <button id="home-base-lookup-apply" type="button">Use Lookup</button>
+          <button id="home-base-clear" type="button">Clear</button>
+        </div>
+        <div class="home-base-manual-row">
+          <label for="home-base-lat-input">Lat</label>
+          <input id="home-base-lat-input" type="number" step="any" placeholder="40.7608" inputmode="decimal" />
+          <label for="home-base-lon-input">Lon</label>
+          <input id="home-base-lon-input" type="number" step="any" placeholder="-111.8910" inputmode="decimal" />
+          <button id="home-base-manual-apply" type="button">Use Coordinates</button>
+        </div>
+        <p id="home-base-status" class="home-base-status">Set a home base from lookup, geolocation, or coordinates.</p>
+      </div>
       <div class="resort-search">
         <label for="resort-search-input">Search Resorts</label>
         <input id="resort-search-input" type="search" placeholder="Name, state, or pass type" autocomplete="off" />
@@ -107,6 +137,7 @@
     window.CLOSESNOW_PAGE_BOOTSTRAP = {{page_bootstrap_json}};
   </script>
   <script src="assets/js/compact_daily_summary.js"></script>
+  <script src="assets/js/home_base.js"></script>
   <script src="assets/js/weather_page.js"></script>
 </body>
 </html>

--- a/src/web/weather_html_renderer.py
+++ b/src/web/weather_html_renderer.py
@@ -17,6 +17,8 @@ _PAGE_SHELL_PLACEHOLDER = """
     <section><h2>Sunrise / Sunset</h2><p class="section-loading">Loading forecast...</p></section>
 """
 
+_HOME_BASE_CONTRACT_VERSION = 1
+
 
 def build_html(
     snowfall: List[Dict[str, str]],
@@ -36,7 +38,10 @@ def build_html(
         "applied_filters": applied_filters or {},
     }
     filter_meta_json = json.dumps(filter_meta, ensure_ascii=False)
-    page_bootstrap_json = json.dumps({"dataUrl": data_url}, ensure_ascii=False)
+    page_bootstrap_json = json.dumps(
+        {"dataUrl": data_url, "homeBaseContractVersion": _HOME_BASE_CONTRACT_VERSION},
+        ensure_ascii=False,
+    )
     return (
         _PAGE_TEMPLATE.replace("{{generated_utc_iso}}", generated_utc_iso)
         .replace("{{filter_meta_json}}", filter_meta_json)

--- a/src/web/weather_page_assets.py
+++ b/src/web/weather_page_assets.py
@@ -9,6 +9,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 ASSET_MIME_TYPES: Dict[str, str] = {
     "assets/css/weather_page.css": "text/css; charset=utf-8",
     "assets/js/compact_daily_summary.js": "application/javascript; charset=utf-8",
+    "assets/js/home_base.js": "application/javascript; charset=utf-8",
     "assets/js/weather_page.js": "application/javascript; charset=utf-8",
     "assets/css/resort_hourly.css": "text/css; charset=utf-8",
     "assets/js/resort_hourly.js": "application/javascript; charset=utf-8",

--- a/tests/frontend/test_assets.py
+++ b/tests/frontend/test_assets.py
@@ -8,11 +8,13 @@ from src.web.weather_page_assets import ASSET_MIME_TYPES, asset_path, read_asset
 def test_asset_path_points_to_repo_assets():
     css_path = asset_path("assets/css/weather_page.css")
     compact_js_path = asset_path("assets/js/compact_daily_summary.js")
+    home_base_js_path = asset_path("assets/js/home_base.js")
     js_path = asset_path("assets/js/weather_page.js")
     hourly_css_path = asset_path("assets/css/resort_hourly.css")
     hourly_js_path = asset_path("assets/js/resort_hourly.js")
     assert str(css_path).endswith("assets/css/weather_page.css")
     assert str(compact_js_path).endswith("assets/js/compact_daily_summary.js")
+    assert str(home_base_js_path).endswith("assets/js/home_base.js")
     assert str(js_path).endswith("assets/js/weather_page.js")
     assert str(hourly_css_path).endswith("assets/css/resort_hourly.css")
     assert str(hourly_js_path).endswith("assets/js/resort_hourly.js")
@@ -21,21 +23,25 @@ def test_asset_path_points_to_repo_assets():
 def test_read_asset_bytes_reads_known_assets():
     css = read_asset_bytes("assets/css/weather_page.css")
     compact_js = read_asset_bytes("assets/js/compact_daily_summary.js")
+    home_base_js = read_asset_bytes("assets/js/home_base.js")
     js = read_asset_bytes("assets/js/weather_page.js")
     hourly_css = read_asset_bytes("assets/css/resort_hourly.css")
     hourly_js = read_asset_bytes("assets/js/resort_hourly.js")
     assert len(css) > 100
     assert len(compact_js) > 100
+    assert len(home_base_js) > 100
     assert len(js) > 100
     assert len(hourly_css) > 100
     assert len(hourly_js) > 100
     assert ASSET_MIME_TYPES["assets/css/weather_page.css"].startswith("text/css")
     assert ASSET_MIME_TYPES["assets/js/compact_daily_summary.js"].startswith("application/javascript")
+    assert ASSET_MIME_TYPES["assets/js/home_base.js"].startswith("application/javascript")
     assert ASSET_MIME_TYPES["assets/js/weather_page.js"].startswith("application/javascript")
     assert ASSET_MIME_TYPES["assets/css/resort_hourly.css"].startswith("text/css")
     assert ASSET_MIME_TYPES["assets/js/resort_hourly.js"].startswith("application/javascript")
     css_text = css.decode("utf-8", errors="ignore")
     compact_js_text = compact_js.decode("utf-8", errors="ignore")
+    home_base_js_text = home_base_js.decode("utf-8", errors="ignore")
     hourly_css_text = hourly_css.decode("utf-8", errors="ignore")
     hourly_js_text = hourly_js.decode("utf-8", errors="ignore")
     js_text = js.decode("utf-8", errors="ignore")
@@ -65,6 +71,14 @@ def test_read_asset_bytes_reads_known_assets():
     assert "data-compact-today-anchor" in compact_js_text
     assert "compact-day-head-phase-start" not in compact_js_text
     assert "compact-day-cell-phase-start" not in compact_js_text
+    assert "window.CloseSnowHomeBase" in home_base_js_text
+    assert 'const STORAGE_KEY = "closesnow_home_base_v1";' in home_base_js_text
+    assert 'source: "home_base_source"' in home_base_js_text
+    assert 'label: "home_base_label"' in home_base_js_text
+    assert "writeHomeBaseToSearchParams" in home_base_js_text
+    assert "findLookupMatches" in home_base_js_text
+    assert "resolveLookupEntry" in home_base_js_text
+    assert "Salt Lake City, UT" in home_base_js_text
     assert "window.CLOSESNOW_PAGE_BOOTSTRAP" in js_text
     assert "No resorts match the current filters." in js_text
     assert 'return "Today";' in js_text

--- a/tests/frontend/test_renderers.py
+++ b/tests/frontend/test_renderers.py
@@ -250,6 +250,11 @@ def test_build_html_contains_meta_sections():
     assert "<h2>Sunrise / Sunset</h2>" in html
     assert html.index("<h2>Temperature</h2>") < html.index("<h2>Weather</h2>")
     assert 'id="resort-search-input"' in html
+    assert 'id="home-base-summary"' in html
+    assert 'id="home-base-lookup-input"' in html
+    assert 'id="home-base-geolocate-btn"' in html
+    assert 'id="home-base-manual-apply"' in html
+    assert 'id="home-base-status"' in html
     assert 'id="filter-open-btn"' in html
     assert 'id="filter-modal"' in html
     assert 'id="filter-sort-select"' in html
@@ -271,6 +276,8 @@ def test_build_html_contains_meta_sections():
     assert "window.CLOSESNOW_FILTER_META" in html
     assert "window.CLOSESNOW_PAGE_BOOTSTRAP" in html
     assert '"dataUrl": "./data.json"' in html
+    assert '"homeBaseContractVersion": 1' in html
+    assert 'assets/js/home_base.js' in html
     assert 'id="page-content-root"' in html
     assert "include_all" in html
     assert 'data-generated-utc="' in html

--- a/tests/integration/test_web_server.py
+++ b/tests/integration/test_web_server.py
@@ -55,6 +55,8 @@ def test_server_api_root_and_asset(monkeypatch):
 
         asset = urllib.request.urlopen(f"{base}/assets/css/weather_page.css", timeout=3).read()
         assert asset == b"body{}"
+        home_base_asset = urllib.request.urlopen(f"{base}/assets/js/home_base.js", timeout=3).read()
+        assert home_base_asset == b"body{}"
         asset_with_prefix = urllib.request.urlopen(f"{base}/CloseSnow/assets/css/weather_page.css", timeout=3).read()
         assert asset_with_prefix == b"body{}"
     finally:


### PR DESCRIPTION
## Summary
- add a reusable client-side home base contract with URL and localStorage persistence
- ship a bundled US city/ZIP lookup plus geolocation and manual coordinate entry controls
- expose the contract in the homepage template and cover it with frontend/integration tests

## Validation
- python3 -m pytest -q tests/frontend/test_assets.py tests/frontend/test_renderers.py tests/integration/test_web_server.py
- python3 -m src.cli static --output-dir /tmp/closesnow-home-base-model --max-workers 8