### PR TITLE
Redesign US snowfall map hierarchy

### DIFF
--- a/assets/css/us_snowfall_map.css
+++ b/assets/css/us_snowfall_map.css
@@ -1,10 +1,15 @@
 .us-snowfall-map-section {
+  --us-map-panel-bg: linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(248, 250, 252, 0.96) 100%);
+  --us-map-panel-border: rgba(148, 163, 184, 0.22);
+  --us-map-panel-shadow: 0 14px 30px rgba(15, 23, 42, 0.08);
   margin: 18px 0 28px;
-  padding: 18px;
-  border: 1px solid rgba(15, 118, 110, 0.18);
-  border-radius: 24px;
-  background: linear-gradient(145deg, rgba(255, 255, 255, 0.96) 0%, rgba(239, 246, 255, 0.94) 100%);
-  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.08);
+  padding: 20px;
+  border: 1px solid rgba(15, 118, 110, 0.14);
+  border-radius: 28px;
+  background:
+    radial-gradient(circle at top left, rgba(191, 219, 254, 0.32) 0, rgba(191, 219, 254, 0) 34%),
+    linear-gradient(160deg, rgba(255, 255, 255, 0.98) 0%, rgba(243, 248, 251, 0.96) 100%);
+  box-shadow: 0 20px 44px rgba(15, 23, 42, 0.08);
 }
 
 .us-snowfall-map-header {
@@ -26,7 +31,8 @@
   max-width: 640px;
   font-size: 13px;
   color: #475569;
-  font-weight: 500;
+  font-weight: 600;
+  line-height: 1.55;
 }
 
 .us-snowfall-map-metric-toggle .unit-btn {
@@ -35,32 +41,83 @@
 
 .us-snowfall-map-shell {
   display: grid;
-  grid-template-columns: minmax(0, 1.7fr) minmax(250px, 0.85fr);
+  grid-template-columns: minmax(0, 2.2fr) minmax(260px, 0.8fr);
   grid-template-areas: "map meta";
-  gap: 16px;
+  gap: 18px;
   align-items: stretch;
 }
 
 .us-snowfall-map-meta {
   grid-area: meta;
   display: grid;
-  gap: 12px;
+  gap: 14px;
   align-content: start;
+}
+
+.us-snowfall-map-panel,
+.us-snowfall-map-legend {
+  padding: 16px 18px;
+  border-radius: 22px;
+  background: var(--us-map-panel-bg);
+  border: 1px solid var(--us-map-panel-border);
+  box-shadow: var(--us-map-panel-shadow);
+}
+
+.us-snowfall-map-panel-status {
+  display: grid;
+  gap: 10px;
+}
+
+.us-snowfall-map-panel-heading {
+  display: grid;
+  gap: 6px;
+}
+
+.us-snowfall-map-panel-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #0f766e;
+}
+
+.us-snowfall-map-panel-copy {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.55;
+  color: #475569;
+  font-weight: 600;
 }
 
 .us-snowfall-map-status {
   margin: 0;
-  padding: 14px 16px;
-  border-radius: 18px;
-  background: rgba(255, 255, 255, 0.86);
-  border: 1px solid rgba(148, 163, 184, 0.3);
+  display: grid;
+  gap: 6px;
   color: #334155;
-  font-size: 13px;
+}
+
+.us-snowfall-map-status strong {
+  font-size: 15px;
+  line-height: 1.35;
+  color: #0f172a;
+}
+
+.us-snowfall-map-status span {
+  font-size: 12px;
+  line-height: 1.55;
+  color: #475569;
   font-weight: 600;
-  line-height: 1.5;
 }
 
 .us-snowfall-map-legend {
+  display: grid;
+  gap: 12px;
+}
+
+.us-snowfall-map-legend-scale {
   display: grid;
   gap: 8px;
 }
@@ -69,12 +126,13 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 9px 12px;
+  min-height: 42px;
+  padding: 10px 12px;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.78);
+  background: rgba(255, 255, 255, 0.92);
   border: 1px solid rgba(148, 163, 184, 0.26);
   font-size: 12px;
