### PR TITLE
Add home base homepage UI

### DIFF
--- a/assets/css/weather_page.css
+++ b/assets/css/weather_page.css
@@ -77,14 +77,16 @@
       color: #1e293b;
     }
     .home-base-lookup-row,
-    .home-base-manual-row {
+    .home-base-manual-row,
+    .home-base-nearby-row {
       display: flex;
       align-items: center;
       gap: 8px;
       flex-wrap: wrap;
     }
     .home-base-lookup-row label,
-    .home-base-manual-row label {
+    .home-base-manual-row label,
+    .home-base-nearby-row label {
       font-size: 12px;
       font-weight: 700;
       color: #334155;
@@ -105,6 +107,14 @@
     #home-base-lon-input {
       width: 130px;
     }
+    #filter-radius-select {
+      padding: 7px 9px;
+      border: 1px solid #cbd5e1;
+      border-radius: 8px;
+      background: #fff;
+      color: #1f2937;
+      font-size: 13px;
+    }
     .home-base-controls button {
       border: 1px solid #94a3b8;
       background: #f8fafc;
@@ -119,6 +129,16 @@
       border-color: #0f766e;
       background: #ecfeff;
       color: #0f766e;
+    }
+    #home-base-sort-distance {
+      border-color: #0f766e;
+      color: #0f766e;
+      background: #f0fdfa;
+    }
+    .home-base-nearby-summary {
+      font-size: 12px;
+      font-weight: 600;
+      color: #334155;
     }
     .home-base-status {
       margin: 0;
@@ -462,8 +482,23 @@
       font-weight: 600;
       color: #475569;
     }
