### PR TITLE
Add favorites alert inbox controls

### DIFF
--- a/assets/css/weather_page.css
+++ b/assets/css/weather_page.css
@@ -205,6 +205,263 @@
       font-weight: 600;
       cursor: pointer;
     }
+    .favorite-alerts-root {
+      margin: 0 0 18px;
+    }
+    .favorite-alerts-panel {
+      display: grid;
+      gap: 14px;
+      padding: 16px;
+      border: 1px solid #cbd5e1;
+      border-radius: 18px;
+      background: linear-gradient(180deg, rgba(255,255,255,0.96) 0%, rgba(241,245,249,0.98) 100%);
+      box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+    }
+    .favorite-alerts-panel-empty {
+      gap: 10px;
+    }
+    .favorite-alerts-head {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+    .favorite-alerts-eyebrow {
+      margin: 0 0 5px;
+      font-size: 11px;
+      font-weight: 800;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: #0f766e;
+    }
+    .favorite-alerts-head h2 {
+      margin: 0;
+      font-size: 22px;
+      color: #0f172a;
+    }
+    .favorite-alerts-description,
+    .favorite-alerts-empty-copy {
+      margin: 0;
+      font-size: 13px;
+      line-height: 1.5;
+      color: #475569;
+    }
+    .favorite-alert-chip-row {
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+      align-items: center;
+    }
+    .favorite-alert-chip {
+      display: inline-flex;
+      align-items: center;
+      border-radius: 999px;
+      padding: 6px 10px;
+      background: #e2e8f0;
+      color: #334155;
+      font-size: 12px;
+      font-weight: 700;
+    }
+    .favorite-alert-chip-strong {
+      background: #0f766e;
+      color: #fff;
+    }
+    .favorite-alerts-grid {
+      display: grid;
+      gap: 14px;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+    .favorite-alert-section {
+      display: grid;
+      gap: 12px;
+      padding: 14px;
+      border-radius: 14px;
+      border: 1px solid #dbe4ee;
+      background: rgba(255,255,255,0.9);
+    }
+    .favorite-alert-section-head {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 10px;
+    }
+    .favorite-alert-section-head h3 {
+      margin: 0 0 4px;
+      font-size: 17px;
+      color: #0f172a;
+    }
+    .favorite-alert-section-head p,
+    .favorite-alert-section-empty,
+    .favorite-alert-section-footnote,
+    .favorite-alert-controls-copy,
+    .favorite-alert-controls-empty {
+      margin: 0;
+      font-size: 12px;
+      line-height: 1.5;
+      color: #64748b;
+    }
+    .favorite-alert-section-count {
+      min-width: 30px;
+      text-align: center;
+      padding: 6px 8px;
+      border-radius: 999px;
+      background: #dbeafe;
+      color: #1d4ed8;
+      font-size: 12px;
+      font-weight: 800;
+    }
+    .favorite-alert-card-list {
+      display: grid;
+      gap: 10px;
+    }
+    .favorite-alert-card {
+      display: grid;
+      gap: 10px;
+      padding: 12px;
+      border-radius: 12px;
+      border: 1px solid #dbe4ee;
+      background: #fff;
+      box-shadow: inset 0 1px 0 rgba(255,255,255,0.9);
+    }
+    .favorite-alert-card[data-alert-read="0"] {
+      border-color: #99f6e4;
+      background: linear-gradient(180deg, #f0fdfa 0%, #ffffff 100%);
+    }
+    .favorite-alert-card-head,
+    .favorite-alert-card-meta-row,
+    .favorite-alert-card-actions {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+    .favorite-alert-card-title-wrap {
+      min-width: 0;
+      flex: 1;
+    }
+    .favorite-alert-card-resort,
+    .favorite-alert-card-link {
+      color: #0f766e;
+      text-decoration: none;
+      font-size: 13px;
+      font-weight: 700;
+    }
+    .favorite-alert-card-resort:hover,
+    .favorite-alert-card-link:hover {
+      text-decoration: underline;
+    }
+    .favorite-alert-card h3 {
+      margin: 0;
+      font-size: 15px;
+      line-height: 1.35;
+      color: #0f172a;
+    }
+    .favorite-alert-card-time,
+    .favorite-alert-card-summary {
+      font-size: 12px;
+      color: #64748b;
+    }
+    .favorite-alert-card-message {
+      margin: 0;
+      font-size: 13px;
+      line-height: 1.5;
+      color: #334155;
+    }
+    .favorite-alert-severity-badge {
+      display: inline-flex;
+      align-items: center;
+      padding: 4px 8px;
+      border-radius: 999px;
+      font-size: 11px;
+      font-weight: 800;
+      letter-spacing: 0.02em;
+      text-transform: uppercase;
+    }
+    .favorite-alert-severity-badge[data-alert-severity="high"] {
+      background: #fee2e2;
+      color: #b91c1c;
+    }
+    .favorite-alert-severity-badge[data-alert-severity="medium"] {
+      background: #fef3c7;
+      color: #b45309;
+    }
+    .favorite-alert-action-btn {
+      border: 1px solid #0f766e;
+      background: #0f766e;
+      color: #fff;
+      border-radius: 8px;
+      padding: 7px 10px;
+      font-size: 12px;
+      font-weight: 700;
+      cursor: pointer;
+    }
+    .favorite-alert-action-btn-secondary {
+      border-color: #cbd5e1;
+      background: #fff;
+      color: #334155;
+    }
+    .favorite-alert-controls {
+      display: grid;
+      gap: 12px;
+      padding-top: 2px;
+    }
+    .favorite-alert-controls summary {
+      cursor: pointer;
+      font-size: 13px;
+      font-weight: 800;
+      color: #0f172a;
+    }
+    .favorite-alert-rule-list {
+      display: grid;
+      gap: 10px;
+      margin-top: 12px;
+    }
+    .favorite-alert-rule-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
+      padding: 10px 12px;
+      border-radius: 12px;
+      background: #f8fafc;
+      border: 1px solid #e2e8f0;
+    }
+    .favorite-alert-rule-name {
+      font-size: 13px;
+      font-weight: 700;
+      color: #0f172a;
+    }
+    .favorite-alert-rule-select {
+      min-width: 145px;
+      border: 1px solid #cbd5e1;
+      border-radius: 8px;
+      background: #fff;
+      color: #1f2937;
+      padding: 7px 9px;
+      font-size: 12px;
+      font-weight: 600;
+    }
+    @media (max-width: 980px) {
+      .favorite-alerts-grid {
+        grid-template-columns: 1fr;
+      }
+    }
+    @media (max-width: 640px) {
+      .favorite-alerts-panel {
+        padding: 14px;
+      }
+      .favorite-alert-rule-row,
+      .favorite-alert-card-actions {
+        align-items: stretch;
+      }
+      .favorite-alert-rule-select,
+      .favorite-alert-action-btn {
+        width: 100%;
+      }
+    }
     .report-powered a {
       color: #0f766e;
       text-decoration: none;

--- a/assets/js/favorites_alerts.js
+++ b/assets/js/favorites_alerts.js
@@ -2,6 +2,7 @@
   const STORAGE_KEY = "closesnow_favorite_alert_state_v1";
   const RULE_VERSION = "favorites_alert_rules_v1";
   const MAX_ALERT_ITEMS = 200;
+  const ALERT_RULE_MODES = new Set(["all", "high_only", "mute"]);
 
   const normalizeText = (value) => String(value || "").trim();
 
@@ -65,12 +66,46 @@
     return Number.isInteger(num) ? String(num) : num.toFixed(1);
   };
 
+  const normalizeRuleMode = (value) => {
+    const text = normalizeText(value).toLowerCase();
+    return ALERT_RULE_MODES.has(text) ? text : "all";
+  };
+
+  const normalizeIdList = (raw, validIds = null) => {
+    if (!Array.isArray(raw)) return [];
+    const out = [];
+    const seen = new Set();
+    raw.forEach((value) => {
+      const id = normalizeText(value);
+      if (!id || seen.has(id)) return;
+      if (validIds && !validIds.has(id)) return;
+      seen.add(id);
+      out.push(id);
+    });
+    return out;
+  };
+
+  const normalizeRuleMap = (raw) => {
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
+    const out = {};
+    Object.entries(raw).forEach(([resortId, rule]) => {
+      const normalizedResortId = normalizeText(resortId);
+      if (!normalizedResortId) return;
+      const mode = normalizeRuleMode(rule && typeof rule === "object" && !Array.isArray(rule) ? rule.mode : rule);
+      if (mode !== "all") out[normalizedResortId] = { mode };
+    });
+    return out;
+  };
+
   const defaultState = () => ({
     schema_version: STORAGE_KEY,
     rule_version: RULE_VERSION,
     updated_at: "",
     snapshots_by_resort_id: {},
     alerts: [],
+    read_alert_ids: [],
+    dismissed_alert_ids: [],
+    rules_by_resort_id: {},
   });
 
   const normalizeSnapshot = (raw) => {
@@ -138,6 +173,10 @@
     });
     const alerts = Array.isArray(raw.alerts) ? raw.alerts : [];
     state.alerts = alerts.map(normalizeAlertItem).filter(Boolean).slice(0, MAX_ALERT_ITEMS);
+    const validAlertIds = new Set(state.alerts.map((alert) => alert.id));
+    state.read_alert_ids = normalizeIdList(raw.read_alert_ids, validAlertIds);
+    state.dismissed_alert_ids = normalizeIdList(raw.dismissed_alert_ids, validAlertIds);
+    state.rules_by_resort_id = normalizeRuleMap(raw.rules_by_resort_id);
     return state;
   };
 
@@ -162,6 +201,55 @@
     }
     return normalized;
   };