-  color: #334155;
+  color: #1e293b;
   font-weight: 700;
 }
 
@@ -102,13 +160,15 @@
 .us-snowfall-map-root {
   grid-area: map;
   position: relative;
-  min-height: clamp(280px, 36vw, 430px);
-  border-radius: 24px;
+  min-height: clamp(320px, 41vw, 480px);
+  border-radius: 28px;
   overflow: hidden;
   isolation: isolate;
-  border: 1px solid rgba(15, 118, 110, 0.2);
-  background: linear-gradient(180deg, #e9f6ff 0%, #bfddf8 46%, #97c5f6 100%);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.55);
+  border: 1px solid rgba(8, 145, 178, 0.24);
+  background: linear-gradient(180deg, #eef8ff 0%, #c9e1f4 45%, #8cb3d3 100%);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.7),
+    0 22px 40px rgba(15, 23, 42, 0.14);
 }
 
 .us-snowfall-map-root::before {
@@ -117,13 +177,13 @@
   inset: 0;
   z-index: 0;
   background:
-    radial-gradient(circle at 20% 16%, rgba(255, 255, 255, 0.56) 0, rgba(255, 255, 255, 0) 22%),
-    radial-gradient(circle at 82% 30%, rgba(255, 255, 255, 0.32) 0, rgba(255, 255, 255, 0) 24%),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.14) 0%, rgba(15, 23, 42, 0.08) 100%);
+    radial-gradient(circle at 18% 14%, rgba(255, 255, 255, 0.72) 0, rgba(255, 255, 255, 0) 24%),
+    radial-gradient(circle at 82% 28%, rgba(255, 255, 255, 0.34) 0, rgba(255, 255, 255, 0) 24%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.1) 0%, rgba(15, 23, 42, 0.14) 100%);
 }
 
 .us-snowfall-map-root[data-map-mode="fallback"] {
-  background: linear-gradient(180deg, #eff6ff 0%, #dbeafe 52%, #bfd7f6 100%);
+  background: linear-gradient(180deg, #f4f8fb 0%, #dde8f1 52%, #bfd1df 100%);
 }
 
 .us-snowfall-map-toolbar,
@@ -135,9 +195,9 @@
 }
 
 .us-snowfall-map-toolbar {
-  top: 14px;
-  left: 14px;
-  right: 14px;
+  top: 16px;
+  left: 16px;
+  right: 16px;
   z-index: 4;
   display: flex;
   align-items: center;
@@ -148,17 +208,17 @@
 .us-snowfall-map-view-badge {
   display: inline-flex;
   align-items: center;
-  min-height: 36px;
-  padding: 0 14px;
+  min-height: 38px;
+  padding: 0 15px;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.9);
-  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(248, 250, 252, 0.94);
+  border: 1px solid rgba(148, 163, 184, 0.3);
   color: #0f172a;
   font-size: 12px;
   font-weight: 800;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.12);
 }
 
 .us-snowfall-map-toolbar-actions {
@@ -169,11 +229,11 @@
 
 .us-snowfall-map-control {
   min-width: 36px;
-  height: 36px;
+  height: 38px;
   padding: 0 12px;
   border: 0;
   border-radius: 999px;
-  background: rgba(15, 23, 42, 0.8);
+  background: rgba(15, 23, 42, 0.82);
   color: #eff6ff;
   font-size: 14px;
   font-weight: 800;
@@ -338,10 +398,10 @@
 .us-snowfall-map-popup {
   position: absolute;
   z-index: 4;
-  border-radius: 20px;
-  background: rgba(255, 255, 255, 0.92);
-  border: 1px solid rgba(148, 163, 184, 0.28);
-  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.18);
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.96);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  box-shadow: 0 20px 38px rgba(15, 23, 42, 0.2);
   color: #0f172a;
 }
 
@@ -372,16 +432,23 @@
 }
 
 .us-snowfall-map-popup {
-  top: 62px;
+  top: 72px;
   right: 18px;
   display: grid;
-  gap: 8px;
-  width: min(280px, calc(100% - 36px));
+  gap: 10px;
+  width: min(320px, calc(100% - 36px));
   padding: 14px 16px 16px;
 }
 
