### PR TITLE
Add browser notification support for alerts

### DIFF
--- a/assets/css/weather_page.css
+++ b/assets/css/weather_page.css
@@ -267,6 +267,48 @@
       background: #0f766e;
       color: #fff;
     }
+    .favorite-alert-notification {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
+      padding: 12px 14px;
+      border-radius: 14px;
+      border: 1px solid #dbe4ee;
+      background: rgba(255,255,255,0.92);
+    }
+    .favorite-alert-notification[data-notification-tone="ready"] {
+      border-color: #99f6e4;
+      background: linear-gradient(180deg, #f0fdfa 0%, #ffffff 100%);
+    }
+    .favorite-alert-notification[data-notification-tone="warning"] {
+      border-color: #fde68a;
+      background: linear-gradient(180deg, #fffbeb 0%, #ffffff 100%);
+    }
+    .favorite-alert-notification h3 {
+      margin: 0 0 4px;
+      font-size: 16px;
+      color: #0f172a;
+    }
+    .favorite-alert-notification p {
+      margin: 0;
+      font-size: 12px;
+      line-height: 1.5;
+      color: #64748b;
+      max-width: 640px;
+    }
+    .favorite-alert-notification-btn {
+      border: 1px solid #0f766e;
+      background: #0f766e;
+      color: #fff;
+      border-radius: 8px;
+      padding: 8px 12px;
+      font-size: 12px;
+      font-weight: 700;
+      cursor: pointer;
+      white-space: nowrap;
+    }
     .favorite-alerts-grid {
       display: grid;
       gap: 14px;
@@ -453,10 +495,12 @@
       .favorite-alerts-panel {
         padding: 14px;
       }
+      .favorite-alert-notification,
       .favorite-alert-rule-row,
       .favorite-alert-card-actions {
         align-items: stretch;
       }
+      .favorite-alert-notification-btn,
       .favorite-alert-rule-select,
       .favorite-alert-action-btn {
         width: 100%;

--- a/assets/js/favorites_alerts.js
+++ b/assets/js/favorites_alerts.js
@@ -105,6 +105,8 @@
     alerts: [],
     read_alert_ids: [],
     dismissed_alert_ids: [],
+    notified_alert_ids: [],
+    notification_opt_in: false,
     rules_by_resort_id: {},
   });
 
@@ -176,6 +178,8 @@
     const validAlertIds = new Set(state.alerts.map((alert) => alert.id));
     state.read_alert_ids = normalizeIdList(raw.read_alert_ids, validAlertIds);
     state.dismissed_alert_ids = normalizeIdList(raw.dismissed_alert_ids, validAlertIds);
+    state.notified_alert_ids = normalizeIdList(raw.notified_alert_ids, validAlertIds);
+    state.notification_opt_in = Boolean(raw.notification_opt_in);
     state.rules_by_resort_id = normalizeRuleMap(raw.rules_by_resort_id);
     return state;
   };
@@ -233,6 +237,22 @@
     ...state,
     read_alert_ids: updateAlertIdList(state.read_alert_ids, alertId, true),
     dismissed_alert_ids: updateAlertIdList(state.dismissed_alert_ids, alertId, true),
+  }), storage);
+
+  const markAlertsNotified = (alertIds, storage = root.localStorage) => updateState((state) => {
+    const validIds = new Set((state.alerts || []).map((alert) => alert.id));
+    return {
+      ...state,
+      notified_alert_ids: normalizeIdList(
+        state.notified_alert_ids.concat(Array.isArray(alertIds) ? alertIds : []),
+        validIds,
+      ),
+    };
+  }, storage);
+
+  const setNotificationOptIn = (enabled, storage = root.localStorage) => updateState((state) => ({
+    ...state,
+    notification_opt_in: Boolean(enabled),
   }), storage);
 
   const setResortRule = (resortId, mode, storage = root.localStorage) => updateState((state) => {
@@ -502,7 +522,9 @@
     markAlertRead,
     markAlertUnread,
     dismissAlert,
+    markAlertsNotified,
     setResortRule,
+    setNotificationOptIn,
     syncPayload,
   };
 })(typeof window !== "undefined" ? window : globalThis);