+
+  const updateState = (updater, storage = root.localStorage) => {
+    const current = loadState(storage);
+    const next = updater(normalizeState(current));
+    return persistState(next || current, storage);
+  };
+
+  const updateAlertIdList = (items, alertId, active) => {
+    const id = normalizeText(alertId);
+    if (!id) return normalizeIdList(items);
+    const next = normalizeIdList(items);
+    if (active) {
+      if (next.includes(id)) return next;
+      return next.concat(id);
+    }
+    return next.filter((value) => value !== id);
+  };
+
+  const markAlertRead = (alertId, storage = root.localStorage) => updateState((state) => ({
+    ...state,
+    read_alert_ids: updateAlertIdList(state.read_alert_ids, alertId, true),
+  }), storage);
+
+  const markAlertUnread = (alertId, storage = root.localStorage) => updateState((state) => ({
+    ...state,
+    read_alert_ids: updateAlertIdList(state.read_alert_ids, alertId, false),
+  }), storage);
+
+  const dismissAlert = (alertId, storage = root.localStorage) => updateState((state) => ({
+    ...state,
+    read_alert_ids: updateAlertIdList(state.read_alert_ids, alertId, true),
+    dismissed_alert_ids: updateAlertIdList(state.dismissed_alert_ids, alertId, true),
+  }), storage);
+
+  const setResortRule = (resortId, mode, storage = root.localStorage) => updateState((state) => {
+    const id = normalizeText(resortId);
+    if (!id) return state;
+    const nextRules = { ...normalizeRuleMap(state.rules_by_resort_id) };
+    const nextMode = normalizeRuleMode(mode);
+    if (nextMode === "all") {
+      delete nextRules[id];
+    } else {
+      nextRules[id] = { mode: nextMode };
+    }
+    return {
+      ...state,
+      rules_by_resort_id: nextRules,
+    };
+  }, storage);
 
   const buildSnapshot = (report, payloadGeneratedAt = "") => {
     if (!report || typeof report !== "object") return null;
@@ -384,12 +472,18 @@
       nextSnapshots[resortId] = current;
     });
 