+.us-snowfall-map-popup-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
 .us-snowfall-map-popup-kicker {
-  font-size: 11px;
+  font-size: 10px;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: #0f766e;
@@ -400,11 +467,18 @@
   color: #1d4ed8;
 }
 
-.us-snowfall-map-popup-meta {
+.us-snowfall-map-popup-detail {
   font-size: 12px;
   line-height: 1.5;
   color: #475569;
   font-weight: 700;
+}
+
+.us-snowfall-map-popup-summary {
+  font-size: 12px;
+  line-height: 1.55;
+  color: #334155;
+  font-weight: 600;
 }
 
 .us-snowfall-map-popup-link {
@@ -420,11 +494,13 @@
 }
 
 .us-snowfall-map-popup-close {
-  justify-self: end;
   border: 0;
-  background: transparent;
-  color: #64748b;
-  font-size: 11px;
+  min-height: 28px;
+  padding: 0 10px;
+  border-radius: 999px;
+  background: rgba(226, 232, 240, 0.72);
+  color: #475569;
+  font-size: 10px;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   font-weight: 800;
@@ -433,23 +509,24 @@
 
 .us-snowfall-map-placeholder {
   position: absolute;
-  left: 20px;
+  left: 18px;
   right: auto;
-  bottom: 20px;
+  bottom: 18px;
   z-index: 1;
   display: grid;
   gap: 6px;
-  max-width: 300px;
-  padding: 14px 16px;
-  border-radius: 18px;
-  background: rgba(255, 255, 255, 0.88);
+  max-width: 340px;
+  padding: 16px 18px;
+  border-radius: 22px;
+  background: rgba(248, 250, 252, 0.94);
+  border: 1px solid rgba(148, 163, 184, 0.22);
   color: #0f172a;
-  box-shadow: 0 10px 22px rgba(15, 23, 42, 0.12);
+  box-shadow: var(--us-map-panel-shadow);
 }
 
 .us-snowfall-map-placeholder strong {
-  font-size: 18px;
-  line-height: 1.2;
+  font-size: 20px;
+  line-height: 1.25;
 }
 
 .us-snowfall-map-placeholder span:last-child {
@@ -480,20 +557,29 @@
   .us-snowfall-map-shell {
     grid-template-columns: 1fr;
     grid-template-areas:
-      "meta"
-      "map";
+      "map"
+      "meta";
+  }
+
+  .us-snowfall-map-root {
+    min-height: clamp(320px, 58vw, 430px);
   }
 }
 
 @media (max-width: 640px) {
   .us-snowfall-map-section {
     padding: 14px;
-    border-radius: 18px;
+    border-radius: 22px;
+  }
+
+  .us-snowfall-map-panel,
+  .us-snowfall-map-legend {
+    padding: 14px 15px;
   }
 
   .us-snowfall-map-root {
-    min-height: 240px;
-    border-radius: 18px;
+    min-height: 320px;
+    border-radius: 22px;
   }
 
   .us-snowfall-map-toolbar {
@@ -501,6 +587,11 @@
     left: 12px;
     right: 12px;
     flex-wrap: wrap;
+  }
+
+  .us-snowfall-map-toolbar-actions {
+    width: 100%;
+    justify-content: flex-end;
   }
 
   .us-snowfall-map-view-badge {
@@ -536,6 +627,14 @@
   }
 
   .us-snowfall-map-popup {
-    top: 60px;
+    top: auto;
+    bottom: 14px;
+  }
+
+  .us-snowfall-map-placeholder {
+    left: 14px;
+    right: 14px;
+    bottom: 14px;
+    max-width: none;
   }
 }

--- a/assets/js/us_snowfall_map.js
+++ b/assets/js/us_snowfall_map.js
@@ -431,15 +431,21 @@
     const metricValue = _formatSnowfall(_metricValue(report, metricKey));
     const passTypes = _escapeHtml(_passTypesText(report));
     const stateText = state ? _escapeHtml(state.toUpperCase()) : "US";
+    const summary = resortId
+      ? "Open the matching hourly page for snowfall timing, wind, and precipitation detail."
+      : "Use the linked resort rows below for the matching forecast record.";
     const linkHtml = resortId
       ? `<a class="us-snowfall-map-popup-link" href="resort/${encodeURIComponent(resortId)}">Open hourly page</a>`
       : "";
     return `
-      <button type="button" class="us-snowfall-map-popup-close" data-map-popup-close="1" aria-label="Close snowfall map popup">Close</button>
-      <div class="us-snowfall-map-popup-kicker">${_escapeHtml(metric.label)}</div>
+      <div class="us-snowfall-map-popup-header">
+        <div class="us-snowfall-map-popup-kicker">${_escapeHtml(metric.label)}</div>
+        <button type="button" class="us-snowfall-map-popup-close" data-map-popup-close="1" aria-label="Close snowfall map popup">Close</button>
+      </div>
       <strong class="us-snowfall-map-popup-title">${header}</strong>
       <div class="us-snowfall-map-popup-metric">${metricValue}</div>
-      <div class="us-snowfall-map-popup-meta">${stateText} · ${passTypes}</div>
+      <div class="us-snowfall-map-popup-detail">${stateText} · ${passTypes}</div>
+      <div class="us-snowfall-map-popup-summary">${_escapeHtml(summary)}</div>
       ${linkHtml}
     `;
   };
@@ -453,11 +459,17 @@
 
   const _legendHtml = () => {
     const config = _metricConfig(DEFAULT_METRIC_KEY);
-    return [
-      `<span class="us-snowfall-map-legend-chip" data-map-legend-stop="low">${config.legend[0]}</span>`,
-      `<span class="us-snowfall-map-legend-chip" data-map-legend-stop="mid">${config.legend[1]}</span>`,
-      `<span class="us-snowfall-map-legend-chip" data-map-legend-stop="high">${config.legend[2]}</span>`,
-    ].join("");
+    return `
+      <div class="us-snowfall-map-panel-heading">
+        <span class="us-snowfall-map-panel-label">Intensity guide</span>
+        <p class="us-snowfall-map-panel-copy">Marker fill reflects the active snowfall range while the rest of the forecast stays available below.</p>
+      </div>
+      <div class="us-snowfall-map-legend-scale">
+        <span class="us-snowfall-map-legend-chip" data-map-legend-stop="low">${config.legend[0]}</span>
+        <span class="us-snowfall-map-legend-chip" data-map-legend-stop="mid">${config.legend[1]}</span>
+        <span class="us-snowfall-map-legend-chip" data-map-legend-stop="high">${config.legend[2]}</span>
+      </div>
+    `;
   };
 
   const _mapStageHtml = () => `
@@ -662,23 +674,35 @@
     const renderStatus = (eligibleReports) => {
       if (!statusElement) return;
       const metric = _metricConfig(state.metricKey);
+      const renderStatusCard = (headline, detail) => {
+        statusElement.innerHTML = `
+          <strong>${_escapeHtml(headline)}</strong>
+          <span>${_escapeHtml(detail)}</span>
+        `;
+      };
       if (state.errorMessage) {
-        statusElement.textContent = `Snowfall map unavailable. ${state.errorMessage}`;
+        renderStatusCard("Interactive map unavailable.", state.errorMessage);
         return;
       }
       const interactionText = state.basemapMode === "geographic"
-        ? "Drag to pan, use scroll or the +/- controls to zoom, and Reset for the full US view."
-        : "Basemap fallback is active. Drag to pan, use scroll or the +/- controls to zoom, and Reset for the full US view.";
+        ? "Drag to pan, use scroll or the +/- controls to zoom, and Reset to return to the full US view."
+        : "Basemap fallback is active. Drag to pan, use scroll or the +/- controls to zoom, and Reset to return to the full US view.";
       if (!eligibleReports.length) {
         const visibleCount = state.visibleReports.length;
         const scopeText = visibleCount ? "No visible resorts" : "No resorts";
-        statusElement.textContent = `${scopeText} are map-ready for ${metric.label}. Non-US resorts and resorts without projectable coordinates stay in the tables only. ${interactionText}`;
+        renderStatusCard(
+          `${scopeText} are map-ready for ${metric.label}.`,
+          `Non-US resorts and resorts without projectable coordinates stay in the tables below. ${interactionText}`,
+        );
         return;
       }
       const focused = state.selectedResortId
-        ? ` Focused resort: ${_displayName(eligibleReports.find((report, index) => _selectionKey(report, index) === state.selectedResortId) || { resort_id: state.selectedResortId, query: state.selectedResortId })}.`
-        : "";
-      statusElement.textContent = `Showing ${eligibleReports.length} US resort${eligibleReports.length === 1 ? "" : "s"} for ${metric.label}.${focused} ${interactionText}`;
+        ? `Focused resort: ${_displayName(eligibleReports.find((report, index) => _selectionKey(report, index) === state.selectedResortId) || { resort_id: state.selectedResortId, query: state.selectedResortId })}.`
+        : "Select a marker to inspect the same resort record that appears in the tables below.";
+      renderStatusCard(
+        `Showing ${eligibleReports.length} US resort${eligibleReports.length === 1 ? "" : "s"} for ${metric.label}.`,
+        `${focused} ${interactionText}`,
+      );
     };
 
     const renderLegend = () => {

--- a/assets/js/weather_page.js
+++ b/assets/js/weather_page.js
@@ -328,7 +328,7 @@ const _renderUsSnowfallMapSection = () => {
     <div class="section-header us-snowfall-map-header">
       <div class="us-snowfall-map-heading-wrap">
         <h2 id="us-snowfall-map-title">US Snowfall Map</h2>
-        <p class="us-snowfall-map-subtitle">Preview the upcoming nationwide snowfall view without displacing the resort tables below.</p>
+        <p class="us-snowfall-map-subtitle">Scan nationwide snowfall concentration, then open the same resort records and hourly pages from one map surface.</p>
       </div>
       <div id="us-snowfall-map-metric-toggle" class="unit-toggle us-snowfall-map-metric-toggle" role="group" aria-label="Snowfall map metric" data-map-metric-toggle="1" data-mode="${activeMetricKey}">
         <button type="button" class="unit-btn${todayActive ? " is-active" : ""}" data-map-metric-key="today" aria-pressed="${todayActive ? "true" : "false"}">24h</button>
@@ -337,19 +337,31 @@ const _renderUsSnowfallMapSection = () => {
       </div>
     </div>
     <div class="us-snowfall-map-shell">
-      <div class="us-snowfall-map-meta">
-        <p id="us-snowfall-map-status" class="us-snowfall-map-status" role="status">Loading the US snowfall map controller.</p>
-        <div id="us-snowfall-map-legend" class="us-snowfall-map-legend" aria-label="Snowfall legend">
-          <span class="us-snowfall-map-legend-chip" data-map-legend-stop="low">0-5 cm</span>
-          <span class="us-snowfall-map-legend-chip" data-map-legend-stop="mid">5-15 cm</span>
-          <span class="us-snowfall-map-legend-chip" data-map-legend-stop="high">15+ cm</span>
-        </div>
-      </div>
       <div id="us-snowfall-map-root" class="us-snowfall-map-root" role="region" aria-label="US snowfall map">
         <div class="us-snowfall-map-placeholder">
-          <span class="us-snowfall-map-placeholder-kicker">Map canvas</span>
-          <strong>US snowfall map</strong>
-          <span>Interactive markers and popups load after the page script initializes.</span>
+          <span class="us-snowfall-map-placeholder-kicker">Nationwide resort snowfall</span>
+          <strong>Track 24h, 72h, and 7-day snow from one map.</strong>
+          <span>Interactive markers, panning, and hourly drill-ins load with the page script while the forecast tables stay available below.</span>
+        </div>
+      </div>
+      <div class="us-snowfall-map-meta">
+        <div class="us-snowfall-map-panel us-snowfall-map-panel-status">
+          <span class="us-snowfall-map-panel-label">Map status</span>
+          <div id="us-snowfall-map-status" class="us-snowfall-map-status" role="status">
+            <strong>Preparing nationwide resort snowfall coverage.</strong>
+            <span>Switch metrics, pan the map, and open a marker to continue into the matching hourly page.</span>
+          </div>
+        </div>
+        <div id="us-snowfall-map-legend" class="us-snowfall-map-legend" aria-label="Snowfall legend">
+          <div class="us-snowfall-map-panel-heading">
+            <span class="us-snowfall-map-panel-label">Intensity guide</span>
+            <p class="us-snowfall-map-panel-copy">Marker fill reflects the active snowfall range while the rest of the forecast stays available below.</p>
+          </div>
+          <div class="us-snowfall-map-legend-scale">
+            <span class="us-snowfall-map-legend-chip" data-map-legend-stop="low">0-5 cm</span>
+            <span class="us-snowfall-map-legend-chip" data-map-legend-stop="mid">5-15 cm</span>
+            <span class="us-snowfall-map-legend-chip" data-map-legend-stop="high">15+ cm</span>
+          </div>
         </div>
       </div>
     </div>

--- a/src/web/weather_html_renderer.py
+++ b/src/web/weather_html_renderer.py
@@ -13,7 +13,7 @@ _PAGE_SHELL_PLACEHOLDER = """
       <div class="section-header us-snowfall-map-header">
         <div class="us-snowfall-map-heading-wrap">
           <h2 id="us-snowfall-map-title">US Snowfall Map</h2>
-          <p class="us-snowfall-map-subtitle">Preview the upcoming nationwide snowfall view without displacing the resort tables below.</p>
+          <p class="us-snowfall-map-subtitle">Scan nationwide snowfall concentration, then open the same resort records and hourly pages from one map surface.</p>
         </div>
         <div id="us-snowfall-map-metric-toggle" class="unit-toggle us-snowfall-map-metric-toggle" role="group" aria-label="Snowfall map metric" data-map-metric-toggle="1" data-mode="today">
           <button type="button" class="unit-btn is-active" data-map-metric-key="today" aria-pressed="true">24h</button>
@@ -22,19 +22,31 @@ _PAGE_SHELL_PLACEHOLDER = """
         </div>
       </div>
       <div class="us-snowfall-map-shell">
-        <div class="us-snowfall-map-meta">
-          <p id="us-snowfall-map-status" class="us-snowfall-map-status" role="status">Loading the US snowfall map controller.</p>
-          <div id="us-snowfall-map-legend" class="us-snowfall-map-legend" aria-label="Snowfall legend">
-            <span class="us-snowfall-map-legend-chip" data-map-legend-stop="low">0-5 cm</span>
-            <span class="us-snowfall-map-legend-chip" data-map-legend-stop="mid">5-15 cm</span>
-            <span class="us-snowfall-map-legend-chip" data-map-legend-stop="high">15+ cm</span>
-          </div>
-        </div>
         <div id="us-snowfall-map-root" class="us-snowfall-map-root" role="region" aria-label="US snowfall map">
           <div class="us-snowfall-map-placeholder">
-            <span class="us-snowfall-map-placeholder-kicker">Map canvas</span>
-            <strong>US snowfall map</strong>
-            <span>Interactive markers and popups load after the page script initializes.</span>
+            <span class="us-snowfall-map-placeholder-kicker">Nationwide resort snowfall</span>
+            <strong>Track 24h, 72h, and 7-day snow from one map.</strong>
+            <span>Interactive markers, panning, and hourly drill-ins load with the page script while the forecast tables stay available below.</span>
+          </div>
+        </div>
+        <div class="us-snowfall-map-meta">
+          <div class="us-snowfall-map-panel us-snowfall-map-panel-status">
+            <span class="us-snowfall-map-panel-label">Map status</span>
+            <div id="us-snowfall-map-status" class="us-snowfall-map-status" role="status">
+              <strong>Preparing nationwide resort snowfall coverage.</strong>
+              <span>Switch metrics, pan the map, and open a marker to continue into the matching hourly page.</span>
+            </div>
+          </div>
+          <div id="us-snowfall-map-legend" class="us-snowfall-map-legend" aria-label="Snowfall legend">
+            <div class="us-snowfall-map-panel-heading">
+              <span class="us-snowfall-map-panel-label">Intensity guide</span>
+              <p class="us-snowfall-map-panel-copy">Marker fill reflects the active snowfall range while the rest of the forecast stays available below.</p>
+            </div>
+            <div class="us-snowfall-map-legend-scale">
+              <span class="us-snowfall-map-legend-chip" data-map-legend-stop="low">0-5 cm</span>
+              <span class="us-snowfall-map-legend-chip" data-map-legend-stop="mid">5-15 cm</span>
+              <span class="us-snowfall-map-legend-chip" data-map-legend-stop="high">15+ cm</span>
+            </div>
           </div>
         </div>
       </div>

--- a/tests/frontend/test_assets.py
+++ b/tests/frontend/test_assets.py
@@ -57,7 +57,10 @@ def test_read_asset_bytes_reads_known_assets():
     assert ".us-snowfall-map-section" in map_css_text
     assert ".us-snowfall-map-root" in map_css_text
     assert ".us-snowfall-map-marker" in map_css_text
+    assert ".us-snowfall-map-panel-label" in map_css_text
+    assert ".us-snowfall-map-legend-scale" in map_css_text
     assert ".us-snowfall-map-popup" in map_css_text
+    assert ".us-snowfall-map-popup-summary" in map_css_text
     assert ".us-snowfall-map-viewport" in map_css_text
     assert ".us-snowfall-map-control" in map_css_text
     assert ".us-snowfall-map-basemap" in map_css_text
@@ -85,6 +88,8 @@ def test_read_asset_bytes_reads_known_assets():
     assert "destroy" in map_js_text
     assert "next_72h" in map_js_text
     assert "week1" in map_js_text
+    assert "Intensity guide" in map_js_text
+    assert "Open the matching hourly page for snowfall timing, wind, and precipitation detail." in map_js_text
     assert "onSelectResort" in map_js_text
     assert "Open hourly page" in map_js_text
     assert "Full US view" in map_js_text
@@ -92,6 +97,8 @@ def test_read_asset_bytes_reads_known_assets():
     assert "pointerdown" in map_js_text
     assert "wheel" in map_js_text
     assert "Basemap unavailable" in map_js_text
+    assert "Preview the upcoming nationwide snowfall view" not in js_text
+    assert "Preparing nationwide resort snowfall coverage." in js_text
     assert "renderSingleResortHtml" in compact_js_text
     assert "labelMode" in compact_js_text
     assert 'return "Today";' in compact_js_text

--- a/tests/frontend/test_renderers.py
+++ b/tests/frontend/test_renderers.py
@@ -253,6 +253,11 @@ def test_build_html_contains_meta_sections():
     assert 'id="us-snowfall-map-legend"' in html
     assert 'id="us-snowfall-map-status"' in html
     assert 'id="us-snowfall-map-root"' in html
+    assert "Map status" in html
+    assert "Intensity guide" in html
+    assert "Preparing nationwide resort snowfall coverage." in html
+    assert "Track 24h, 72h, and 7-day snow from one map." in html
+    assert "Preview the upcoming nationwide snowfall view" not in html
     assert 'data-map-metric-key="today"' in html
     assert 'data-map-metric-key="next_72h"' in html
     assert 'data-map-metric-key="week1"' in html


### PR DESCRIPTION
## Summary
- make the US snowfall map read like a production surface instead of a preview
- rebalance the desktop and mobile layout so the map carries the primary visual weight
- tighten popup, legend, and status treatments and cover the new copy in tests

## Testing
- python3 -m pytest -q tests/frontend/test_assets.py tests/frontend/test_renderers.py tests/frontend/test_static_site_pipeline.py tests/integration/test_web_server.py
- python3 -m src.cli static --output-dir /tmp/closesnow-us-map-redesign --max-workers 8