--- a/assets/js/favorites_alerts_sw.js
+++ b/assets/js/favorites_alerts_sw.js
@@ -1,0 +1,24 @@
+self.addEventListener("install", (event) => {
+  event.waitUntil(self.skipWaiting());
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener("notificationclick", (event) => {
+  const targetUrl = event.notification?.data?.url || "/";
+  event.notification.close();
+  event.waitUntil((async () => {
+    const existingClients = await self.clients.matchAll({ type: "window", includeUncontrolled: true });
+    for (const client of existingClients) {
+      if (client.url === targetUrl && "focus" in client) {
+        await client.focus();
+        return;
+      }
+    }
+    if (self.clients.openWindow) {
+      await self.clients.openWindow(targetUrl);
+    }
+  })());
+});

--- a/assets/js/weather_page.js
+++ b/assets/js/weather_page.js
@@ -70,6 +70,8 @@ const appState = {
   sunTimeToggleMode: "metric",
   favoriteAlertState: null,
   newFavoriteAlerts: [],
+  favoriteAlertNotificationRegistration: null,
+  favoriteAlertNotificationRegistrationReady: false,
 };
 
 const _normalizeSearch = (value) => String(value || "").trim().toLowerCase();
@@ -762,6 +764,136 @@ const _favoriteAlertCollections = () => {
   };
 };
 
+const _favoriteAlertNotificationSummary = (state) => {
+  const notificationSupported = typeof window.Notification !== "undefined";
+  const permission = notificationSupported ? window.Notification.permission : "unsupported";
+  const optIn = Boolean(state.notification_opt_in);
+  if (!notificationSupported) {
+    return {
+      title: "Notifications unavailable",
+      copy: "This browser does not expose the Notification API, so CloseSnow will stay inbox-only.",
+      action: "",
+      tone: "muted",
+    };
+  }
+  if (permission === "denied") {
+    return {
+      title: "Notifications blocked",
+      copy: "Browser notifications are blocked for this site. The inbox remains the source of truth for favorite alerts.",
+      action: optIn ? "disable" : "",
+      tone: "warning",
+    };
+  }
+  if (!optIn || permission !== "granted") {
+    return {
+      title: "Browser notifications off",
+      copy: "Enable this optional enhancement to mirror newly generated favorite alerts while the browser supports it.",
+      action: "enable",
+      tone: "muted",
+    };
+  }
+  if (appState.favoriteAlertNotificationRegistrationReady) {
+    return {
+      title: "Browser notifications enabled",
+      copy: "New favorite alerts can appear as browser notifications and still map back to the same inbox items.",
+      action: "disable",
+      tone: "ready",
+    };
+  }
+  return {
+    title: "Browser notifications enabled (page delivery)",
+    copy: "Permission is granted, but service worker setup is unavailable. CloseSnow will still notify while this page stays open.",
+    action: "disable",
+    tone: "ready",
+  };
+};
+
+const _favoriteAlertNotificationControlsHtml = (state) => {
+  const summary = _favoriteAlertNotificationSummary(state);
+  const buttonLabel = summary.action === "enable" ? "Enable notifications" : "Turn off";
+  return `<section class='favorite-alert-notification' data-notification-tone='${summary.tone}'>
+    <div>
+      <h3>${_escapeHtml(summary.title)}</h3>
+      <p>${_escapeHtml(summary.copy)}</p>
+    </div>
+    ${summary.action
+      ? `<button type='button' class='favorite-alert-notification-btn' data-favorite-alert-notifications='${summary.action}'>${_escapeHtml(buttonLabel)}</button>`
+      : ""}
+  </section>`;
+};
+
+const registerFavoriteAlertServiceWorker = async () => {
+  if (!("serviceWorker" in navigator)) return null;
+  if (appState.favoriteAlertNotificationRegistration) return appState.favoriteAlertNotificationRegistration;
+  try {
+    const registration = await navigator.serviceWorker.register(
+      new URL("assets/js/favorites_alerts_sw.js", window.location.href).toString(),
+    );
+    appState.favoriteAlertNotificationRegistration = registration;
+    appState.favoriteAlertNotificationRegistrationReady = true;
+    return registration;
+  } catch (error) {
+    appState.favoriteAlertNotificationRegistrationReady = false;
+    return null;
+  }
+};
+
+const notifyFavoriteAlertsIfNeeded = async () => {
+  if (!favoriteAlertsApi || typeof favoriteAlertsApi.markAlertsNotified !== "function") return;
+  const state = _favoriteAlertState();
+  if (!state.notification_opt_in) return;
+  if (typeof window.Notification === "undefined" || window.Notification.permission !== "granted") return;
+  if (!Array.isArray(appState.newFavoriteAlerts) || appState.newFavoriteAlerts.length === 0) return;
+  const alreadyNotified = new Set(Array.isArray(state.notified_alert_ids) ? state.notified_alert_ids : []);
+  const pendingAlerts = appState.newFavoriteAlerts.filter((alert) => {
+    const alertId = String(alert?.id || "").trim();
+    return alertId && !alreadyNotified.has(alertId);
+  });
+  if (!pendingAlerts.length) return;
+
+  const registration = await registerFavoriteAlertServiceWorker();
+  const notifiedIds = [];
+  for (const alert of pendingAlerts) {
+    const alertId = String(alert?.id || "").trim();
+    if (!alertId) continue;
+    const title = String(alert?.title || alert?.resort_name || "Favorite alert").trim() || "Favorite alert";
+    const body = String(alert?.message || "").trim() || "A favorite resort forecast changed.";
+    const destinationUrl = alert?.resort_id
+      ? new URL(`resort/${encodeURIComponent(alert.resort_id)}`, window.location.href).toString()
+      : window.location.href;
+    try {
+      if (registration && typeof registration.showNotification === "function") {
+        await registration.showNotification(title, {
+          body,
+          tag: alertId,
+          data: { url: destinationUrl, alertId },
+        });
+      } else {
+        new window.Notification(title, {
+          body,
+          tag: alertId,
+        });
+      }
+      notifiedIds.push(alertId);
+    } catch (error) {
+      break;
+    }
+  }
+  if (!notifiedIds.length) return;
+  favoriteAlertsApi.markAlertsNotified(notifiedIds);
+  refreshFavoriteAlertStateFromStorage();
+  renderFavoriteAlertsPanel();
+};
+
+const warmFavoriteAlertNotificationRegistration = () => {
+  const state = _favoriteAlertState();
+  if (!state.notification_opt_in) return;
+  if (typeof window.Notification === "undefined" || window.Notification.permission !== "granted") return;
+  void registerFavoriteAlertServiceWorker().then(() => {
+    renderFavoriteAlertsPanel();
+  });
+};
+
 const _favoriteAlertCardHtml = (alert, read) => {
   const alertId = String(alert?.id || "").trim();
   const resortId = String(alert?.resort_id || "").trim();
@@ -872,6 +1004,7 @@ const renderFavoriteAlertsPanel = () => {
       <div class='favorite-alert-chip-row'>${chips.join("")}</div>
     </div>
     <p class='favorite-alerts-description'>Review forecast swings without leaving the homepage. Alerts stay local to this browser and never auto-mark themselves as read.</p>
+    ${_favoriteAlertNotificationControlsHtml(state)}
     <div class='favorite-alerts-grid'>
       ${_favoriteAlertSectionHtml({
         title: "Unread alerts",
@@ -907,6 +1040,7 @@ const syncFavoriteAlertState = () => {
     result && result.state ? result.state : null,
     result && Array.isArray(result.newAlerts) ? result.newAlerts : [],
   );
+  void notifyFavoriteAlertsIfNeeded();
   return result;
 };
 
@@ -2001,6 +2135,7 @@ const reloadDynamicPayloadForFilters = async () => {
   appState.reports = _payloadReports();
   appState.availableFilters = _availableFilters();
   syncFavoriteAlertState();
+  warmFavoriteAlertNotificationRegistration();
   updateFilterLabels();
 };
 
@@ -2090,6 +2225,31 @@ const bindControls = () => {
     if (event.key === "Escape" && filterModal && !filterModal.hidden) closeFilterModal();
   });
   document.addEventListener("click", (event) => {
+    const notificationButton = event.target.closest("[data-favorite-alert-notifications]");
+    if (notificationButton && favoriteAlertsApi && typeof favoriteAlertsApi.setNotificationOptIn === "function") {
+      const action = notificationButton.getAttribute("data-favorite-alert-notifications");
+      if (action === "enable") {
+        if (typeof window.Notification === "undefined") {
+          renderFavoriteAlertsPanel();
+          return;
+        }
+        window.Notification.requestPermission().then(async (permission) => {
+          if (permission === "granted") {
+            favoriteAlertsApi.setNotificationOptIn(true);
+            await registerFavoriteAlertServiceWorker();
+          }
+          refreshFavoriteAlertStateFromStorage();
+          renderFavoriteAlertsPanel();
+        });
+        return;
+      }
+      if (action === "disable") {
+        favoriteAlertsApi.setNotificationOptIn(false);
+        refreshFavoriteAlertStateFromStorage();
+        renderFavoriteAlertsPanel();
+        return;
+      }
+    }
     const alertActionButton = event.target.closest("[data-alert-action][data-alert-id]");
     if (alertActionButton && favoriteAlertsApi) {
       const action = alertActionButton.getAttribute("data-alert-action");
@@ -2170,6 +2330,7 @@ const initialize = async () => {
     appState.reports = _payloadReports();
     appState.availableFilters = _availableFilters();
     syncFavoriteAlertState();
+    warmFavoriteAlertNotificationRegistration();
     updateFilterLabels();
     applyControlsFromQueryOrMeta();
     renderPage();

--- a/src/web/weather_page_assets.py
+++ b/src/web/weather_page_assets.py
@@ -10,6 +10,7 @@ ASSET_MIME_TYPES: Dict[str, str] = {
     "assets/css/weather_page.css": "text/css; charset=utf-8",
     "assets/js/compact_daily_summary.js": "application/javascript; charset=utf-8",
     "assets/js/favorites_alerts.js": "application/javascript; charset=utf-8",
+    "assets/js/favorites_alerts_sw.js": "application/javascript; charset=utf-8",
     "assets/js/weather_page.js": "application/javascript; charset=utf-8",
     "assets/css/resort_hourly.css": "text/css; charset=utf-8",
     "assets/js/resort_hourly.js": "application/javascript; charset=utf-8",

--- a/tests/frontend/test_assets.py
+++ b/tests/frontend/test_assets.py
@@ -9,12 +9,14 @@ def test_asset_path_points_to_repo_assets():
     css_path = asset_path("assets/css/weather_page.css")
     compact_js_path = asset_path("assets/js/compact_daily_summary.js")
     favorites_js_path = asset_path("assets/js/favorites_alerts.js")
+    favorites_sw_js_path = asset_path("assets/js/favorites_alerts_sw.js")
     js_path = asset_path("assets/js/weather_page.js")
     hourly_css_path = asset_path("assets/css/resort_hourly.css")
     hourly_js_path = asset_path("assets/js/resort_hourly.js")
     assert str(css_path).endswith("assets/css/weather_page.css")
     assert str(compact_js_path).endswith("assets/js/compact_daily_summary.js")
     assert str(favorites_js_path).endswith("assets/js/favorites_alerts.js")
+    assert str(favorites_sw_js_path).endswith("assets/js/favorites_alerts_sw.js")
     assert str(js_path).endswith("assets/js/weather_page.js")
     assert str(hourly_css_path).endswith("assets/css/resort_hourly.css")
     assert str(hourly_js_path).endswith("assets/js/resort_hourly.js")
@@ -24,24 +26,28 @@ def test_read_asset_bytes_reads_known_assets():
     css = read_asset_bytes("assets/css/weather_page.css")
     compact_js = read_asset_bytes("assets/js/compact_daily_summary.js")
     favorites_js = read_asset_bytes("assets/js/favorites_alerts.js")
+    favorites_sw_js = read_asset_bytes("assets/js/favorites_alerts_sw.js")
     js = read_asset_bytes("assets/js/weather_page.js")
     hourly_css = read_asset_bytes("assets/css/resort_hourly.css")
     hourly_js = read_asset_bytes("assets/js/resort_hourly.js")
     assert len(css) > 100
     assert len(compact_js) > 100
     assert len(favorites_js) > 100
+    assert len(favorites_sw_js) > 50
     assert len(js) > 100
     assert len(hourly_css) > 100
     assert len(hourly_js) > 100
     assert ASSET_MIME_TYPES["assets/css/weather_page.css"].startswith("text/css")
     assert ASSET_MIME_TYPES["assets/js/compact_daily_summary.js"].startswith("application/javascript")
     assert ASSET_MIME_TYPES["assets/js/favorites_alerts.js"].startswith("application/javascript")
+    assert ASSET_MIME_TYPES["assets/js/favorites_alerts_sw.js"].startswith("application/javascript")
     assert ASSET_MIME_TYPES["assets/js/weather_page.js"].startswith("application/javascript")
     assert ASSET_MIME_TYPES["assets/css/resort_hourly.css"].startswith("text/css")
     assert ASSET_MIME_TYPES["assets/js/resort_hourly.js"].startswith("application/javascript")
     css_text = css.decode("utf-8", errors="ignore")
     compact_js_text = compact_js.decode("utf-8", errors="ignore")
     favorites_js_text = favorites_js.decode("utf-8", errors="ignore")
+    favorites_sw_js_text = favorites_sw_js.decode("utf-8", errors="ignore")
     hourly_css_text = hourly_css.decode("utf-8", errors="ignore")
     hourly_js_text = hourly_js.decode("utf-8", errors="ignore")
     js_text = js.decode("utf-8", errors="ignore")
@@ -49,6 +55,7 @@ def test_read_asset_bytes_reads_known_assets():
     assert ".favorite-alerts-panel" in css_text
     assert ".favorite-alert-card" in css_text
     assert ".favorite-alert-rule-select" in css_text
+    assert ".favorite-alert-notification" in css_text
     assert ".hourly-charts" in hourly_css_text
     assert ".resort-local-time" in hourly_css_text
     assert ".resort-timeline-section" in hourly_css_text
@@ -87,12 +94,22 @@ def test_read_asset_bytes_reads_known_assets():
     assert "setResortRule" in favorites_js_text
     assert "read_alert_ids" in favorites_js_text
     assert "dismissed_alert_ids" in favorites_js_text
+    assert "notification_opt_in" in favorites_js_text
+    assert "notified_alert_ids" in favorites_js_text
+    assert "setNotificationOptIn" in favorites_js_text
+    assert "markAlertsNotified" in favorites_js_text
+    assert "notificationclick" in favorites_sw_js_text
+    assert "clients.openWindow" in favorites_sw_js_text
     assert "window.CLOSESNOW_PAGE_BOOTSTRAP" in js_text
     assert "window.CLOSESNOW_FAVORITE_ALERT_STATE" in js_text
     assert "syncFavoriteAlertState();" in js_text
     assert "renderFavoriteAlertsPanel" in js_text
     assert "favorite-alerts-root" in js_text
     assert "favorite-alert-rule-select" in js_text
+    assert "favorite-alert-notification" in js_text
+    assert "Enable notifications" in js_text
+    assert "Notification.requestPermission" in js_text
+    assert "favorites_alerts_sw.js" in js_text
     assert "No resorts match the current filters." in js_text
     assert 'return "Today";' in js_text
     assert "renderHourlyCharts" in hourly_js_text

--- a/tests/integration/test_web_server.py
+++ b/tests/integration/test_web_server.py
@@ -38,6 +38,7 @@ def test_server_api_root_and_asset(monkeypatch):
     asset_bodies = {
         "assets/css/weather_page.css": b"body{}",
         "assets/js/favorites_alerts.js": b"window.CloseSnowFavoritesAlerts={};",
+        "assets/js/favorites_alerts_sw.js": b"self.addEventListener('notificationclick',()=>{});",
     }
     monkeypatch.setattr("src.web.weather_page_server.read_asset_bytes", lambda name: asset_bodies.get(name, b"body{}"))
 
@@ -63,6 +64,8 @@ def test_server_api_root_and_asset(monkeypatch):
         assert asset_with_prefix == b"body{}"
         favorites_asset = urllib.request.urlopen(f"{base}/assets/js/favorites_alerts.js", timeout=3).read()
         assert favorites_asset == b"window.CloseSnowFavoritesAlerts={};"
+        favorites_sw_asset = urllib.request.urlopen(f"{base}/assets/js/favorites_alerts_sw.js", timeout=3).read()
+        assert favorites_sw_asset == b"self.addEventListener('notificationclick',()=>{});"
     finally:
         server.shutdown()
         server.server_close()


### PR DESCRIPTION
## Summary
- add explicit browser notification opt-in controls to the favorites alert inbox
- persist notification opt-in and notified alert ids in the existing local alert state
- register a lightweight service worker for notification click handling with clean fallback to inbox-only delivery

## Validation
- python3 -m pytest -q tests/frontend/test_assets.py tests/frontend/test_renderers.py tests/frontend/test_static_site_pipeline.py tests/integration/test_web_server.py
- python3 -m src.cli static --output-dir /tmp/closesnow-favorites-alert-notify --max-workers 8