+    const trimmedAlerts = nextAlerts.slice(0, MAX_ALERT_ITEMS);
+    const nextAlertIds = new Set(trimmedAlerts.map((alert) => alert.id));
+
     const nextState = {
       schema_version: STORAGE_KEY,
       rule_version: RULE_VERSION,
       updated_at: payloadGeneratedAt,
       snapshots_by_resort_id: nextSnapshots,
-      alerts: nextAlerts.slice(0, MAX_ALERT_ITEMS),
+      alerts: trimmedAlerts,
+      read_alert_ids: normalizeIdList(state.read_alert_ids, nextAlertIds),
+      dismissed_alert_ids: normalizeIdList(state.dismissed_alert_ids, nextAlertIds),
+      rules_by_resort_id: normalizeRuleMap(state.rules_by_resort_id),
     };
 
     return {
@@ -405,6 +499,10 @@
     compareSnapshots,
     loadState,
     persistState,
+    markAlertRead,
+    markAlertUnread,
+    dismissAlert,
+    setResortRule,
     syncPayload,
   };
 })(typeof window !== "undefined" ? window : globalThis);

--- a/assets/js/weather_page.js
+++ b/assets/js/weather_page.js
@@ -13,6 +13,7 @@ const filterMetaApplied =
     ? filterMeta.applied_filters
     : {};
 