+    .resort-distance-meta {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
     .resort-distance-unavailable {
       color: #94a3b8;
+    }
+    .resort-directions-link {
+      font-size: 11px;
+      font-weight: 700;
+      color: #0f766e;
+      text-decoration: none;
+    }
+    .resort-directions-link:hover {
+      text-decoration: underline;
     }
     .favorite-btn {
       position: relative;

--- a/assets/js/weather_page.js
+++ b/assets/js/weather_page.js
@@ -25,6 +25,8 @@ const homeBaseClearBtn = document.getElementById("home-base-clear");
 const homeBaseLatInput = document.getElementById("home-base-lat-input");
 const homeBaseLonInput = document.getElementById("home-base-lon-input");
 const homeBaseManualApply = document.getElementById("home-base-manual-apply");
+const homeBaseNearbySummary = document.getElementById("home-base-nearby-summary");
+const homeBaseSortDistance = document.getElementById("home-base-sort-distance");
 const resortSearchInput = document.getElementById("resort-search-input");
 const resortSearchClear = document.getElementById("resort-search-clear");
 const filterOpenBtn = document.getElementById("filter-open-btn");
@@ -268,16 +270,29 @@ const _favoriteAllButtonHtml = (reports) => {
 
 const _displayName = (report) => String(report?.display_name || report?.query || "").trim();
 
+const _buildDirectionsUrl = (report) => {
+  if (!appState.homeBase) return "";
+  const coordinates = _reportCoordinates(report);
+  if (!coordinates) return "";
+  const url = new URL("https://www.google.com/maps/dir/");
+  url.searchParams.set("api", "1");
+  url.searchParams.set("origin", `${appState.homeBase.latitude},${appState.homeBase.longitude}`);
+  url.searchParams.set("destination", `${coordinates.latitude},${coordinates.longitude}`);
+  url.searchParams.set("travelmode", "driving");
+  return url.toString();
+};
+
 const _resortCellHtml = (report) => {
   const text = _escapeHtml(_displayName(report));
   const resortId = String(report.resort_id || "").trim();
   const linkHtml = resortId
     ? `<a class='resort-link' href='resort/${encodeURIComponent(resortId)}'>${text}</a>`
     : text;
+  const directionsUrl = _buildDirectionsUrl(report);
   const distanceHtml = appState.homeBase
     ? (
       report.home_base_distance_available
-        ? `<div class='resort-distance'>${_escapeHtml(report.home_base_distance_mi.toFixed(1))} mi / ${_escapeHtml(report.home_base_distance_km.toFixed(1))} km</div>`
+        ? `<div class='resort-distance resort-distance-meta'>${_escapeHtml(report.home_base_distance_mi.toFixed(1))} mi / ${_escapeHtml(report.home_base_distance_km.toFixed(1))} km${directionsUrl ? ` <a class='resort-directions-link' href='${_escapeHtml(directionsUrl)}' target='_blank' rel='noopener noreferrer'>Directions</a>` : ""}</div>`
         : "<div class='resort-distance resort-distance-unavailable'>Distance unavailable</div>"
     )
     : "";
@@ -898,6 +913,29 @@ const syncHomeBaseControls = () => {
   if (homeBaseLonInput) homeBaseLonInput.value = homeBase ? _formatCoordinateSummary(homeBase.longitude) : "";
 };
 
+const syncHomeBaseNearbySummary = (visibleCount = null) => {
+  if (homeBaseSortDistance) {
+    homeBaseSortDistance.disabled = !appState.homeBase;
+    homeBaseSortDistance.textContent = appState.filterState.sortBy === "distance" ? "Distance Sorted" : "Sort by Distance";
+  }
+  if (!homeBaseNearbySummary) return;
+  if (!appState.homeBase) {
+    homeBaseNearbySummary.textContent = "Set a home base to unlock nearby filtering and directions.";
+    return;
+  }
+  ensureDistanceContext();
+  if (appState.distanceState.availableCount === 0) {
+    homeBaseNearbySummary.textContent = "No resort coordinates are available for nearby search yet.";
+    return;
+  }
+  if (appState.filterState.distanceRadiusKm !== null) {
+    const count = visibleCount === null ? _filteredReports().length : visibleCount;
+    homeBaseNearbySummary.textContent = `${count} resorts within ${_radiusLabel(appState.filterState.distanceRadiusKm)}.`;
+    return;
+  }
+  homeBaseNearbySummary.textContent = `${appState.distanceState.availableCount} resorts can be sorted by distance.`;
+};
+
 const setHomeBaseStatus = (message = "", isError = false) => {
   if (!homeBaseStatus) return;
   homeBaseStatus.textContent = message;
@@ -932,6 +970,7 @@ const setHomeBaseState = (rawHomeBase, options = {}) => {
     if (options.updateUrl !== false) syncHomeBaseToUrl();
   }
   syncHomeBaseControls();
+  syncHomeBaseNearbySummary();
   notifyHomeBaseChanged();
   if (options.renderPage !== false && appState.payload) {
     renderPagePreservingScroll();
@@ -1050,6 +1089,7 @@ const initializeHomeBase = () => {
   if (urlHomeBase) {
     appState.homeBase = homeBaseApi.persistHomeBase(urlHomeBase) || urlHomeBase;
     syncHomeBaseControls();
+    syncHomeBaseNearbySummary();
     notifyHomeBaseChanged();
     setHomeBaseStatus(`Home base restored from shared URL: ${urlHomeBase.label}.`, false);
     refreshHomeBaseLookupOptions();
@@ -1057,6 +1097,7 @@ const initializeHomeBase = () => {
   }
   appState.homeBase = homeBaseApi.loadStoredHomeBase();
   syncHomeBaseControls();
+  syncHomeBaseNearbySummary();
   notifyHomeBaseChanged();
   setHomeBaseStatus(
     appState.homeBase
@@ -1908,6 +1949,7 @@ const renderPage = () => {
   observeLayoutContainers();
   pageContentRoot.removeAttribute("data-loading");
   syncFilterSummary(visibleReports.length, totalReports);
+  syncHomeBaseNearbySummary(visibleReports.length);
   renderReportDate();
   applyUnitModes();
   document.body.classList.remove("units-pending");
@@ -2102,6 +2144,16 @@ const bindHomeBaseControls = () => {
   if (homeBaseGeolocateBtn) {
     homeBaseGeolocateBtn.addEventListener("click", () => {
       applyGeolocationHomeBase();
+    });
+  }
+  if (homeBaseSortDistance) {
+    homeBaseSortDistance.addEventListener("click", () => {
+      if (!appState.homeBase) {
+        setHomeBaseStatus("Set a home base before sorting nearby resorts by distance.", true);
+        return;
+      }
+      if (filterSortSelect) filterSortSelect.value = "distance";
+      applyFiltersImmediately();
     });
   }
   if (homeBaseClearBtn) {

--- a/src/web/templates/weather_page.html
+++ b/src/web/templates/weather_page.html
@@ -52,6 +52,20 @@
           <input id="home-base-lon-input" type="number" step="any" placeholder="-111.8910" inputmode="decimal" />
           <button id="home-base-manual-apply" type="button">Use Coordinates</button>
         </div>
+        <div class="home-base-nearby-row">
+          <label for="filter-radius-select">Nearby Radius</label>
+          <select id="filter-radius-select">
+            <option value="" selected>All distances</option>
+            <option value="40">25 mi / 40 km</option>
+            <option value="80">50 mi / 80 km</option>
+            <option value="160">100 mi / 160 km</option>
+            <option value="320">200 mi / 320 km</option>
+          </select>
+          <button id="home-base-sort-distance" type="button">Sort by Distance</button>
+          <span id="home-base-nearby-summary" class="home-base-nearby-summary">
+            Set a home base to unlock nearby filtering and directions.
+          </span>
+        </div>
         <p id="home-base-status" class="home-base-status">Set a home base from lookup, geolocation, or coordinates.</p>
       </div>
       <div class="resort-search">
@@ -106,16 +120,6 @@
             <option value="favorites">Favorites First</option>
             <option value="today_snow">Today's Snowfall</option>
             <option value="week_snow" selected>This Week's Snowfall</option>
-          </select>
-        </div>
-        <div class="filter-group">
-          <div class="filter-group-title">Nearby Radius</div>
-          <select id="filter-radius-select">
-            <option value="" selected>All distances</option>
-            <option value="40">25 mi / 40 km</option>
-            <option value="80">50 mi / 80 km</option>
-            <option value="160">100 mi / 160 km</option>
-            <option value="320">200 mi / 320 km</option>
           </select>
         </div>
         <div class="filter-group">

--- a/tests/frontend/test_assets.py
+++ b/tests/frontend/test_assets.py
@@ -83,6 +83,10 @@ def test_read_asset_bytes_reads_known_assets():
     assert "home_base_distance_km" in js_text
     assert 'if (text === "distance") return "distance";' in js_text
     assert "filter-radius-select" in js_text
+    assert "_buildDirectionsUrl" in js_text
+    assert "home-base-nearby-summary" in js_text
+    assert "Sort by Distance" in js_text
+    assert "https://www.google.com/maps/dir/" in js_text
     assert "window.CLOSESNOW_PAGE_BOOTSTRAP" in js_text
     assert "No resorts match the current filters." in js_text
     assert 'return "Today";' in js_text

--- a/tests/frontend/test_renderers.py
+++ b/tests/frontend/test_renderers.py
@@ -254,6 +254,8 @@ def test_build_html_contains_meta_sections():
     assert 'id="home-base-lookup-input"' in html
     assert 'id="home-base-geolocate-btn"' in html
     assert 'id="home-base-manual-apply"' in html
+    assert 'id="home-base-sort-distance"' in html
+    assert 'id="home-base-nearby-summary"' in html
     assert 'id="home-base-status"' in html
     assert 'id="filter-open-btn"' in html
     assert 'id="filter-modal"' in html


### PR DESCRIPTION
## Summary
- move nearby radius controls into the visible home-base cluster and add a quick distance-sort action
- expose nearby counts in the home-base UI and keep the layout usable across responsive breakpoints
- add Google Maps directions handoff for resorts with usable coordinates and an active home base

## Validation
- python3 -m pytest -q tests/frontend/test_assets.py tests/frontend/test_renderers.py tests/integration/test_web_server.py
- python3 -m src.cli static --output-dir /tmp/closesnow-home-base-ui --max-workers 8