+const favoriteAlertsRoot = document.getElementById("favorite-alerts-root");
 const pageContentRoot = document.getElementById("page-content-root");
 const reportDateEl = document.getElementById("report-date");
 const resortSearchInput = document.getElementById("resort-search-input");
@@ -37,6 +38,8 @@ const FAVORITES_STORAGE_KEY = "closesnow_favorite_resorts_v1";
 const VALID_UNIT_KINDS = new Set(["snow", "rain", "temp"]);
 const DEFAULT_AVAILABLE_FILTERS = { pass_type: {}, region: {}, country: {} };
 const MAX_DISPLAY_DAYS = 14;
+const MAX_UNREAD_ALERTS = 8;
+const MAX_READ_ALERTS = 6;
 const MIN_DESKTOP_SNOW_3DAY_PX = 554;
 const compactDailySummary = window.CloseSnowCompactDailySummary || {};
 const favoriteAlertsApi = window.CloseSnowFavoritesAlerts || null;
@@ -628,6 +631,267 @@ const publishFavoriteAlertState = (state, newAlerts) => {
   window.CLOSESNOW_FAVORITE_ALERT_STATE = state;
   window.CLOSESNOW_FAVORITE_ALERTS = state && Array.isArray(state.alerts) ? state.alerts : [];
   window.CLOSESNOW_NEW_FAVORITE_ALERTS = appState.newFavoriteAlerts;
+};
+
+const _defaultFavoriteAlertState = () => ({
+  alerts: [],
+  read_alert_ids: [],
+  dismissed_alert_ids: [],
+  rules_by_resort_id: {},
+});
+
+const _favoriteAlertState = () => {
+  const raw = appState.favoriteAlertState;
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return _defaultFavoriteAlertState();
+  return {
+    alerts: Array.isArray(raw.alerts) ? raw.alerts.filter((alert) => alert && typeof alert === "object") : [],
+    read_alert_ids: Array.isArray(raw.read_alert_ids)
+      ? raw.read_alert_ids.map((value) => String(value || "").trim()).filter(Boolean)
+      : [],
+    dismissed_alert_ids: Array.isArray(raw.dismissed_alert_ids)
+      ? raw.dismissed_alert_ids.map((value) => String(value || "").trim()).filter(Boolean)
+      : [],
+    rules_by_resort_id: raw.rules_by_resort_id && typeof raw.rules_by_resort_id === "object" && !Array.isArray(raw.rules_by_resort_id)
+      ? raw.rules_by_resort_id
+      : {},
+  };
+};
+
+const refreshFavoriteAlertStateFromStorage = () => {
+  if (!favoriteAlertsApi || typeof favoriteAlertsApi.loadState !== "function") return null;
+  const state = favoriteAlertsApi.loadState();
+  publishFavoriteAlertState(state, []);
+  return state;
+};
+
+const _favoriteAlertRuleMode = (state, resortId) => {
+  const id = String(resortId || "").trim();
+  if (!id) return "all";
+  const rawRule = state.rules_by_resort_id[id];
+  const rawMode = rawRule && typeof rawRule === "object" && !Array.isArray(rawRule) ? rawRule.mode : rawRule;
+  const mode = _normalizeSearch(rawMode);
+  if (mode === "high_only" || mode === "mute") return mode;
+  return "all";
+};
+
+const _favoriteAlertWindowLabel = (value) => {
+  const text = _normalizeSearch(value);
+  if (text === "next_3_days") return "Next 3 days";
+  if (text === "week_1") return "Week 1";
+  if (!text) return "";
+  return text.split("_").map((part) => part.charAt(0).toUpperCase() + part.slice(1)).join(" ");
+};
+
+const _favoriteAlertTimeLabel = (value) => {
+  const dt = new Date(value || "");
+  if (Number.isNaN(dt.getTime())) return "Update time unavailable";
+  return dt.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+};
+
+const _favoriteAlertMetricSummary = (metrics) => {
+  if (!metrics || typeof metrics !== "object" || Array.isArray(metrics)) return "";
+  const parts = [];
+  const windowLabel = _favoriteAlertWindowLabel(metrics.window);
+  const unit = String(metrics.unit || "").trim().toUpperCase();
+  const delta = _asFiniteNumber(metrics.delta);
+  const current = _asFiniteNumber(metrics.current);
+  if (windowLabel) parts.push(`Window: ${windowLabel}`);
+  if (delta !== null) parts.push(`Change: ${delta > 0 ? "+" : ""}${_formatMetric(delta)} ${unit}`.trim());
+  if (current !== null) parts.push(`Now: ${_formatMetric(current)} ${unit}`.trim());
+  return parts.join(" | ");
+};
+
+const _favoriteResortSummaries = () => {
+  const reportsByResortId = {};
+  _payloadReports().forEach((report) => {
+    const resortId = String(report?.resort_id || "").trim();
+    if (resortId && !reportsByResortId[resortId]) reportsByResortId[resortId] = report;
+  });
+  return Array.from(appState.favoriteResortIds)
+    .map((resortId) => {
+      const report = reportsByResortId[resortId] || {};
+      return {
+        resortId,
+        name: _displayName(report) || resortId,
+      };
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+};
+
+const _favoriteAlertCollections = () => {
+  const state = _favoriteAlertState();
+  const dismissedIds = new Set(state.dismissed_alert_ids);
+  const readIds = new Set(state.read_alert_ids);
+  const visibleAlerts = [];
+  let hiddenByRuleCount = 0;
+
+  state.alerts.forEach((alert) => {
+    const id = String(alert?.id || "").trim();
+    if (!id || dismissedIds.has(id)) return;
+    const mode = _favoriteAlertRuleMode(state, alert.resort_id);
+    const severity = _normalizeSearch(alert.severity);
+    if (mode === "mute" || (mode === "high_only" && severity !== "high")) {
+      hiddenByRuleCount += 1;
+      return;
+    }
+    visibleAlerts.push(alert);
+  });
+
+  const unreadAlerts = [];
+  const readAlerts = [];
+  visibleAlerts.forEach((alert) => {
+    const id = String(alert?.id || "").trim();
+    if (readIds.has(id)) {
+      readAlerts.push(alert);
+    } else {
+      unreadAlerts.push(alert);
+    }
+  });
+
+  return {
+    state,
+    visibleAlerts,
+    unreadAlerts,
+    readAlerts,
+    hiddenByRuleCount,
+  };
+};
+
+const _favoriteAlertCardHtml = (alert, read) => {
+  const alertId = String(alert?.id || "").trim();
+  const resortId = String(alert?.resort_id || "").trim();
+  const resortName = String(alert?.resort_name || "Favorite resort").trim() || "Favorite resort";
+  const severity = _normalizeSearch(alert?.severity) === "high" ? "high" : "medium";
+  const metricSummary = _favoriteAlertMetricSummary(alert?.metrics);
+  const resortHref = resortId ? `resort/${encodeURIComponent(resortId)}` : "";
+
+  return `<article class='favorite-alert-card' data-alert-read='${read ? "1" : "0"}' data-alert-severity='${severity}'>
+    <div class='favorite-alert-card-head'>
+      <div class='favorite-alert-card-title-wrap'>
+        <div class='favorite-alert-card-meta-row'>
+          ${resortHref ? `<a class='favorite-alert-card-resort' href='${resortHref}'>${_escapeHtml(resortName)}</a>` : `<span class='favorite-alert-card-resort'>${_escapeHtml(resortName)}</span>`}
+          <span class='favorite-alert-severity-badge' data-alert-severity='${severity}'>${severity === "high" ? "High priority" : "Medium priority"}</span>
+        </div>
+        <h3>${_escapeHtml(String(alert?.title || "Favorite alert"))}</h3>
+      </div>
+      <time class='favorite-alert-card-time'>${_escapeHtml(_favoriteAlertTimeLabel(alert?.created_at || alert?.payload_generated_at))}</time>
+    </div>
+    <p class='favorite-alert-card-message'>${_escapeHtml(String(alert?.message || ""))}</p>
+    ${metricSummary ? `<p class='favorite-alert-card-summary'>${_escapeHtml(metricSummary)}</p>` : ""}
+    <div class='favorite-alert-card-actions'>
+      <button type='button' class='favorite-alert-action-btn' data-alert-action='${read ? "unread" : "read"}' data-alert-id='${_escapeHtml(alertId)}'>${read ? "Mark unread" : "Mark read"}</button>
+      <button type='button' class='favorite-alert-action-btn favorite-alert-action-btn-secondary' data-alert-action='dismiss' data-alert-id='${_escapeHtml(alertId)}'>Dismiss</button>
+      ${resortHref ? `<a class='favorite-alert-card-link' href='${resortHref}'>Open resort</a>` : ""}
+    </div>
+  </article>`;
+};
+
+const _favoriteAlertSectionHtml = ({ title, subtitle, alerts, emptyMessage, read, limit }) => {
+  const shownAlerts = alerts.slice(0, limit);
+  const overflow = alerts.length - shownAlerts.length;
+  return `<section class='favorite-alert-section'>
+    <div class='favorite-alert-section-head'>
+      <div>
+        <h3>${_escapeHtml(title)}</h3>
+        <p>${_escapeHtml(subtitle)}</p>
+      </div>
+      <span class='favorite-alert-section-count'>${alerts.length}</span>
+    </div>
+    ${shownAlerts.length
+      ? `<div class='favorite-alert-card-list'>${shownAlerts.map((alert) => _favoriteAlertCardHtml(alert, read)).join("")}</div>`
+      : `<p class='favorite-alert-section-empty'>${_escapeHtml(emptyMessage)}</p>`}
+    ${overflow > 0 ? `<p class='favorite-alert-section-footnote'>Showing the latest ${shownAlerts.length} of ${alerts.length} alerts.</p>` : ""}
+  </section>`;
+};
+
+const _favoriteAlertControlsHtml = (state, favorites) => {
+  if (!favorites.length) {
+    return `<div class='favorite-alert-controls-empty'>Favorite a resort with the heart icon to set per-resort alert visibility.</div>`;
+  }
+  const rows = favorites.map(({ resortId, name }) => {
+    const mode = _favoriteAlertRuleMode(state, resortId);
+    return `<label class='favorite-alert-rule-row'>
+      <span class='favorite-alert-rule-name'>${_escapeHtml(name)}</span>
+      <select class='favorite-alert-rule-select' data-alert-rule-resort-id='${_escapeHtml(resortId)}'>
+        <option value='all'${mode === "all" ? " selected" : ""}>All alerts</option>
+        <option value='high_only'${mode === "high_only" ? " selected" : ""}>Major only</option>
+        <option value='mute'${mode === "mute" ? " selected" : ""}>Mute</option>
+      </select>
+    </label>`;
+  }).join("");
+
+  return `<details class='favorite-alert-controls'>
+    <summary>Alert controls</summary>
+    <div class='favorite-alert-rule-list'>${rows}</div>
+    <p class='favorite-alert-controls-copy'>Use “Major only” to hide medium-severity forecast churn, or mute a resort entirely without removing it from favorites.</p>
+  </details>`;
+};
+
+const renderFavoriteAlertsPanel = () => {
+  if (!favoriteAlertsRoot) return;
+  const favorites = _favoriteResortSummaries();
+  const {
+    state,
+    visibleAlerts,
+    unreadAlerts,
+    readAlerts,
+    hiddenByRuleCount,
+  } = _favoriteAlertCollections();
+
+  if (!favorites.length && visibleAlerts.length === 0) {
+    favoriteAlertsRoot.innerHTML = `<section class='favorite-alerts-panel favorite-alerts-panel-empty'>
+      <div class='favorite-alerts-head'>
+        <div>
+          <p class='favorite-alerts-eyebrow'>Favorite alerts</p>
+          <h2>No alerts yet</h2>
+        </div>
+      </div>
+      <p class='favorite-alerts-empty-copy'>Save a resort with the heart icon and CloseSnow will surface unread forecast changes here on the homepage.</p>
+    </section>`;
+    return;
+  }
+
+  const chips = [
+    `<span class='favorite-alert-chip favorite-alert-chip-strong'>Unread ${unreadAlerts.length}</span>`,
+    `<span class='favorite-alert-chip'>Visible ${visibleAlerts.length}</span>`,
+    `<span class='favorite-alert-chip'>Favorites ${favorites.length}</span>`,
+  ];
+  if (hiddenByRuleCount > 0) chips.push(`<span class='favorite-alert-chip'>Hidden by controls ${hiddenByRuleCount}</span>`);
+
+  favoriteAlertsRoot.innerHTML = `<section class='favorite-alerts-panel'>
+    <div class='favorite-alerts-head'>
+      <div>
+        <p class='favorite-alerts-eyebrow'>Favorite alerts</p>
+        <h2>Unread changes and alert controls</h2>
+      </div>
+      <div class='favorite-alert-chip-row'>${chips.join("")}</div>
+    </div>
+    <p class='favorite-alerts-description'>Review forecast swings without leaving the homepage. Alerts stay local to this browser and never auto-mark themselves as read.</p>
+    <div class='favorite-alerts-grid'>
+      ${_favoriteAlertSectionHtml({
+        title: "Unread alerts",
+        subtitle: "Fresh changes that still need review.",
+        alerts: unreadAlerts,
+        emptyMessage: favorites.length ? "No unread alerts right now. New forecast changes will show up here." : "Add a favorite resort to start tracking unread alerts.",
+        read: false,
+        limit: MAX_UNREAD_ALERTS,
+      })}
+      ${_favoriteAlertSectionHtml({
+        title: "Reviewed alerts",
+        subtitle: "Recent items you already checked.",
+        alerts: readAlerts,
+        emptyMessage: "Nothing marked as read yet.",
+        read: true,
+        limit: MAX_READ_ALERTS,
+      })}
+    </div>
+    ${_favoriteAlertControlsHtml(state, favorites)}
+  </section>`;
 };
 
 const syncFavoriteAlertState = () => {
@@ -1602,6 +1866,7 @@ const renderPage = () => {
     : (appState.filterState.favoritesOnly
       ? "No favorite resorts match the current filters."
       : "No resorts match the current filters.");
+  renderFavoriteAlertsPanel();
   pageContentRoot.innerHTML = _renderSections(visibleReports, emptyMessage);
   applyLayout();
   observeLayoutContainers();
@@ -1794,6 +2059,16 @@ const bindControls = () => {
   if (filterSortSelect) filterSortSelect.addEventListener("change", applyFiltersImmediately);
   if (filterIncludeAllInput) filterIncludeAllInput.addEventListener("change", applyFiltersImmediately);
   if (filterSearchAllInput) filterSearchAllInput.addEventListener("change", applyFiltersImmediately);
+  document.addEventListener("change", (event) => {
+    const ruleSelect = event.target.closest(".favorite-alert-rule-select[data-alert-rule-resort-id]");
+    if (!ruleSelect || !favoriteAlertsApi || typeof favoriteAlertsApi.setResortRule !== "function") return;
+    favoriteAlertsApi.setResortRule(
+      ruleSelect.getAttribute("data-alert-rule-resort-id"),
+      ruleSelect.value,
+    );
+    refreshFavoriteAlertStateFromStorage();
+    renderFavoriteAlertsPanel();
+  });
   if (favoritesOnlyToggle) {
     favoritesOnlyToggle.addEventListener("change", () => {
       setFavoritesOnlyControls(favoritesOnlyToggle.checked);
@@ -1815,6 +2090,23 @@ const bindControls = () => {
     if (event.key === "Escape" && filterModal && !filterModal.hidden) closeFilterModal();
   });
   document.addEventListener("click", (event) => {
+    const alertActionButton = event.target.closest("[data-alert-action][data-alert-id]");
+    if (alertActionButton && favoriteAlertsApi) {
+      const action = alertActionButton.getAttribute("data-alert-action");
+      const alertId = alertActionButton.getAttribute("data-alert-id");
+      if (action === "read" && typeof favoriteAlertsApi.markAlertRead === "function") {
+        favoriteAlertsApi.markAlertRead(alertId);
+      } else if (action === "unread" && typeof favoriteAlertsApi.markAlertUnread === "function") {
+        favoriteAlertsApi.markAlertUnread(alertId);
+      } else if (action === "dismiss" && typeof favoriteAlertsApi.dismissAlert === "function") {
+        favoriteAlertsApi.dismissAlert(alertId);
+      } else {
+        return;
+      }
+      refreshFavoriteAlertStateFromStorage();
+      renderFavoriteAlertsPanel();
+      return;
+    }
     const favoriteAllButton = event.target.closest(".favorite-all-btn[data-favorite-all='1']");
     if (favoriteAllButton) {
       event.preventDefault();
@@ -1826,6 +2118,7 @@ const bindControls = () => {
       } else {
         syncFavoriteUiInPlace(visibleReports);
       }
+      renderFavoriteAlertsPanel();
       return;
     }
     const favoriteButton = event.target.closest(".favorite-btn[data-resort-id]");
@@ -1839,6 +2132,7 @@ const bindControls = () => {
       } else {
         syncFavoriteUiInPlace(visibleReports);
       }
+      renderFavoriteAlertsPanel();
       return;
     }
     const button = event.target.closest(".unit-btn[data-unit-mode]");

--- a/src/web/templates/weather_page.html
+++ b/src/web/templates/weather_page.html
@@ -95,6 +95,7 @@
         </div>
       </div>
     </div>
+    <section id="favorite-alerts-root" class="favorite-alerts-root" aria-live="polite"></section>
     <div id="page-content-root" data-loading="1">
       {{page_shell_placeholder}}
     </div>

--- a/tests/frontend/test_assets.py
+++ b/tests/frontend/test_assets.py
@@ -46,6 +46,9 @@ def test_read_asset_bytes_reads_known_assets():
     hourly_js_text = hourly_js.decode("utf-8", errors="ignore")
     js_text = js.decode("utf-8", errors="ignore")
     assert ".compact-grid-wrap" in css_text
+    assert ".favorite-alerts-panel" in css_text
+    assert ".favorite-alert-card" in css_text
+    assert ".favorite-alert-rule-select" in css_text
     assert ".hourly-charts" in hourly_css_text
     assert ".resort-local-time" in hourly_css_text
     assert ".resort-timeline-section" in hourly_css_text
@@ -78,9 +81,18 @@ def test_read_asset_bytes_reads_known_assets():
     assert "rain_crossover" in favorites_js_text
     assert "warming_shift" in favorites_js_text
     assert "syncPayload" in favorites_js_text
+    assert "markAlertRead" in favorites_js_text
+    assert "markAlertUnread" in favorites_js_text
+    assert "dismissAlert" in favorites_js_text
+    assert "setResortRule" in favorites_js_text
+    assert "read_alert_ids" in favorites_js_text
+    assert "dismissed_alert_ids" in favorites_js_text
     assert "window.CLOSESNOW_PAGE_BOOTSTRAP" in js_text
     assert "window.CLOSESNOW_FAVORITE_ALERT_STATE" in js_text
     assert "syncFavoriteAlertState();" in js_text
+    assert "renderFavoriteAlertsPanel" in js_text
+    assert "favorite-alerts-root" in js_text
+    assert "favorite-alert-rule-select" in js_text
     assert "No resorts match the current filters." in js_text
     assert 'return "Today";' in js_text
     assert "renderHourlyCharts" in hourly_js_text

--- a/tests/frontend/test_renderers.py
+++ b/tests/frontend/test_renderers.py
@@ -271,6 +271,7 @@ def test_build_html_contains_meta_sections():
     assert "window.CLOSESNOW_FILTER_META" in html
     assert "window.CLOSESNOW_PAGE_BOOTSTRAP" in html
     assert '"dataUrl": "./data.json"' in html
+    assert 'id="favorite-alerts-root"' in html
     assert 'id="page-content-root"' in html
     assert "include_all" in html
     assert 'data-generated-utc="' in html


### PR DESCRIPTION
## Summary
- add a homepage-mounted favorites alert inbox root, rendering logic, and styles for unread/read alert cards
- persist alert read state, dismissals, and per-favorite visibility rules in the favorites alerts client state
- cover the new template and asset hooks with frontend and integration validation

## Validation
- python3 -m pytest -q tests/frontend/test_assets.py tests/frontend/test_renderers.py tests/frontend/test_static_site_pipeline.py tests/integration/test_web_server.py
- python3 -m pytest -q tests/integration/test_gateway_render_integration.py
- python3 -m src.cli static --output-dir /tmp/closesnow-favorites-alert-inbox --max-workers 8