### PR TITLE
Unify homepage sticky tables

### DIFF
--- a/assets/css/weather_page.css
+++ b/assets/css/weather_page.css
@@ -899,6 +899,27 @@
       overflow: hidden;
       text-overflow: ellipsis;
     }
+    .mobile-precip-resort-content {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      min-width: 0;
+    }
+    .mobile-precip-resort-content .resort-cell {
+      flex: 1 1 auto;
+      min-width: 0;
+    }
+    .mobile-precip-resort-head {
+      text-align: left;
+    }
+    .mobile-precip-resort-head .favorite-btn,
+    .mobile-precip-resort-cell .favorite-btn {
+      flex: 0 0 auto;
+      margin: 0;
+    }
+    .mobile-precip-resort-label {
+      min-width: 0;
+    }
     .snowfall-sticky-table .query-col {
       max-width: var(--snowfall-query-w);
     }
@@ -1150,6 +1171,7 @@
     }
     body.mobile-simple {
       --mobile-leading-col-max: max(0px, calc(50vw - 28px));
+      --mobile-single-leading-col-max: 50vw;
     }
     body.mobile-simple .plain-table {
       min-width: 0;
@@ -1166,11 +1188,35 @@
     body.mobile-simple .snowfall-left-table .query-col {
       max-width: min(var(--query-col-w), var(--mobile-leading-col-max));
     }
+    body.mobile-simple .snowfall-sticky-wrap.mobile-only .snowfall-sticky-table col.col-query {
+      width: min(var(--snowfall-query-w), var(--mobile-single-leading-col-max));
+    }
+    body.mobile-simple .snowfall-sticky-wrap.mobile-only .snowfall-sticky-table .query-col {
+      max-width: min(var(--snowfall-query-w), var(--mobile-single-leading-col-max));
+    }
+    body.mobile-simple .snowfall-sticky-wrap.mobile-only .snowfall-sticky-table col.col-week {
+      width: 92px;
+    }
+    body.mobile-simple .snowfall-sticky-wrap.mobile-only .snowfall-sticky-table col.col-day {
+      width: 62px;
+    }
     body.mobile-simple .rain-left-table col.col-query {
       width: min(var(--rain-query-w), var(--mobile-leading-col-max));
     }
     body.mobile-simple .rain-left-table .query-col {
       max-width: min(var(--rain-query-w), var(--mobile-leading-col-max));
+    }
+    body.mobile-simple .rain-sticky-wrap.mobile-only .rain-sticky-table col.col-query {
+      width: min(var(--rain-query-w), var(--mobile-single-leading-col-max));
+    }
+    body.mobile-simple .rain-sticky-wrap.mobile-only .rain-sticky-table .query-col {
+      max-width: min(var(--rain-query-w), var(--mobile-single-leading-col-max));
+    }
+    body.mobile-simple .rain-sticky-wrap.mobile-only .rain-sticky-table col.col-week {
+      width: 92px;
+    }
+    body.mobile-simple .rain-sticky-wrap.mobile-only .rain-sticky-table col.col-day {
+      width: 62px;
     }
     body.mobile-simple .temperature-single-table col.col-query {
       width: min(var(--temp-query-w), var(--mobile-leading-col-max));

--- a/assets/css/weather_page.css
+++ b/assets/css/weather_page.css
@@ -528,8 +528,7 @@
     .snowfall-right-wrap,
     .rain-left-wrap,
     .rain-right-wrap,
-    .temperature-left-wrap,
-    .temperature-right-wrap,
+    .temperature-sticky-wrap,
     .sun-left-wrap,
     .sun-right-wrap {
       -webkit-overflow-scrolling: touch;
@@ -999,55 +998,30 @@
     .rain-left-table td, .rain-right-table td {
       background-clip: padding-box;
     }
-    .temperature-split-wrap {
-      display: flex;
+    .temperature-sticky-wrap {
+      margin-top: 8px;
       border: 1px solid #d1d5db;
       border-radius: 10px;
       background: #fff;
       box-shadow: 0 6px 24px rgba(0,0,0,0.06);
-      overflow: hidden;
-      --temp-header-row1-h: 32px;
-    }
-    .temperature-left-wrap {
-      flex: 0 0 auto;
-      background: #fff;
-      overflow: hidden;
+      overflow: auto;
       --temp-query-w: 220px;
     }
-    .temperature-right-wrap {
-      flex: 1 1 auto;
-      overflow: auto;
-    }
-    .temperature-left-table,
-    .temperature-right-table {
+    .temperature-single-table {
       table-layout: fixed;
-      width: auto;
-      min-width: 0;
+      width: max-content;
+      min-width: 100%;
     }
-    .temperature-left-table col.col-favorite {
+    .temperature-single-table col.col-favorite {
       width: 28px;
     }
-    .temperature-left-table col.col-query {
+    .temperature-single-table col.col-query {
       width: var(--temp-query-w);
     }
-    .temperature-right-table col.col-temp {
+    .temperature-single-table col.col-temp {
       width: 50px;
     }
-    .temperature-left-table thead tr:first-child th,
-    .temperature-right-table thead tr:first-child th {
-      position: sticky;
-      top: 0;
-      z-index: 5;
-      background: #e5e7eb;
-    }
-    .temperature-left-table thead tr:nth-child(2) th,
-    .temperature-right-table thead tr:nth-child(2) th {
-      position: sticky;
-      top: var(--temp-header-row1-h);
-      z-index: 5;
-      background: #e5e7eb;
-    }
-    .temperature-left-table .query-col {
+    .temperature-single-table .query-col {
       text-align: left;
       font-weight: 600;
       background: #fff;
@@ -1055,8 +1029,7 @@
       overflow: hidden;
       text-overflow: ellipsis;
     }
-    .temperature-left-table td,
-    .temperature-right-table td {
+    .temperature-single-table td {
       background-clip: padding-box;
     }
     .sun-split-wrap {
@@ -1168,10 +1141,10 @@
     body.mobile-simple .rain-left-table .query-col {
       max-width: min(var(--rain-query-w), var(--mobile-leading-col-max));
     }
-    body.mobile-simple .temperature-left-table col.col-query {
+    body.mobile-simple .temperature-single-table col.col-query {
       width: min(var(--temp-query-w), var(--mobile-leading-col-max));
     }
-    body.mobile-simple .temperature-left-table .query-col {
+    body.mobile-simple .temperature-single-table .query-col {
       max-width: min(var(--temp-query-w), var(--mobile-leading-col-max));
     }
     body.mobile-simple .weather-left-table col.col-query {

--- a/assets/css/weather_page.css
+++ b/assets/css/weather_page.css
@@ -521,6 +521,7 @@
     .compact-grid-left-wrap,
     .compact-grid-right-wrap,
     .sticky-single-table-wrap,
+    .weather-table-wrap,
     .weather-left-wrap,
     .weather-right-wrap,
     .snowfall-left-wrap,
@@ -740,6 +741,55 @@
     }
     .mobile-only {
       display: none;
+    }
+    .weather-table-wrap {
+      margin-top: 8px;
+      border: 1px solid #d1d5db;
+      border-radius: 10px;
+      background: #fff;
+      box-shadow: 0 6px 24px rgba(0,0,0,0.06);
+      overflow: auto;
+      --weather-query-w: 220px;
+    }
+    .weather-table {
+      table-layout: fixed;
+      width: max-content;
+      min-width: 100%;
+    }
+    .weather-table col.col-favorite {
+      width: 28px;
+    }
+    .weather-table col.col-query {
+      width: var(--weather-query-w);
+    }
+    .weather-table col.col-weather {
+      width: 68px;
+    }
+    .weather-table .favorite-col,
+    .weather-table .favorite-head {
+      width: 28px;
+      min-width: 28px;
+      padding-left: 0;
+      padding-right: 0;
+    }
+    .weather-table .query-col {
+      text-align: left;
+      font-weight: 600;
+      background: #fff;
+      max-width: var(--weather-query-w);
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .weather-table thead .query-col {
+      background: #e5e7eb;
+    }
+    .weather-table td {
+      background-clip: padding-box;
+    }
+    .weather-table td.weather-emoji-cell {
+      text-align: center;
+      font-size: 18px;
+      line-height: 1;
     }
     .weather-split-wrap {
       display: flex;

--- a/assets/css/weather_page.css
+++ b/assets/css/weather_page.css
@@ -523,8 +523,10 @@
     .sticky-single-table-wrap,
     .weather-left-wrap,
     .weather-right-wrap,
+    .snowfall-sticky-wrap,
     .snowfall-left-wrap,
     .snowfall-right-wrap,
+    .rain-sticky-wrap,
     .rain-left-wrap,
     .rain-right-wrap,
     .temperature-left-wrap,
@@ -805,6 +807,63 @@
       text-align: center;
       font-size: 18px;
       line-height: 1;
+    }
+    .snowfall-sticky-wrap,
+    .rain-sticky-wrap {
+      border: 1px solid #d1d5db;
+      border-radius: 10px;
+      background: #fff;
+      box-shadow: 0 6px 24px rgba(0,0,0,0.06);
+      overflow: auto;
+    }
+    .snowfall-sticky-wrap {
+      --snowfall-query-w: 220px;
+      --snowfall-week-w: 110px;
+    }
+    .rain-sticky-wrap {
+      --rain-query-w: 220px;
+      --rain-week-w: 110px;
+    }
+    .snowfall-sticky-table col.col-favorite,
+    .rain-sticky-table col.col-favorite {
+      width: 28px;
+    }
+    .snowfall-sticky-table col.col-query {
+      width: var(--snowfall-query-w);
+    }
+    .rain-sticky-table col.col-query {
+      width: var(--rain-query-w);
+    }
+    .snowfall-sticky-table col.col-week {
+      width: var(--snowfall-week-w);
+    }
+    .rain-sticky-table col.col-week {
+      width: var(--rain-week-w);
+    }
+    .snowfall-sticky-table col.col-day,
+    .rain-sticky-table col.col-day {
+      width: 66px;
+    }
+    .snowfall-sticky-table .query-col,
+    .rain-sticky-table .query-col {
+      text-align: left;
+      font-weight: 600;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .snowfall-sticky-table .query-col {
+      max-width: var(--snowfall-query-w);
+    }
+    .rain-sticky-table .query-col {
+      max-width: var(--rain-query-w);
+    }
+    .snowfall-sticky-table .week-col-cell,
+    .rain-sticky-table .week-col-cell {
+      text-align: center;
+    }
+    .snowfall-sticky-table td,
+    .rain-sticky-table td {
+      background-clip: padding-box;
     }
     .snowfall-split-wrap {
       display: flex;

--- a/assets/css/weather_page.css
+++ b/assets/css/weather_page.css
@@ -520,6 +520,7 @@
     .compact-grid-mobile-wrap,
     .compact-grid-left-wrap,
     .compact-grid-right-wrap,
+    .sticky-single-table-wrap,
     .weather-left-wrap,
     .weather-right-wrap,
     .snowfall-left-wrap,
@@ -531,6 +532,34 @@
     .sun-left-wrap,
     .sun-right-wrap {
       -webkit-overflow-scrolling: touch;
+    }
+    .sticky-single-table-wrap {
+      overflow: auto;
+    }
+    .sticky-single-table {
+      table-layout: fixed;
+      width: max-content;
+      min-width: 100%;
+    }
+    .sticky-single-table thead th {
+      position: sticky;
+      top: 0;
+      z-index: 5;
+      background: #e5e7eb;
+    }
+    .sticky-single-table[data-sticky-header-rows="2"] thead tr:nth-child(2) th {
+      top: var(--sticky-header-row-2-top, 32px);
+    }
+    .sticky-single-table .sticky-leading-cell {
+      position: sticky;
+      left: var(--sticky-leading-left, 0px);
+      z-index: 6;
+      background: #fff;
+      background-clip: padding-box;
+    }
+    .sticky-single-table thead .sticky-leading-cell {
+      z-index: 8;
+      background: #e5e7eb;
     }
     .compact-grid-mobile-table {
       table-layout: fixed;
@@ -584,9 +613,6 @@
       text-align: left;
     }
     .compact-grid-mobile-table .query-col {
-      position: sticky;
-      left: 28px;
-      z-index: 6;
       text-align: left;
       font-weight: 600;
       background: #fff;
@@ -628,12 +654,6 @@
     }
     .compact-grid-mobile-table .favorite-col,
     .compact-grid-mobile-table .favorite-head {
-      position: sticky;
-      left: 0;
-      z-index: 7;
-    }
-    .compact-grid-mobile-table thead .favorite-head {
-      z-index: 9;
     }
     .compact-day-cell {
       padding: 5px 8px;

--- a/assets/css/weather_page.css
+++ b/assets/css/weather_page.css
@@ -529,8 +529,7 @@
     .rain-right-wrap,
     .temperature-left-wrap,
     .temperature-right-wrap,
-    .sun-left-wrap,
-    .sun-right-wrap {
+    .sun-single-wrap {
       -webkit-overflow-scrolling: touch;
     }
     .sticky-single-table-wrap {
@@ -1009,55 +1008,29 @@
     .temperature-right-table td {
       background-clip: padding-box;
     }
-    .sun-split-wrap {
-      display: flex;
+    .sun-single-wrap {
       border: 1px solid #d1d5db;
       border-radius: 10px;
       background: #fff;
       box-shadow: 0 6px 24px rgba(0,0,0,0.06);
-      overflow: hidden;
-      --sun-header-row1-h: 32px;
-    }
-    .sun-left-wrap {
-      flex: 0 0 auto;
-      background: #fff;
-      overflow: hidden;
+      overflow: auto;
       --sun-query-w: 220px;
     }
-    .sun-right-wrap {
-      flex: 1 1 auto;
-      overflow: auto;
-    }
-    .sun-left-table,
-    .sun-right-table {
+    .sun-single-table {
       table-layout: fixed;
-      width: auto;
-      min-width: 0;
+      width: max-content;
+      min-width: 100%;
     }
-    .sun-left-table col.col-favorite {
+    .sun-single-table col.col-favorite {
       width: 28px;
     }
-    .sun-left-table col.col-query {
+    .sun-single-table col.col-query {
       width: var(--sun-query-w);
     }
-    .sun-right-table col.col-sun {
+    .sun-single-table col.col-sun {
       width: 58px;
     }
-    .sun-left-table thead tr:first-child th,
-    .sun-right-table thead tr:first-child th {
-      position: sticky;
-      top: 0;
-      z-index: 5;
-      background: #e5e7eb;
-    }
-    .sun-left-table thead tr:nth-child(2) th,
-    .sun-right-table thead tr:nth-child(2) th {
-      position: sticky;
-      top: var(--sun-header-row1-h);
-      z-index: 5;
-      background: #e5e7eb;
-    }
-    .sun-left-table .query-col {
+    .sun-single-table .query-col {
       text-align: left;
       font-weight: 600;
       background: #fff;
@@ -1065,11 +1038,10 @@
       overflow: hidden;
       text-overflow: ellipsis;
     }
-    .sun-left-table td,
-    .sun-right-table td {
+    .sun-single-table td {
       background-clip: padding-box;
     }
-    .sun-right-table td {
+    .sun-single-table td[data-sun-time-raw] {
       text-align: center;
     }
     body.mobile-simple .desktop-only {
@@ -1130,10 +1102,10 @@
     body.mobile-simple .weather-left-table .query-col {
       max-width: min(var(--weather-query-w), var(--mobile-leading-col-max));
     }
-    body.mobile-simple .sun-left-table col.col-query {
+    body.mobile-simple .sun-single-table col.col-query {
       width: min(var(--sun-query-w), var(--mobile-leading-col-max));
     }
-    body.mobile-simple .sun-left-table .query-col {
+    body.mobile-simple .sun-single-table .query-col {
       max-width: min(var(--sun-query-w), var(--mobile-leading-col-max));
     }
   

--- a/assets/css/weather_page.css
+++ b/assets/css/weather_page.css
@@ -522,8 +522,6 @@
     .compact-grid-right-wrap,
     .sticky-single-table-wrap,
     .weather-table-wrap,
-    .weather-left-wrap,
-    .weather-right-wrap,
     .snowfall-sticky-wrap,
     .snowfall-left-wrap,
     .snowfall-right-wrap,
@@ -787,71 +785,6 @@
       background-clip: padding-box;
     }
     .weather-table td.weather-emoji-cell {
-      text-align: center;
-      font-size: 18px;
-      line-height: 1;
-    }
-    .weather-split-wrap {
-      display: flex;
-      border: 1px solid #d1d5db;
-      border-radius: 10px;
-      background: #fff;
-      box-shadow: 0 6px 24px rgba(0,0,0,0.06);
-      overflow: hidden;
-      --weather-header-row1-h: 32px;
-    }
-    .weather-left-wrap {
-      flex: 0 0 auto;
-      background: #fff;
-      overflow: hidden;
-      --weather-query-w: 220px;
-    }
-    .weather-right-wrap {
-      flex: 1 1 auto;
-      overflow: auto;
-    }
-    .weather-left-table,
-    .weather-right-table {
-      table-layout: fixed;
-      width: auto;
-      min-width: 0;
-    }
-    .weather-left-table col.col-favorite {
-      width: 28px;
-    }
-    .weather-left-table col.col-query {
-      width: var(--weather-query-w);
-    }
-    .weather-right-table col.col-weather {
-      width: 68px;
-    }
-    .weather-left-table thead tr:first-child th,
-    .weather-right-table thead tr:first-child th {
-      position: sticky;
-      top: 0;
-      z-index: 5;
-      background: #e5e7eb;
-    }
-    .weather-left-table thead tr:nth-child(2) th,
-    .weather-right-table thead tr:nth-child(2) th {
-      position: sticky;
-      top: var(--weather-header-row1-h);
-      z-index: 5;
-      background: #e5e7eb;
-    }
-    .weather-left-table .query-col {
-      text-align: left;
-      font-weight: 600;
-      background: #fff;
-      max-width: var(--weather-query-w);
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-    .weather-left-table td,
-    .weather-right-table td {
-      background-clip: padding-box;
-    }
-    .weather-right-table td.weather-emoji-cell {
       text-align: center;
       font-size: 18px;
       line-height: 1;
@@ -1224,10 +1157,10 @@
     body.mobile-simple .temperature-single-table .query-col {
       max-width: min(var(--temp-query-w), var(--mobile-leading-col-max));
     }
-    body.mobile-simple .weather-left-table col.col-query {
+    body.mobile-simple .weather-table col.col-query {
       width: min(var(--weather-query-w), var(--mobile-leading-col-max));
     }
-    body.mobile-simple .weather-left-table .query-col {
+    body.mobile-simple .weather-table .query-col {
       max-width: min(var(--weather-query-w), var(--mobile-leading-col-max));
     }
     body.mobile-simple .sun-single-table col.col-query {

--- a/assets/js/sticky_single_table_layout.js
+++ b/assets/js/sticky_single_table_layout.js
@@ -71,6 +71,24 @@
     });
   };
 
+  const _stickyColumnWidth = (rowCellMaps, columnIndex) => {
+    const exactCell = rowCellMaps
+      .map((visualCells) => visualCells[columnIndex])
+      .find((cell) => cell && Math.max(1, Number.parseInt(String(cell.colSpan || 1), 10) || 1) === 1);
+    if (exactCell) {
+      return exactCell.getBoundingClientRect?.().width || exactCell.offsetWidth || 0;
+    }
+
+    const spanningCell = rowCellMaps
+      .map((visualCells) => visualCells[columnIndex])
+      .find(Boolean);
+    if (!spanningCell) return 0;
+
+    const span = Math.max(1, Number.parseInt(String(spanningCell.colSpan || 1), 10) || 1);
+    const totalWidth = spanningCell.getBoundingClientRect?.().width || spanningCell.offsetWidth || 0;
+    return totalWidth / span;
+  };
+
   const _applyStickyLeadingColumns = (table, requestedColumns) => {
     _clearStickyLeadingCells(table);
 
@@ -83,13 +101,14 @@
     const allRows = headRows.concat(bodyRows);
     if (allRows.length <= 0) return;
     const rowCellMaps = _rowCellMapsByVisualColumn(allRows);
+    const positionedCells = new WeakSet();
     let runningLeft = 0;
     for (let colIndex = 0; colIndex < leadingColumns; colIndex += 1) {
-      const sampleCell = rowCellMaps.map((visualCells) => visualCells[colIndex]).find(Boolean);
-      const width = sampleCell?.getBoundingClientRect?.().width || sampleCell?.offsetWidth || 0;
+      const width = _stickyColumnWidth(rowCellMaps, colIndex);
       allRows.forEach((row, rowIndex) => {
         const cell = rowCellMaps[rowIndex]?.[colIndex];
-        if (!cell) return;
+        if (!cell || positionedCells.has(cell)) return;
+        positionedCells.add(cell);
         cell.classList.add("sticky-leading-cell");
         cell.style.setProperty("--sticky-leading-left", `${runningLeft}px`);
         cell.style.left = `${runningLeft}px`;

--- a/assets/js/sticky_single_table_layout.js
+++ b/assets/js/sticky_single_table_layout.js
@@ -44,6 +44,33 @@
     }
   };
 
+  const _rowCellMapsByVisualColumn = (rows) => {
+    const pendingRowspans = [];
+    return rows.map((row) => {
+      const visualCells = [];
+      let visualCol = 0;
+      Array.from(row.cells || []).forEach((cell) => {
+        while ((pendingRowspans[visualCol] || 0) > 0) {
+          visualCol += 1;
+        }
+        const colSpan = Math.max(1, Number.parseInt(String(cell.colSpan || 1), 10) || 1);
+        const rowSpan = Math.max(1, Number.parseInt(String(cell.rowSpan || 1), 10) || 1);
+        for (let spanOffset = 0; spanOffset < colSpan; spanOffset += 1) {
+          const targetCol = visualCol + spanOffset;
+          visualCells[targetCol] = cell;
+          if (rowSpan > 1) pendingRowspans[targetCol] = rowSpan;
+        }
+        visualCol += colSpan;
+      });
+      for (let col = 0; col < pendingRowspans.length; col += 1) {
+        if ((pendingRowspans[col] || 0) > 0) {
+          pendingRowspans[col] -= 1;
+        }
+      }
+      return visualCells;
+    });
+  };
+
   const _applyStickyLeadingColumns = (table, requestedColumns) => {
     _clearStickyLeadingCells(table);
 
@@ -53,16 +80,15 @@
 
     const headRows = Array.from(table.tHead?.rows || []);
     const bodyRows = Array.from(table.tBodies[0]?.rows || []);
-    const sampleRow = headRows[headRows.length - 1] || bodyRows[0];
-    if (!sampleRow) return;
-
     const allRows = headRows.concat(bodyRows);
+    if (allRows.length <= 0) return;
+    const rowCellMaps = _rowCellMapsByVisualColumn(allRows);
     let runningLeft = 0;
     for (let colIndex = 0; colIndex < leadingColumns; colIndex += 1) {
-      const sampleCell = sampleRow.cells[colIndex] || allRows.find((row) => row.cells[colIndex])?.cells[colIndex];
+      const sampleCell = rowCellMaps.map((visualCells) => visualCells[colIndex]).find(Boolean);
       const width = sampleCell?.getBoundingClientRect?.().width || sampleCell?.offsetWidth || 0;
-      allRows.forEach((row) => {
-        const cell = row.cells[colIndex];
+      allRows.forEach((row, rowIndex) => {
+        const cell = rowCellMaps[rowIndex]?.[colIndex];
         if (!cell) return;
         cell.classList.add("sticky-leading-cell");
         cell.style.setProperty("--sticky-leading-left", `${runningLeft}px`);

--- a/assets/js/sticky_single_table_layout.js
+++ b/assets/js/sticky_single_table_layout.js
@@ -1,0 +1,124 @@
+(function () {
+  const STICKY_VIEWPORT_ROW_CAP = 10;
+
+  const _asPositiveInt = (value, fallback) => {
+    const parsed = Number.parseInt(String(value ?? ""), 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+    return parsed;
+  };
+
+  const _headerRows = (table, requestedRows) => {
+    const rows = Array.from(table.tHead?.rows || []);
+    const maxRows = rows.length > 0 ? Math.min(2, rows.length) : 1;
+    return Math.max(1, Math.min(_asPositiveInt(requestedRows, 1), maxRows));
+  };
+
+  const _leadingStickyColumns = (table, requestedColumns) => {
+    const headRows = Array.from(table.tHead?.rows || []);
+    const lastHeadRow = headRows[headRows.length - 1];
+    const bodyRow = table.tBodies[0]?.rows?.[0];
+    const maxColumns = bodyRow?.cells?.length || lastHeadRow?.cells?.length || 0;
+    if (maxColumns <= 0) return 0;
+    return Math.max(0, Math.min(_asPositiveInt(requestedColumns, 0), maxColumns));
+  };
+
+  const _clearStickyLeadingCells = (table) => {
+    table.querySelectorAll(".sticky-leading-cell").forEach((cell) => {
+      cell.classList.remove("sticky-leading-cell");
+      cell.style.removeProperty("--sticky-leading-left");
+      cell.style.removeProperty("left");
+      cell.style.removeProperty("z-index");
+    });
+  };
+
+  const _applyStickyHeaders = (table, requestedRows) => {
+    const headerRows = _headerRows(table, requestedRows);
+    table.dataset.stickyHeaderRows = String(headerRows);
+    table.style.removeProperty("--sticky-header-row-2-top");
+    if (headerRows < 2) return;
+
+    const firstRow = table.tHead?.rows?.[0];
+    const firstHeight = firstRow?.getBoundingClientRect?.().height || firstRow?.offsetHeight || 0;
+    if (firstHeight > 0) {
+      table.style.setProperty("--sticky-header-row-2-top", `${Math.ceil(firstHeight)}px`);
+    }
+  };
+
+  const _applyStickyLeadingColumns = (table, requestedColumns) => {
+    _clearStickyLeadingCells(table);
+
+    const leadingColumns = _leadingStickyColumns(table, requestedColumns);
+    table.dataset.stickyLeadingCols = String(leadingColumns);
+    if (leadingColumns <= 0) return;
+
+    const headRows = Array.from(table.tHead?.rows || []);
+    const bodyRows = Array.from(table.tBodies[0]?.rows || []);
+    const sampleRow = headRows[headRows.length - 1] || bodyRows[0];
+    if (!sampleRow) return;
+
+    const allRows = headRows.concat(bodyRows);
+    let runningLeft = 0;
+    for (let colIndex = 0; colIndex < leadingColumns; colIndex += 1) {
+      const sampleCell = sampleRow.cells[colIndex] || allRows.find((row) => row.cells[colIndex])?.cells[colIndex];
+      const width = sampleCell?.getBoundingClientRect?.().width || sampleCell?.offsetWidth || 0;
+      allRows.forEach((row) => {
+        const cell = row.cells[colIndex];
+        if (!cell) return;
+        cell.classList.add("sticky-leading-cell");
+        cell.style.setProperty("--sticky-leading-left", `${runningLeft}px`);
+        cell.style.left = `${runningLeft}px`;
+        const baseLayer = row.parentElement?.tagName === "THEAD" ? 8 : 6;
+        cell.style.zIndex = String(baseLayer + Math.max(0, leadingColumns - colIndex));
+      });
+      runningLeft += Math.ceil(width);
+    }
+  };
+
+  const _applyViewportCap = (wrap, table, requestedRows) => {
+    wrap.style.removeProperty("max-height");
+    const bodyRows = Array.from(table.tBodies[0]?.rows || []);
+    if (bodyRows.length <= 0) return;
+
+    const configuredRows = _asPositiveInt(requestedRows, STICKY_VIEWPORT_ROW_CAP);
+    const visibleRows = Math.min(configuredRows, STICKY_VIEWPORT_ROW_CAP, bodyRows.length);
+    const headRows = Array.from(table.tHead?.rows || []);
+    const headerHeight = headRows.reduce((sum, row) => sum + (row.getBoundingClientRect?.().height || row.offsetHeight || 0), 0);
+    const bodyHeight = bodyRows.slice(0, visibleRows)
+      .reduce((sum, row) => sum + (row.getBoundingClientRect?.().height || row.offsetHeight || 0), 0);
+    const total = Math.ceil(headerHeight + bodyHeight);
+    if (total > 0) {
+      wrap.style.maxHeight = `${total}px`;
+    }
+  };
+
+  const _sectionContracts = (root) => Array.from(root.querySelectorAll("[data-sticky-single-table-section]"))
+    .map((wrap) => {
+      const table = wrap.querySelector("table");
+      if (!table) return null;
+      return {
+        wrap,
+        table,
+        leadingStickyColumns: wrap.dataset.stickyLeadingCols,
+        stickyHeaderRows: wrap.dataset.stickyHeaderRows,
+        maxVisibleRows: wrap.dataset.stickyMaxVisibleRows,
+      };
+    })
+    .filter(Boolean);
+
+  const applyFromDom = ({ root = document } = {}) => {
+    const contracts = _sectionContracts(root);
+    contracts.forEach(({ wrap, table, leadingStickyColumns, stickyHeaderRows, maxVisibleRows }) => {
+      wrap.classList.add("sticky-single-table-wrap");
+      table.classList.add("sticky-single-table");
+      _applyStickyHeaders(table, stickyHeaderRows);
+      _applyStickyLeadingColumns(table, leadingStickyColumns);
+      _applyViewportCap(wrap, table, maxVisibleRows);
+    });
+    return contracts.length;
+  };
+
+  window.CloseSnowStickySingleTableLayout = {
+    STICKY_VIEWPORT_ROW_CAP,
+    applyFromDom,
+  };
+}());

--- a/assets/js/weather_page.js
+++ b/assets/js/weather_page.js
@@ -450,8 +450,7 @@ const _renderTemperatureSection = (reports, emptyMessage = "No resorts match the
   const labels = reports.length
     ? Array.from({ length: displayDays }, (_, idx) => _dayLabelFor(reports[0], idx))
     : _fallbackDayLabels(displayDays);
-  const leftRows = reports.length ? reports.map((report) => `<tr${_filterAttrs(report)}>${_resortCellHtml(report)}</tr>`).join("") : _emptyStateRow(2, emptyMessage);
-  const rightRows = reports.length ? reports.map((report) => {
+  const rows = reports.length ? reports.map((report) => {
     const attrs = _filterAttrs(report);
     const cells = Array.from({ length: displayDays }, (_, idx) => {
       const day = _dailyAt(report, idx);
@@ -460,8 +459,8 @@ const _renderTemperatureSection = (reports, emptyMessage = "No resorts match the
         _metricCellHtml(_formatTemp(day.temperature_max_c), "temp", _tempColor(day.temperature_max_c)),
       ].join("");
     }).join("");
-    return `<tr${attrs}>${cells}</tr>`;
-  }).join("") : _emptyStateRow(Math.max(1, displayDays * 2), emptyMessage);
+    return `<tr${attrs}>${_resortCellHtml(report)}${cells}</tr>`;
+  }).join("") : _emptyStateRow(2 + Math.max(1, displayDays * 2), emptyMessage);
   return `
     <section>
       <div class="section-header">
@@ -471,21 +470,19 @@ const _renderTemperatureSection = (reports, emptyMessage = "No resorts match the
           <button type="button" class="unit-btn" data-unit-mode="imperial">°F</button>
         </div>
       </div>
-      <div class="temperature-split-wrap">
-        <div class="temperature-left-wrap" id="temperature-left-wrap">
-          <table class="temperature-left-table" id="temperature-left-table">
-            <colgroup><col class="col-favorite"><col class="col-query"></colgroup>
-            <thead><tr><th rowspan='2' class='favorite-col favorite-head'>${_favoriteAllButtonHtml(reports)}</th><th rowspan='2' class='query-col'>Resort</th></tr><tr></tr></thead>
-            <tbody>${leftRows}</tbody>
-          </table>
-        </div>
-        <div class="temperature-right-wrap" id="temperature-right-wrap">
-          <table class="temperature-right-table" id="temperature-right-table">
-            <colgroup>${Array.from({ length: displayDays * 2 }, () => "<col class='col-temp'>").join("")}</colgroup>
-            <thead><tr>${labels.map((label) => `<th colspan='2'>${_dayLabelHtml(label)}</th>`).join("")}</tr><tr>${Array.from({ length: displayDays }, () => "<th>min</th><th>max</th>").join("")}</tr></thead>
-            <tbody>${rightRows}</tbody>
-          </table>
-        </div>
+      <div
+        class="temperature-sticky-wrap"
+        id="temperature-sticky-wrap"
+        data-sticky-single-table-section="${STICKY_SINGLE_TABLE_SECTION_KEYS.temperature}"
+        data-sticky-leading-cols="2"
+        data-sticky-header-rows="2"
+        data-sticky-max-visible-rows="10"
+      >
+        <table class="temperature-single-table" id="temperature-single-table">
+          <colgroup><col class="col-favorite"><col class="col-query">${Array.from({ length: displayDays * 2 }, () => "<col class='col-temp'>").join("")}</colgroup>
+          <thead><tr><th rowspan='2' class='favorite-col favorite-head'>${_favoriteAllButtonHtml(reports)}</th><th rowspan='2' class='query-col'>Resort</th>${labels.map((label) => `<th colspan='2'>${_dayLabelHtml(label)}</th>`).join("")}</tr><tr>${Array.from({ length: displayDays }, () => "<th>min</th><th>max</th>").join("")}</tr></thead>
+          <tbody>${rows}</tbody>
+        </table>
       </div>
     </section>`;
 };
@@ -1330,7 +1327,6 @@ const attachSplitScrollSync = () => {
     [".snowfall-left-wrap#snowfall-left-wrap-mobile", ".snowfall-right-wrap#snowfall-right-wrap-mobile"],
     [".rain-left-wrap#rain-left-wrap", ".rain-right-wrap#rain-right-wrap"],
     [".rain-left-wrap#rain-left-wrap-mobile", ".rain-right-wrap#rain-right-wrap-mobile"],
-    [".temperature-left-wrap", ".temperature-right-wrap"],
     [".weather-left-wrap", ".weather-right-wrap"],
     [".sun-left-wrap", ".sun-right-wrap"],
   ].forEach(([leftSelector, rightSelector]) => {
@@ -1375,6 +1371,14 @@ const autoSizeSplitTables = () => {
     padding: isCompactLayout() ? 22 : 28,
     capToMobileHalfScreen: isCompactLayout(),
   });
+  _autoSizeQueryOnly({
+    tableSelector: ".temperature-sticky-wrap .temperature-single-table",
+    wrapSelector: ".temperature-sticky-wrap",
+    queryVarName: "--temp-query-w",
+    minWidth: 150,
+    maxWidth: 220,
+    capToMobileHalfScreen: isCompactLayout(),
+  });
   if (isCompactLayout()) {
     _autoSizeMobileQueryColumn({
       tableSelector: ".snowfall-left-wrap#snowfall-left-wrap-mobile .snowfall-left-table",
@@ -1407,14 +1411,6 @@ const autoSizeSplitTables = () => {
       daySelector: "col.col-day",
       minWeekWidth: 92,
       minDayWidth: 62,
-    });
-    _autoSizeQueryOnly({
-      tableSelector: ".temperature-left-wrap .temperature-left-table",
-      wrapSelector: ".temperature-left-wrap",
-      queryVarName: "--temp-query-w",
-      minWidth: 150,
-      maxWidth: 220,
-      capToMobileHalfScreen: true,
     });
     _autoSizeQueryOnly({
       tableSelector: ".weather-left-wrap .weather-left-table",
@@ -1459,20 +1455,9 @@ const autoSizeSplitTables = () => {
     minWidth: 66,
   });
   _autoSizeQueryOnly({
-    tableSelector: ".temperature-left-wrap .temperature-left-table",
-    wrapSelector: ".temperature-left-wrap",
-    queryVarName: "--temp-query-w",
-  });
-  _autoSizeQueryOnly({
     tableSelector: ".weather-table-wrap .weather-table",
     wrapSelector: ".weather-table-wrap",
     queryVarName: "--weather-query-w",
-  });
-  _stretchColumnsToWrap({
-    wrapSelector: ".temperature-right-wrap",
-    tableSelector: ".temperature-right-table",
-    colSelector: "col.col-temp",
-    minWidth: 50,
   });
   _autoSizeQueryOnly({
     tableSelector: ".sun-left-wrap .sun-left-table",
@@ -1522,14 +1507,12 @@ const syncSplitTableHeights = () => {
     ? [
       [".snowfall-left-wrap#snowfall-left-wrap-mobile .snowfall-left-table", ".snowfall-right-wrap#snowfall-right-wrap-mobile .snowfall-right-table", ".snowfall-split-wrap.mobile-only", "--snow-header-row1-h"],
       [".rain-left-wrap#rain-left-wrap-mobile .rain-left-table", ".rain-right-wrap#rain-right-wrap-mobile .rain-right-table", ".rain-split-wrap.mobile-only", "--rain-header-row1-h"],
-      [".temperature-left-table", ".temperature-right-table", ".temperature-split-wrap", "--temp-header-row1-h"],
       [".weather-left-table", ".weather-right-table", ".weather-split-wrap", "--weather-header-row1-h"],
       [".sun-left-table", ".sun-right-table", ".sun-split-wrap", "--sun-header-row1-h"],
     ]
     : [
       [".snowfall-left-wrap#snowfall-left-wrap .snowfall-left-table", ".snowfall-right-wrap#snowfall-right-wrap .snowfall-right-table", ".snowfall-split-wrap.desktop-only", "--snow-header-row1-h"],
       [".rain-left-wrap#rain-left-wrap .rain-left-table", ".rain-right-wrap#rain-right-wrap .rain-right-table", ".rain-split-wrap.desktop-only", "--rain-header-row1-h"],
-      [".temperature-left-table", ".temperature-right-table", ".temperature-split-wrap", "--temp-header-row1-h"],
       [".weather-left-table", ".weather-right-table", ".weather-split-wrap", "--weather-header-row1-h"],
       [".sun-left-table", ".sun-right-table", ".sun-split-wrap", "--sun-header-row1-h"],
     ];
@@ -1588,8 +1571,7 @@ const observeLayoutContainers = () => {
     ".rain-left-wrap#rain-left-wrap-mobile",
     ".rain-right-wrap#rain-right-wrap-mobile",
     ".compact-grid-mobile-wrap",
-    ".temperature-left-wrap",
-    ".temperature-right-wrap",
+    ".temperature-sticky-wrap",
     ".weather-left-wrap",
     ".weather-right-wrap",
     ".sun-left-wrap",
@@ -1819,8 +1801,7 @@ const _SCROLLABLE_WRAP_SELECTORS = [
   ".rain-right-wrap#rain-right-wrap",
   ".rain-left-wrap#rain-left-wrap-mobile",
   ".rain-right-wrap#rain-right-wrap-mobile",
-  ".temperature-left-wrap",
-  ".temperature-right-wrap",
+  ".temperature-sticky-wrap",
   ".weather-left-wrap",
   ".weather-right-wrap",
   ".sun-left-wrap",

--- a/assets/js/weather_page.js
+++ b/assets/js/weather_page.js
@@ -503,33 +503,6 @@ const _renderWeatherSection = (reports, emptyMessage = "No resorts match the cur
     const title = code === null || code === undefined || code === "" ? "WMO code: unknown" : `WMO code: ${code}`;
     return `<td class='weather-emoji-cell' title='${_escapeHtml(title)}'>${_weatherEmoji(code)}</td>`;
   }).join("");
-  if (appState.layoutMode === "compact") {
-    const leftRows = reports.length ? reports.map((report) => `<tr${_filterAttrs(report)}>${_resortCellHtml(report)}</tr>`).join("") : _emptyStateRow(2, emptyMessage);
-    const rightRows = reports.length ? reports.map((report) => {
-      const attrs = _filterAttrs(report);
-      return `<tr${attrs}>${weatherCells(report)}</tr>`;
-    }).join("") : _emptyStateRow(Math.max(1, displayDays), emptyMessage);
-    return `
-    <section>
-      <h2>Weather</h2>
-      <div class='weather-split-wrap'>
-        <div class='weather-left-wrap' id='weather-left-wrap'>
-          <table class='weather-left-table' id='weather-left-table'>
-            <colgroup><col class='col-favorite'><col class='col-query'></colgroup>
-            <thead><tr><th rowspan='2' class='favorite-col favorite-head'>${_favoriteAllButtonHtml(reports)}</th><th rowspan='2' class='query-col'>Resort</th></tr><tr></tr></thead>
-            <tbody>${leftRows}</tbody>
-          </table>
-        </div>
-        <div class='weather-right-wrap' id='weather-right-wrap'>
-          <table class='weather-right-table' id='weather-right-table'>
-            <colgroup>${Array.from({ length: displayDays }, () => "<col class='col-weather'>").join("")}</colgroup>
-            <thead><tr>${labels.map((label) => `<th>${_dayLabelHtml(label)}</th>`).join("")}</tr></thead>
-            <tbody>${rightRows}</tbody>
-          </table>
-        </div>
-      </div>
-    </section>`;
-  }
   const rows = reports.length ? reports.map((report) => `<tr${_filterAttrs(report)}>${_resortCellHtml(report)}${weatherCells(report)}</tr>`).join("") : _emptyStateRow(2 + Math.max(1, displayDays), emptyMessage);
   return `
     <section>
@@ -1312,31 +1285,6 @@ const _setFixedMobileHeights = (leftSelector, rightSelector, wrapSelector, stick
   }
 };
 
-const attachVerticalSync = (left, right) => {
-  if (!left || !right || left.dataset.scrollSyncAttached === "1") return;
-  let syncing = false;
-  const sync = (source, target) => {
-    if (syncing) return;
-    syncing = true;
-    target.scrollTop = source.scrollTop;
-    requestAnimationFrame(() => {
-      syncing = false;
-    });
-  };
-  left.addEventListener("scroll", () => sync(left, right), { passive: true });
-  right.addEventListener("scroll", () => sync(right, left), { passive: true });
-  left.dataset.scrollSyncAttached = "1";
-  right.dataset.scrollSyncAttached = "1";
-};
-
-const attachSplitScrollSync = () => {
-  [
-    [".weather-left-wrap", ".weather-right-wrap"],
-  ].forEach(([leftSelector, rightSelector]) => {
-    attachVerticalSync(document.querySelector(leftSelector), document.querySelector(rightSelector));
-  });
-};
-
 const _stretchColumnsToWrap = ({ wrapSelector, tableSelector, colSelector, minWidth }) => {
   const wrap = document.querySelector(wrapSelector);
   const table = document.querySelector(tableSelector);
@@ -1382,6 +1330,14 @@ const autoSizeSplitTables = () => {
     maxWidth: 220,
     capToMobileHalfScreen: isCompactLayout(),
   });
+  _autoSizeQueryOnly({
+    tableSelector: ".weather-table-wrap .weather-table",
+    wrapSelector: ".weather-table-wrap",
+    queryVarName: "--weather-query-w",
+    minWidth: 150,
+    maxWidth: 220,
+    capToMobileHalfScreen: isCompactLayout(),
+  });
   if (isCompactLayout()) {
     _autoSizeQueryOnly({
       tableSelector: ".snowfall-sticky-wrap.mobile-only .snowfall-sticky-table",
@@ -1404,14 +1360,6 @@ const autoSizeSplitTables = () => {
       mobileCapOffset: 0,
     });
     _autoSizeQueryOnly({
-      tableSelector: ".weather-left-wrap .weather-left-table",
-      wrapSelector: ".weather-left-wrap",
-      queryVarName: "--weather-query-w",
-      minWidth: 150,
-      maxWidth: 220,
-      capToMobileHalfScreen: true,
-    });
-    _autoSizeQueryOnly({
       tableSelector: ".sun-single-wrap .sun-single-table",
       wrapSelector: ".sun-single-wrap",
       queryVarName: "--sun-query-w",
@@ -1432,11 +1380,6 @@ const autoSizeSplitTables = () => {
     queryVarName: "--rain-query-w",
   });
   _autoSizeQueryOnly({
-    tableSelector: ".weather-table-wrap .weather-table",
-    wrapSelector: ".weather-table-wrap",
-    queryVarName: "--weather-query-w",
-  });
-  _autoSizeQueryOnly({
     tableSelector: ".sun-single-wrap .sun-single-table",
     wrapSelector: ".sun-single-wrap",
     queryVarName: "--sun-query-w",
@@ -1446,115 +1389,6 @@ const autoSizeSplitTables = () => {
     tableSelector: ".sun-single-table",
     colSelector: "col.col-sun",
     minWidth: 58,
-  });
-};
-
-const _clearRowHeights = (rows) => {
-  rows.forEach((row) => {
-    row.style.height = "";
-  });
-};
-
-const _syncRowPairHeights = (leftRows, rightRows) => {
-  const count = Math.min(leftRows.length, rightRows.length);
-  const heights = [];
-  for (let index = 0; index < count; index += 1) {
-    heights.push(Math.max(leftRows[index].offsetHeight, rightRows[index].offsetHeight));
-  }
-  for (let index = 0; index < count; index += 1) {
-    const targetHeight = heights[index];
-    leftRows[index].style.height = `${targetHeight}px`;
-    rightRows[index].style.height = `${targetHeight}px`;
-  }
-};
-
-const _syncStickySecondRowTop = (leftTable, rightTable, splitWrap, variableName) => {
-  if (!leftTable || !rightTable || !splitWrap) return;
-  const leftFirstRow = leftTable.tHead?.rows?.[0];
-  const rightFirstRow = rightTable.tHead?.rows?.[0];
-  if (!leftFirstRow || !rightFirstRow) return;
-  const top = Math.max(leftFirstRow.offsetHeight, rightFirstRow.offsetHeight);
-  if (top > 0) {
-    splitWrap.style.setProperty(variableName, `${top}px`);
-  }
-};
-
-const _applySplitViewportCap = ({
-  leftTableSelector,
-  rightTableSelector,
-  leftWrapSelector,
-  rightWrapSelector,
-  maxVisibleRows = 10,
-}) => {
-  const leftTable = document.querySelector(leftTableSelector);
-  const rightTable = document.querySelector(rightTableSelector);
-  const leftWrap = document.querySelector(leftWrapSelector);
-  const rightWrap = document.querySelector(rightWrapSelector);
-
-  [leftWrap, rightWrap].forEach((wrap) => {
-    wrap?.style.removeProperty("max-height");
-  });
-  if (!leftTable || !rightTable || !leftWrap || !rightWrap) return;
-
-  const leftHeadRows = Array.from(leftTable.tHead?.rows || []);
-  const rightHeadRows = Array.from(rightTable.tHead?.rows || []);
-  const leftBodyRows = Array.from(leftTable.tBodies[0]?.rows || []);
-  const rightBodyRows = Array.from(rightTable.tBodies[0]?.rows || []);
-  const visibleRows = Math.min(maxVisibleRows, leftBodyRows.length, rightBodyRows.length);
-  if (visibleRows <= 0) return;
-
-  const headerHeight = Math.max(
-    leftHeadRows.reduce((sum, row) => sum + (row.offsetHeight || 0), 0),
-    rightHeadRows.reduce((sum, row) => sum + (row.offsetHeight || 0), 0),
-  );
-  const bodyHeight = Array.from({ length: visibleRows }, (_, index) => Math.max(
-    leftBodyRows[index]?.offsetHeight || 0,
-    rightBodyRows[index]?.offsetHeight || 0,
-  )).reduce((sum, height) => sum + height, 0);
-  const total = Math.ceil(headerHeight + bodyHeight);
-  if (total <= 0) return;
-
-  leftWrap.style.maxHeight = `${total}px`;
-  rightWrap.style.maxHeight = `${total}px`;
-};
-
-const syncSplitTableHeights = () => {
-  const tablePairs = isCompactLayout()
-    ? [
-      [".weather-left-table", ".weather-right-table", ".weather-split-wrap", "--weather-header-row1-h"],
-    ]
-    : [
-      [".weather-left-table", ".weather-right-table", ".weather-split-wrap", "--weather-header-row1-h"],
-    ];
-  tablePairs.forEach(([leftSelector, rightSelector, wrapSelector, stickyVar]) => {
-    const leftTable = document.querySelector(leftSelector);
-    const rightTable = document.querySelector(rightSelector);
-    const splitWrap = document.querySelector(wrapSelector);
-    if (!leftTable || !rightTable) return;
-
-    const leftHeadRows = Array.from(leftTable.tHead ? leftTable.tHead.rows : []);
-    const rightHeadRows = Array.from(rightTable.tHead ? rightTable.tHead.rows : []);
-    const leftBodyRows = Array.from(leftTable.tBodies[0] ? leftTable.tBodies[0].rows : []);
-    const rightBodyRows = Array.from(rightTable.tBodies[0] ? rightTable.tBodies[0].rows : []);
-
-    _clearRowHeights(leftHeadRows);
-    _clearRowHeights(rightHeadRows);
-    _clearRowHeights(leftBodyRows);
-    _clearRowHeights(rightBodyRows);
-
-    _syncRowPairHeights(leftHeadRows, rightHeadRows);
-    _syncRowPairHeights(leftBodyRows, rightBodyRows);
-    _syncStickySecondRowTop(leftTable, rightTable, splitWrap, stickyVar);
-  });
-};
-
-const applySplitViewportCaps = () => {
-  _applySplitViewportCap({
-    leftTableSelector: ".weather-left-table",
-    rightTableSelector: ".weather-right-table",
-    leftWrapSelector: ".weather-left-wrap",
-    rightWrapSelector: ".weather-right-wrap",
-    maxVisibleRows: 10,
   });
 };
 
@@ -1568,12 +1402,9 @@ const applyLayout = () => {
     layoutFrame = 0;
     updateLayoutMode();
     autoSizeSplitTables();
-    syncSplitTableHeights();
-    applySplitViewportCaps();
     if (typeof stickySingleTableLayout.applyFromDom === "function") {
       stickySingleTableLayout.applyFromDom({ root: pageContentRoot || document });
     }
-    attachSplitScrollSync();
   });
 };
 
@@ -1589,8 +1420,7 @@ const observeLayoutContainers = () => {
     ".rain-sticky-wrap.mobile-only",
     ".compact-grid-mobile-wrap",
     ".temperature-sticky-wrap",
-    ".weather-left-wrap",
-    ".weather-right-wrap",
+    ".weather-table-wrap",
     ".sun-single-wrap",
   ].forEach((selector) => {
     const element = document.querySelector(selector);
@@ -1814,8 +1644,7 @@ const _SCROLLABLE_WRAP_SELECTORS = [
   ".rain-sticky-wrap.desktop-only",
   ".rain-sticky-wrap.mobile-only",
   ".temperature-sticky-wrap",
-  ".weather-left-wrap",
-  ".weather-right-wrap",
+  ".weather-table-wrap",
   ".sun-single-wrap",
 ];
 

--- a/assets/js/weather_page.js
+++ b/assets/js/weather_page.js
@@ -495,17 +495,18 @@ const _renderWeatherSection = (reports, emptyMessage = "No resorts match the cur
   const labels = reports.length
     ? Array.from({ length: displayDays }, (_, idx) => _dayLabelFor(reports[0], idx))
     : _fallbackDayLabels(displayDays);
-  const leftRows = reports.length ? reports.map((report) => `<tr${_filterAttrs(report)}>${_resortCellHtml(report)}</tr>`).join("") : _emptyStateRow(2, emptyMessage);
-  const rightRows = reports.length ? reports.map((report) => {
-    const attrs = _filterAttrs(report);
-    const cells = Array.from({ length: displayDays }, (_, idx) => {
-      const code = _dailyAt(report, idx).weather_code;
-      const title = code === null || code === undefined || code === "" ? "WMO code: unknown" : `WMO code: ${code}`;
-      return `<td class='weather-emoji-cell' title='${_escapeHtml(title)}'>${_weatherEmoji(code)}</td>`;
-    }).join("");
-    return `<tr${attrs}>${cells}</tr>`;
-  }).join("") : _emptyStateRow(Math.max(1, displayDays), emptyMessage);
-  return `
+  const weatherCells = (report) => Array.from({ length: displayDays }, (_, idx) => {
+    const code = _dailyAt(report, idx).weather_code;
+    const title = code === null || code === undefined || code === "" ? "WMO code: unknown" : `WMO code: ${code}`;
+    return `<td class='weather-emoji-cell' title='${_escapeHtml(title)}'>${_weatherEmoji(code)}</td>`;
+  }).join("");
+  if (appState.layoutMode === "compact") {
+    const leftRows = reports.length ? reports.map((report) => `<tr${_filterAttrs(report)}>${_resortCellHtml(report)}</tr>`).join("") : _emptyStateRow(2, emptyMessage);
+    const rightRows = reports.length ? reports.map((report) => {
+      const attrs = _filterAttrs(report);
+      return `<tr${attrs}>${weatherCells(report)}</tr>`;
+    }).join("") : _emptyStateRow(Math.max(1, displayDays), emptyMessage);
+    return `
     <section>
       <h2>Weather</h2>
       <div class='weather-split-wrap'>
@@ -523,6 +524,26 @@ const _renderWeatherSection = (reports, emptyMessage = "No resorts match the cur
             <tbody>${rightRows}</tbody>
           </table>
         </div>
+      </div>
+    </section>`;
+  }
+  const rows = reports.length ? reports.map((report) => `<tr${_filterAttrs(report)}>${_resortCellHtml(report)}${weatherCells(report)}</tr>`).join("") : _emptyStateRow(2 + Math.max(1, displayDays), emptyMessage);
+  return `
+    <section>
+      <h2>Weather</h2>
+      <div
+        class='weather-table-wrap'
+        id='weather-table-wrap'
+        data-sticky-single-table-section='${STICKY_SINGLE_TABLE_SECTION_KEYS.weather}'
+        data-sticky-leading-cols='2'
+        data-sticky-header-rows='1'
+        data-sticky-max-visible-rows='10'
+      >
+        <table class='weather-table' id='weather-table'>
+          <colgroup><col class='col-favorite'><col class='col-query'>${Array.from({ length: displayDays }, () => "<col class='col-weather'>").join("")}</colgroup>
+          <thead><tr><th class='favorite-col favorite-head'>${_favoriteAllButtonHtml(reports)}</th><th class='query-col'>Resort</th>${labels.map((label) => `<th>${_dayLabelHtml(label)}</th>`).join("")}</tr></thead>
+          <tbody>${rows}</tbody>
+        </table>
       </div>
     </section>`;
 };
@@ -1443,8 +1464,8 @@ const autoSizeSplitTables = () => {
     queryVarName: "--temp-query-w",
   });
   _autoSizeQueryOnly({
-    tableSelector: ".weather-left-wrap .weather-left-table",
-    wrapSelector: ".weather-left-wrap",
+    tableSelector: ".weather-table-wrap .weather-table",
+    wrapSelector: ".weather-table-wrap",
     queryVarName: "--weather-query-w",
   });
   _stretchColumnsToWrap({
@@ -1457,12 +1478,6 @@ const autoSizeSplitTables = () => {
     tableSelector: ".sun-left-wrap .sun-left-table",
     wrapSelector: ".sun-left-wrap",
     queryVarName: "--sun-query-w",
-  });
-  _stretchColumnsToWrap({
-    wrapSelector: ".weather-right-wrap",
-    tableSelector: ".weather-right-table",
-    colSelector: "col.col-weather",
-    minWidth: 68,
   });
   _stretchColumnsToWrap({
     wrapSelector: ".sun-right-wrap",

--- a/assets/js/weather_page.js
+++ b/assets/js/weather_page.js
@@ -401,22 +401,19 @@ const _renderPrecipSection = (title, kind, metricUnit, imperialUnit, reports, op
         </div>
       </section>`;
   }
-  const desktopLeftRows = reports.length ? reports.map((report) => {
+  const desktopRows = reports.length ? reports.map((report) => {
     const attrs = _filterAttrs(report);
     const weeklyValues = [
       options.week1(report),
       options.week2(report),
-    ].map((value) => _metricCellHtml(_formatMetric(value), kind, options.color(value)));
-    return `<tr${attrs}>${_resortCellHtml(report)}${weeklyValues.join("")}</tr>`;
-  }).join("") : _emptyStateRow(4, emptyMessage);
-  const desktopRightRows = reports.length ? reports.map((report) => {
-    const attrs = _filterAttrs(report);
+    ].map((value) => _metricCellHtml(_formatMetric(value), kind, options.color(value), "week-col-cell"));
     const dailyValues = Array.from({ length: displayDays }, (_, idx) => {
       const value = options.daily(_dailyAt(report, idx));
-      return _metricCellHtml(_formatMetric(value), kind, options.color(value));
+      return _metricCellHtml(_formatMetric(value), kind, options.color(value), "day-col-cell");
     }).join("");
-    return `<tr${attrs}>${dailyValues}</tr>`;
-  }).join("") : _emptyStateRow(Math.max(1, displayDays), emptyMessage);
+    return `<tr${attrs}>${_resortCellHtml(report)}${weeklyValues.join("")}${dailyValues}</tr>`;
+  }).join("") : _emptyStateRow(4 + Math.max(1, displayDays), emptyMessage);
+  const stickySectionKey = options.sectionKey || options.prefix;
   return `
     <section>
       <div class="section-header">
@@ -426,21 +423,19 @@ const _renderPrecipSection = (title, kind, metricUnit, imperialUnit, reports, op
           <button type="button" class="unit-btn" data-unit-mode="imperial">${imperialUnit}</button>
         </div>
       </div>
-      <div class="${options.prefix}-split-wrap desktop-only">
-        <div class="${options.prefix}-left-wrap" id="${options.prefix}-left-wrap">
-          <table class="${options.prefix}-left-table">
-            <colgroup><col class='col-favorite'><col class='col-query'><col class='col-week'><col class='col-week'></colgroup>
-            <thead><tr><th rowspan='2' class='favorite-col favorite-head'>${favoriteAllButton}</th><th rowspan='2' class='query-col'>Resort</th><th colspan='2'>Weekly</th></tr><tr><th>${weeklyHeaders[0]}</th><th>${weeklyHeaders[1]}</th></tr></thead>
-            <tbody>${desktopLeftRows}</tbody>
-          </table>
-        </div>
-        <div class="${options.prefix}-right-wrap" id="${options.prefix}-right-wrap">
-          <table class="${options.prefix}-right-table">
-            <colgroup>${Array.from({ length: displayDays }, () => "<col class='col-day'>").join("")}</colgroup>
-            <thead><tr><th colspan='${displayDays}'>Daily</th></tr><tr>${dayLabels.map((label) => `<th>${_dayLabelHtml(label)}</th>`).join("")}</tr></thead>
-            <tbody>${desktopRightRows}</tbody>
-          </table>
-        </div>
+      <div
+        class="${options.prefix}-sticky-wrap desktop-only"
+        id="${options.prefix}-sticky-wrap"
+        data-sticky-single-table-section="${_escapeHtml(stickySectionKey)}"
+        data-sticky-leading-cols="4"
+        data-sticky-header-rows="2"
+        data-sticky-max-visible-rows="10"
+      >
+        <table class="${options.prefix}-sticky-table">
+          <colgroup><col class='col-favorite'><col class='col-query'><col class='col-week'><col class='col-week'>${Array.from({ length: displayDays }, () => "<col class='col-day'>").join("")}</colgroup>
+          <thead><tr><th rowspan='2' class='favorite-col favorite-head'>${favoriteAllButton}</th><th rowspan='2' class='query-col'>Resort</th><th colspan='2' class='week-group'>Weekly</th><th colspan='${displayDays}'>Daily</th></tr><tr><th class='week-col-cell'>${weeklyHeaders[0]}</th><th class='week-col-cell'>${weeklyHeaders[1]}</th>${dayLabels.map((label) => `<th class='day-col-cell'>${_dayLabelHtml(label)}</th>`).join("")}</tr></thead>
+          <tbody>${desktopRows}</tbody>
+        </table>
       </div>
     </section>`;
 };
@@ -591,6 +586,7 @@ const _renderSections = (reports, emptyMessage = "No resorts match the current f
   _renderCompactGridSection(reports, emptyMessage),
   _renderPrecipSection("Snowfall", "snow", "cm", "in", reports, {
     prefix: "snowfall",
+    sectionKey: STICKY_SINGLE_TABLE_SECTION_KEYS.snowfall,
     week1: (report) => report.week1_total_snowfall_cm,
     week2: (report) => report.week2_total_snowfall_cm,
     daily: (day) => day.snowfall_cm,
@@ -598,6 +594,7 @@ const _renderSections = (reports, emptyMessage = "No resorts match the current f
   }, emptyMessage),
   _renderPrecipSection("Rainfall", "rain", "mm", "in", reports, {
     prefix: "rain",
+    sectionKey: STICKY_SINGLE_TABLE_SECTION_KEYS.rainfall,
     week1: (report) => report.week1_total_rain_mm,
     week2: (report) => report.week2_total_rain_mm,
     daily: (day) => day.rain_mm,
@@ -1305,9 +1302,7 @@ const attachVerticalSync = (left, right) => {
 
 const attachSplitScrollSync = () => {
   [
-    [".snowfall-left-wrap#snowfall-left-wrap", ".snowfall-right-wrap#snowfall-right-wrap"],
     [".snowfall-left-wrap#snowfall-left-wrap-mobile", ".snowfall-right-wrap#snowfall-right-wrap-mobile"],
-    [".rain-left-wrap#rain-left-wrap", ".rain-right-wrap#rain-right-wrap"],
     [".rain-left-wrap#rain-left-wrap-mobile", ".rain-right-wrap#rain-right-wrap-mobile"],
     [".temperature-left-wrap", ".temperature-right-wrap"],
     [".weather-left-wrap", ".weather-right-wrap"],
@@ -1413,29 +1408,15 @@ const autoSizeSplitTables = () => {
     });
     return;
   }
-  _autoSizeDesktopLeftColumns({
-    tableSelector: ".snowfall-left-wrap#snowfall-left-wrap .snowfall-left-table",
-    wrapSelector: ".snowfall-left-wrap#snowfall-left-wrap",
-    queryVarName: "--query-col-w",
-    weekVarName: "--week-col-w",
+  _autoSizeQueryOnly({
+    tableSelector: ".snowfall-sticky-wrap.desktop-only .snowfall-sticky-table",
+    wrapSelector: ".snowfall-sticky-wrap.desktop-only",
+    queryVarName: "--snowfall-query-w",
   });
-  _stretchColumnsToWrap({
-    wrapSelector: ".snowfall-right-wrap#snowfall-right-wrap",
-    tableSelector: ".snowfall-right-wrap#snowfall-right-wrap .snowfall-right-table",
-    colSelector: "col.col-day",
-    minWidth: 66,
-  });
-  _autoSizeDesktopLeftColumns({
-    tableSelector: ".rain-left-wrap#rain-left-wrap .rain-left-table",
-    wrapSelector: ".rain-left-wrap#rain-left-wrap",
+  _autoSizeQueryOnly({
+    tableSelector: ".rain-sticky-wrap.desktop-only .rain-sticky-table",
+    wrapSelector: ".rain-sticky-wrap.desktop-only",
     queryVarName: "--rain-query-w",
-    weekVarName: "--rain-week-w",
-  });
-  _stretchColumnsToWrap({
-    wrapSelector: ".rain-right-wrap#rain-right-wrap",
-    tableSelector: ".rain-right-wrap#rain-right-wrap .rain-right-table",
-    colSelector: "col.col-day",
-    minWidth: 66,
   });
   _autoSizeQueryOnly({
     tableSelector: ".temperature-left-wrap .temperature-left-table",
@@ -1512,8 +1493,6 @@ const syncSplitTableHeights = () => {
       [".sun-left-table", ".sun-right-table", ".sun-split-wrap", "--sun-header-row1-h"],
     ]
     : [
-      [".snowfall-left-wrap#snowfall-left-wrap .snowfall-left-table", ".snowfall-right-wrap#snowfall-right-wrap .snowfall-right-table", ".snowfall-split-wrap.desktop-only", "--snow-header-row1-h"],
-      [".rain-left-wrap#rain-left-wrap .rain-left-table", ".rain-right-wrap#rain-right-wrap .rain-right-table", ".rain-split-wrap.desktop-only", "--rain-header-row1-h"],
       [".temperature-left-table", ".temperature-right-table", ".temperature-split-wrap", "--temp-header-row1-h"],
       [".weather-left-table", ".weather-right-table", ".weather-split-wrap", "--weather-header-row1-h"],
       [".sun-left-table", ".sun-right-table", ".sun-split-wrap", "--sun-header-row1-h"],
@@ -1564,12 +1543,10 @@ const observeLayoutContainers = () => {
   layoutObserver = new ResizeObserver(() => applyLayout());
   const observed = new Set();
   [
-    ".snowfall-left-wrap#snowfall-left-wrap",
-    ".snowfall-right-wrap#snowfall-right-wrap",
+    ".snowfall-sticky-wrap.desktop-only",
     ".snowfall-left-wrap#snowfall-left-wrap-mobile",
     ".snowfall-right-wrap#snowfall-right-wrap-mobile",
-    ".rain-left-wrap#rain-left-wrap",
-    ".rain-right-wrap#rain-right-wrap",
+    ".rain-sticky-wrap.desktop-only",
     ".rain-left-wrap#rain-left-wrap-mobile",
     ".rain-right-wrap#rain-right-wrap-mobile",
     ".compact-grid-mobile-wrap",
@@ -1796,12 +1773,10 @@ const renderPage = () => {
 
 const _SCROLLABLE_WRAP_SELECTORS = [
   ".compact-grid-mobile-wrap",
-  ".snowfall-left-wrap#snowfall-left-wrap",
-  ".snowfall-right-wrap#snowfall-right-wrap",
+  ".snowfall-sticky-wrap.desktop-only",
   ".snowfall-left-wrap#snowfall-left-wrap-mobile",
   ".snowfall-right-wrap#snowfall-right-wrap-mobile",
-  ".rain-left-wrap#rain-left-wrap",
-  ".rain-right-wrap#rain-right-wrap",
+  ".rain-sticky-wrap.desktop-only",
   ".rain-left-wrap#rain-left-wrap-mobile",
   ".rain-right-wrap#rain-right-wrap-mobile",
   ".temperature-left-wrap",

--- a/assets/js/weather_page.js
+++ b/assets/js/weather_page.js
@@ -281,14 +281,28 @@ const _favoriteAllButtonHtml = (reports) => {
 
 const _displayName = (report) => String(report?.display_name || report?.query || "").trim();
 
-const _resortCellHtml = (report) => {
+const _resortLinkHtml = (report) => {
   const text = _escapeHtml(_displayName(report));
   const resortId = String(report.resort_id || "").trim();
-  const linkHtml = resortId
+  return resortId
     ? `<a class='resort-link' href='resort/${encodeURIComponent(resortId)}'>${text}</a>`
     : text;
+};
+
+const _resortCellHtml = (report) => {
+  const linkHtml = _resortLinkHtml(report);
   return `<td class='favorite-col'>${_favoriteButtonHtml(report)}</td><td class='query-col'><div class='resort-cell'><div class='resort-link-wrap'>${linkHtml}</div></div></td>`;
 };
+
+const _mobilePrecipResortHeadHtml = (favoriteAllButton) => `
+  <th rowspan='2' class='query-col mobile-precip-resort-head'>
+    <div class='mobile-precip-resort-content'>${favoriteAllButton}<span class='mobile-precip-resort-label'>Resort</span></div>
+  </th>`;
+
+const _mobilePrecipResortCellHtml = (report) => `
+  <td class='query-col mobile-precip-resort-cell'>
+    <div class='mobile-precip-resort-content'>${_favoriteButtonHtml(report)}<div class='resort-cell'><div class='resort-link-wrap'>${_resortLinkHtml(report)}</div></div></div>
+  </td>`;
 
 const _displayDays = () => {
   const raw = appState.payload && Number(appState.payload.forecast_days);
@@ -342,7 +356,7 @@ const _renderCompactGridSection = (reports, emptyMessage = "No resorts match the
         data-sticky-single-table-section="${STICKY_SINGLE_TABLE_SECTION_KEYS.dailySummary}"
         data-sticky-leading-cols="2"
         data-sticky-header-rows="1"
-        data-sticky-max-visible-rows="10"
+        data-sticky-max-visible-rows="5"
       >
         <table class="compact-grid-mobile-table" id="compact-grid-mobile-table">
           <colgroup><col class='col-favorite'><col class='col-query'>${Array.from({ length: displayDays }, () => "<col class='col-compact-day'>").join("")}</colgroup>
@@ -360,9 +374,9 @@ const _renderPrecipSection = (title, kind, metricUnit, imperialUnit, reports, op
     : _fallbackDayLabels(displayDays);
   const weeklyHeaders = ["week 1", "week 2"];
   const favoriteAllButton = _favoriteAllButtonHtml(reports);
+  const stickySectionKey = options.sectionKey || options.prefix;
   if (appState.layoutMode === "compact") {
-    const mobileLeftRows = reports.length ? reports.map((report) => `<tr${_filterAttrs(report)}>${_resortCellHtml(report)}</tr>`).join("") : _emptyStateRow(2, emptyMessage);
-    const mobileRightRows = reports.length ? reports.map((report) => {
+    const mobileRows = reports.length ? reports.map((report) => {
       const attrs = _filterAttrs(report);
       const weeklyValues = [
         options.week1(report),
@@ -370,10 +384,10 @@ const _renderPrecipSection = (title, kind, metricUnit, imperialUnit, reports, op
       ].map((value) => _metricCellHtml(_formatMetric(value), kind, options.color(value), "week-col-cell"));
       const dailyValues = Array.from({ length: displayDays }, (_, idx) => {
         const value = options.daily(_dailyAt(report, idx));
-        return _metricCellHtml(_formatMetric(value), kind, options.color(value));
+        return _metricCellHtml(_formatMetric(value), kind, options.color(value), "day-col-cell");
       });
-      return `<tr${attrs}>${weeklyValues.join("")}${dailyValues.join("")}</tr>`;
-    }).join("") : _emptyStateRow(2 + Math.max(1, displayDays), emptyMessage);
+      return `<tr${attrs}>${_mobilePrecipResortCellHtml(report)}${weeklyValues.join("")}${dailyValues.join("")}</tr>`;
+    }).join("") : _emptyStateRow(3 + Math.max(1, displayDays), emptyMessage);
     return `
       <section>
         <div class="section-header">
@@ -383,21 +397,19 @@ const _renderPrecipSection = (title, kind, metricUnit, imperialUnit, reports, op
             <button type="button" class="unit-btn" data-unit-mode="imperial">${imperialUnit}</button>
           </div>
         </div>
-        <div class="${options.prefix}-split-wrap mobile-only">
-          <div class="${options.prefix}-left-wrap" id="${options.prefix}-left-wrap-mobile">
-            <table class="${options.prefix}-left-table">
-              <colgroup><col class='col-favorite'><col class='col-query'></colgroup>
-              <thead><tr><th rowspan='2' class='favorite-col favorite-head'>${favoriteAllButton}</th><th rowspan='2' class='query-col'>Resort</th></tr><tr></tr></thead>
-              <tbody>${mobileLeftRows}</tbody>
-            </table>
-          </div>
-          <div class="${options.prefix}-right-wrap" id="${options.prefix}-right-wrap-mobile">
-            <table class="${options.prefix}-right-table">
-              <colgroup><col class='col-week-right'><col class='col-week-right'>${Array.from({ length: displayDays }, () => "<col class='col-day'>").join("")}</colgroup>
-              <thead><tr><th class='week-group' colspan='2'>Weekly</th><th colspan='${displayDays}'>Daily</th></tr><tr><th class='week-col-cell'>Week 1</th><th class='week-col-cell'>Week 2</th>${dayLabels.map((label) => `<th>${_dayLabelHtml(label)}</th>`).join("")}</tr></thead>
-              <tbody>${mobileRightRows}</tbody>
-            </table>
-          </div>
+        <div
+          class="${options.prefix}-sticky-wrap mobile-only"
+          id="${options.prefix}-sticky-wrap-mobile"
+          data-sticky-single-table-section="${_escapeHtml(stickySectionKey)}"
+          data-sticky-leading-cols="1"
+          data-sticky-header-rows="2"
+          data-sticky-max-visible-rows="10"
+        >
+          <table class="${options.prefix}-sticky-table ${options.prefix}-mobile-sticky-table">
+            <colgroup><col class='col-query'><col class='col-week'><col class='col-week'>${Array.from({ length: displayDays }, () => "<col class='col-day'>").join("")}</colgroup>
+            <thead><tr>${_mobilePrecipResortHeadHtml(favoriteAllButton)}<th colspan='2' class='week-group'>Weekly</th><th colspan='${displayDays}'>Daily</th></tr><tr><th class='week-col-cell'>${weeklyHeaders[0]}</th><th class='week-col-cell'>${weeklyHeaders[1]}</th>${dayLabels.map((label) => `<th class='day-col-cell'>${_dayLabelHtml(label)}</th>`).join("")}</tr></thead>
+            <tbody>${mobileRows}</tbody>
+          </table>
         </div>
       </section>`;
   }
@@ -413,7 +425,6 @@ const _renderPrecipSection = (title, kind, metricUnit, imperialUnit, reports, op
     }).join("");
     return `<tr${attrs}>${_resortCellHtml(report)}${weeklyValues.join("")}${dailyValues}</tr>`;
   }).join("") : _emptyStateRow(4 + Math.max(1, displayDays), emptyMessage);
-  const stickySectionKey = options.sectionKey || options.prefix;
   return `
     <section>
       <div class="section-header">
@@ -1115,22 +1126,23 @@ const updateLayoutMode = () => {
 
 const isCompactLayout = () => appState.layoutMode === "compact";
 
-const _mobileLeadingQueryCap = () => {
+const _mobileLeadingQueryCap = (offset = LEADING_FAVORITE_COL_PX) => {
   const viewportWidth = Math.max(
     document.documentElement?.clientWidth || 0,
     window.innerWidth || 0,
   );
-  return Math.max(0, Math.floor((viewportWidth / 2) - LEADING_FAVORITE_COL_PX));
+  return Math.max(0, Math.floor((viewportWidth / 2) - Math.max(0, offset)));
 };
 
 const _resolveQueryColumnBounds = ({
   minWidth,
   maxWidth,
   capToMobileHalfScreen = false,
+  mobileCapOffset = LEADING_FAVORITE_COL_PX,
 }) => {
   let resolvedMax = maxWidth;
   if (capToMobileHalfScreen && isCompactLayout()) {
-    resolvedMax = Math.min(resolvedMax, _mobileLeadingQueryCap());
+    resolvedMax = Math.min(resolvedMax, _mobileLeadingQueryCap(mobileCapOffset));
   }
   return {
     minWidth: Math.min(minWidth, resolvedMax),
@@ -1185,6 +1197,7 @@ const _autoSizeQueryOnly = ({
   maxWidth = 240,
   padding = 28,
   capToMobileHalfScreen = false,
+  mobileCapOffset = LEADING_FAVORITE_COL_PX,
 }) => {
   const table = document.querySelector(tableSelector);
   const wrap = document.querySelector(wrapSelector);
@@ -1201,7 +1214,7 @@ const _autoSizeQueryOnly = ({
     measureTextWidth(headerText, font),
     ...values.map((value) => measureTextWidth(value, font)),
   );
-  const bounds = _resolveQueryColumnBounds({ minWidth, maxWidth, capToMobileHalfScreen });
+  const bounds = _resolveQueryColumnBounds({ minWidth, maxWidth, capToMobileHalfScreen, mobileCapOffset });
   wrap.style.setProperty(
     queryVarName,
     `${Math.max(bounds.minWidth, Math.min(bounds.maxWidth, Math.ceil(queryMax + padding)))}px`,
@@ -1318,8 +1331,6 @@ const attachVerticalSync = (left, right) => {
 
 const attachSplitScrollSync = () => {
   [
-    [".snowfall-left-wrap#snowfall-left-wrap-mobile", ".snowfall-right-wrap#snowfall-right-wrap-mobile"],
-    [".rain-left-wrap#rain-left-wrap-mobile", ".rain-right-wrap#rain-right-wrap-mobile"],
     [".weather-left-wrap", ".weather-right-wrap"],
   ].forEach(([leftSelector, rightSelector]) => {
     attachVerticalSync(document.querySelector(leftSelector), document.querySelector(rightSelector));
@@ -1372,37 +1383,25 @@ const autoSizeSplitTables = () => {
     capToMobileHalfScreen: isCompactLayout(),
   });
   if (isCompactLayout()) {
-    _autoSizeMobileQueryColumn({
-      tableSelector: ".snowfall-left-wrap#snowfall-left-wrap-mobile .snowfall-left-table",
-      wrapSelector: ".snowfall-left-wrap#snowfall-left-wrap-mobile",
+    _autoSizeQueryOnly({
+      tableSelector: ".snowfall-sticky-wrap.mobile-only .snowfall-sticky-table",
+      wrapSelector: ".snowfall-sticky-wrap.mobile-only",
+      queryVarName: "--snowfall-query-w",
       minWidth: 150,
-      maxWidth: 240,
-      padding: 22,
+      maxWidth: 220,
+      padding: 38,
       capToMobileHalfScreen: true,
+      mobileCapOffset: 0,
     });
-    _autoSizeMobileRightColumns({
-      tableSelector: ".snowfall-right-wrap#snowfall-right-wrap-mobile .snowfall-right-table",
-      wrapSelector: ".snowfall-right-wrap#snowfall-right-wrap-mobile",
-      weekSelector: "col.col-week-right",
-      daySelector: "col.col-day",
-      minWeekWidth: 92,
-      minDayWidth: 62,
-    });
-    _autoSizeMobileQueryColumn({
-      tableSelector: ".rain-left-wrap#rain-left-wrap-mobile .rain-left-table",
-      wrapSelector: ".rain-left-wrap#rain-left-wrap-mobile",
+    _autoSizeQueryOnly({
+      tableSelector: ".rain-sticky-wrap.mobile-only .rain-sticky-table",
+      wrapSelector: ".rain-sticky-wrap.mobile-only",
+      queryVarName: "--rain-query-w",
       minWidth: 150,
-      maxWidth: 240,
-      padding: 22,
+      maxWidth: 220,
+      padding: 38,
       capToMobileHalfScreen: true,
-    });
-    _autoSizeMobileRightColumns({
-      tableSelector: ".rain-right-wrap#rain-right-wrap-mobile .rain-right-table",
-      wrapSelector: ".rain-right-wrap#rain-right-wrap-mobile",
-      weekSelector: "col.col-week-right",
-      daySelector: "col.col-day",
-      minWeekWidth: 92,
-      minDayWidth: 62,
+      mobileCapOffset: 0,
     });
     _autoSizeQueryOnly({
       tableSelector: ".weather-left-wrap .weather-left-table",
@@ -1480,11 +1479,48 @@ const _syncStickySecondRowTop = (leftTable, rightTable, splitWrap, variableName)
   }
 };
 
+const _applySplitViewportCap = ({
+  leftTableSelector,
+  rightTableSelector,
+  leftWrapSelector,
+  rightWrapSelector,
+  maxVisibleRows = 10,
+}) => {
+  const leftTable = document.querySelector(leftTableSelector);
+  const rightTable = document.querySelector(rightTableSelector);
+  const leftWrap = document.querySelector(leftWrapSelector);
+  const rightWrap = document.querySelector(rightWrapSelector);
+
+  [leftWrap, rightWrap].forEach((wrap) => {
+    wrap?.style.removeProperty("max-height");
+  });
+  if (!leftTable || !rightTable || !leftWrap || !rightWrap) return;
+
+  const leftHeadRows = Array.from(leftTable.tHead?.rows || []);
+  const rightHeadRows = Array.from(rightTable.tHead?.rows || []);
+  const leftBodyRows = Array.from(leftTable.tBodies[0]?.rows || []);
+  const rightBodyRows = Array.from(rightTable.tBodies[0]?.rows || []);
+  const visibleRows = Math.min(maxVisibleRows, leftBodyRows.length, rightBodyRows.length);
+  if (visibleRows <= 0) return;
+
+  const headerHeight = Math.max(
+    leftHeadRows.reduce((sum, row) => sum + (row.offsetHeight || 0), 0),
+    rightHeadRows.reduce((sum, row) => sum + (row.offsetHeight || 0), 0),
+  );
+  const bodyHeight = Array.from({ length: visibleRows }, (_, index) => Math.max(
+    leftBodyRows[index]?.offsetHeight || 0,
+    rightBodyRows[index]?.offsetHeight || 0,
+  )).reduce((sum, height) => sum + height, 0);
+  const total = Math.ceil(headerHeight + bodyHeight);
+  if (total <= 0) return;
+
+  leftWrap.style.maxHeight = `${total}px`;
+  rightWrap.style.maxHeight = `${total}px`;
+};
+
 const syncSplitTableHeights = () => {
   const tablePairs = isCompactLayout()
     ? [
-      [".snowfall-left-wrap#snowfall-left-wrap-mobile .snowfall-left-table", ".snowfall-right-wrap#snowfall-right-wrap-mobile .snowfall-right-table", ".snowfall-split-wrap.mobile-only", "--snow-header-row1-h"],
-      [".rain-left-wrap#rain-left-wrap-mobile .rain-left-table", ".rain-right-wrap#rain-right-wrap-mobile .rain-right-table", ".rain-split-wrap.mobile-only", "--rain-header-row1-h"],
       [".weather-left-table", ".weather-right-table", ".weather-split-wrap", "--weather-header-row1-h"],
     ]
     : [
@@ -1512,6 +1548,16 @@ const syncSplitTableHeights = () => {
   });
 };
 
+const applySplitViewportCaps = () => {
+  _applySplitViewportCap({
+    leftTableSelector: ".weather-left-table",
+    rightTableSelector: ".weather-right-table",
+    leftWrapSelector: ".weather-left-wrap",
+    rightWrapSelector: ".weather-right-wrap",
+    maxVisibleRows: 10,
+  });
+};
+
 let layoutFrame = 0;
 let layoutObserver = null;
 let dynamicPayloadAbortController = null;
@@ -1523,6 +1569,7 @@ const applyLayout = () => {
     updateLayoutMode();
     autoSizeSplitTables();
     syncSplitTableHeights();
+    applySplitViewportCaps();
     if (typeof stickySingleTableLayout.applyFromDom === "function") {
       stickySingleTableLayout.applyFromDom({ root: pageContentRoot || document });
     }
@@ -1537,11 +1584,9 @@ const observeLayoutContainers = () => {
   const observed = new Set();
   [
     ".snowfall-sticky-wrap.desktop-only",
-    ".snowfall-left-wrap#snowfall-left-wrap-mobile",
-    ".snowfall-right-wrap#snowfall-right-wrap-mobile",
+    ".snowfall-sticky-wrap.mobile-only",
     ".rain-sticky-wrap.desktop-only",
-    ".rain-left-wrap#rain-left-wrap-mobile",
-    ".rain-right-wrap#rain-right-wrap-mobile",
+    ".rain-sticky-wrap.mobile-only",
     ".compact-grid-mobile-wrap",
     ".temperature-sticky-wrap",
     ".weather-left-wrap",
@@ -1765,11 +1810,9 @@ const renderPage = () => {
 const _SCROLLABLE_WRAP_SELECTORS = [
   ".compact-grid-mobile-wrap",
   ".snowfall-sticky-wrap.desktop-only",
-  ".snowfall-left-wrap#snowfall-left-wrap-mobile",
-  ".snowfall-right-wrap#snowfall-right-wrap-mobile",
+  ".snowfall-sticky-wrap.mobile-only",
   ".rain-sticky-wrap.desktop-only",
-  ".rain-left-wrap#rain-left-wrap-mobile",
-  ".rain-right-wrap#rain-right-wrap-mobile",
+  ".rain-sticky-wrap.mobile-only",
   ".temperature-sticky-wrap",
   ".weather-left-wrap",
   ".weather-right-wrap",

--- a/assets/js/weather_page.js
+++ b/assets/js/weather_page.js
@@ -56,8 +56,18 @@ const MAX_DISPLAY_DAYS = 14;
 const MIN_DESKTOP_SNOW_3DAY_PX = 554;
 const LEADING_FAVORITE_COL_PX = 28;
 const compactDailySummary = window.CloseSnowCompactDailySummary || {};
+const stickySingleTableLayout = window.CloseSnowStickySingleTableLayout || {};
 const COMPACT_SUMMARY_UNIT_KIND = "compact_summary";
 const SUN_TIME_TOGGLE_KIND = "sun_time";
+// Reserve section keys so later workers can move one section at a time to shared single-table layout.
+const STICKY_SINGLE_TABLE_SECTION_KEYS = Object.freeze({
+  dailySummary: "daily-summary",
+  snowfall: "snowfall",
+  rainfall: "rainfall",
+  temperature: "temperature",
+  weather: "weather",
+  sun: "sunrise-sunset",
+});
 
 const appState = {
   payload: null,
@@ -326,7 +336,14 @@ const _renderCompactGridSection = (reports, emptyMessage = "No resorts match the
           <button type="button" class="unit-btn" data-unit-mode="imperial">Imperial</button>
         </div>
       </div>
-      <div class="compact-grid-mobile-wrap" id="compact-grid-mobile-wrap">
+      <div
+        class="compact-grid-mobile-wrap"
+        id="compact-grid-mobile-wrap"
+        data-sticky-single-table-section="${STICKY_SINGLE_TABLE_SECTION_KEYS.dailySummary}"
+        data-sticky-leading-cols="2"
+        data-sticky-header-rows="1"
+        data-sticky-max-visible-rows="10"
+      >
         <table class="compact-grid-mobile-table" id="compact-grid-mobile-table">
           <colgroup><col class='col-favorite'><col class='col-query'>${Array.from({ length: displayDays }, () => "<col class='col-compact-day'>").join("")}</colgroup>
           <thead><tr><th class='favorite-col favorite-head'>${_favoriteAllButtonHtml(reports)}</th><th class='query-col'>Resort</th>${labels.map((label) => `<th>${_dayLabelHtml(label)}</th>`).join("")}</tr></thead>
@@ -1485,53 +1502,6 @@ const _syncStickySecondRowTop = (leftTable, rightTable, splitWrap, variableName)
   }
 };
 
-const _setVisibleRowViewport = ({ leftSelector, rightSelector, rowsVisible = 5 }) => {
-  const leftWrap = document.querySelector(leftSelector);
-  const rightWrap = document.querySelector(rightSelector);
-  const leftTable = leftWrap?.querySelector("table");
-  const rightTable = rightWrap?.querySelector("table");
-  if (!leftWrap || !rightWrap || !leftTable || !rightTable) return;
-
-  const leftHeadRows = Array.from(leftTable.tHead?.rows || []);
-  const rightHeadRows = Array.from(rightTable.tHead?.rows || []);
-  const leftBodyRows = Array.from(leftTable.tBodies[0]?.rows || []);
-  const rightBodyRows = Array.from(rightTable.tBodies[0]?.rows || []);
-  const visibleCount = Math.min(
-    rowsVisible,
-    leftBodyRows.length || rowsVisible,
-    rightBodyRows.length || rowsVisible,
-  );
-  if (visibleCount <= 0) return;
-
-  const leftHeadHeight = leftHeadRows.reduce((sum, row) => sum + row.offsetHeight, 0);
-  const rightHeadHeight = rightHeadRows.reduce((sum, row) => sum + row.offsetHeight, 0);
-  const leftBodyHeight = leftBodyRows.slice(0, visibleCount).reduce((sum, row) => sum + row.offsetHeight, 0);
-  const rightBodyHeight = rightBodyRows.slice(0, visibleCount).reduce((sum, row) => sum + row.offsetHeight, 0);
-  const maxHeight = Math.max(leftHeadHeight + leftBodyHeight, rightHeadHeight + rightBodyHeight);
-  if (maxHeight > 0) {
-    leftWrap.style.maxHeight = `${maxHeight}px`;
-    rightWrap.style.maxHeight = `${maxHeight}px`;
-  }
-};
-
-const _setSingleTableViewport = ({ wrapSelector, rowsVisible = 5 }) => {
-  const wrap = document.querySelector(wrapSelector);
-  const table = wrap?.querySelector("table");
-  if (!wrap || !table) return;
-
-  const headRows = Array.from(table.tHead?.rows || []);
-  const bodyRows = Array.from(table.tBodies[0]?.rows || []);
-  const visibleCount = Math.min(rowsVisible, bodyRows.length || rowsVisible);
-  if (visibleCount <= 0) return;
-
-  const headHeight = headRows.reduce((sum, row) => sum + row.offsetHeight, 0);
-  const bodyHeight = bodyRows.slice(0, visibleCount).reduce((sum, row) => sum + row.offsetHeight, 0);
-  const maxHeight = headHeight + bodyHeight;
-  if (maxHeight > 0) {
-    wrap.style.maxHeight = `${maxHeight}px`;
-  }
-};
-
 const syncSplitTableHeights = () => {
   const tablePairs = isCompactLayout()
     ? [
@@ -1568,10 +1538,6 @@ const syncSplitTableHeights = () => {
     _syncRowPairHeights(leftBodyRows, rightBodyRows);
     _syncStickySecondRowTop(leftTable, rightTable, splitWrap, stickyVar);
   });
-  _setSingleTableViewport({
-    wrapSelector: ".compact-grid-mobile-wrap",
-    rowsVisible: 5,
-  });
 };
 
 let layoutFrame = 0;
@@ -1585,6 +1551,9 @@ const applyLayout = () => {
     updateLayoutMode();
     autoSizeSplitTables();
     syncSplitTableHeights();
+    if (typeof stickySingleTableLayout.applyFromDom === "function") {
+      stickySingleTableLayout.applyFromDom({ root: pageContentRoot || document });
+    }
     attachSplitScrollSync();
   });
 };
@@ -1593,6 +1562,7 @@ const observeLayoutContainers = () => {
   if (!window.ResizeObserver) return;
   if (layoutObserver) layoutObserver.disconnect();
   layoutObserver = new ResizeObserver(() => applyLayout());
+  const observed = new Set();
   [
     ".snowfall-left-wrap#snowfall-left-wrap",
     ".snowfall-right-wrap#snowfall-right-wrap",
@@ -1611,7 +1581,14 @@ const observeLayoutContainers = () => {
     ".sun-right-wrap",
   ].forEach((selector) => {
     const element = document.querySelector(selector);
-    if (element) layoutObserver.observe(element);
+    if (!element || observed.has(element)) return;
+    layoutObserver.observe(element);
+    observed.add(element);
+  });
+  document.querySelectorAll("[data-sticky-single-table-section]").forEach((element) => {
+    if (observed.has(element)) return;
+    layoutObserver.observe(element);
+    observed.add(element);
   });
 };
 
@@ -1835,19 +1812,44 @@ const _SCROLLABLE_WRAP_SELECTORS = [
   ".sun-right-wrap",
 ];
 
-const _captureWrapScrollPositions = () => _SCROLLABLE_WRAP_SELECTORS.map((selector) => {
-  const element = document.querySelector(selector);
-  if (!element) return null;
-  return {
-    selector,
-    scrollTop: element.scrollTop,
-    scrollLeft: element.scrollLeft,
-  };
-}).filter(Boolean);
+const _captureWrapScrollPositions = () => {
+  const entries = [];
+  const seen = new Set();
+  _SCROLLABLE_WRAP_SELECTORS.forEach((selector) => {
+    const element = document.querySelector(selector);
+    if (!element || seen.has(element)) return;
+    entries.push({
+      selector,
+      sectionKey: "",
+      scrollTop: element.scrollTop,
+      scrollLeft: element.scrollLeft,
+    });
+    seen.add(element);
+  });
+  document.querySelectorAll("[data-sticky-single-table-section]").forEach((element) => {
+    if (seen.has(element)) return;
+    const sectionKey = String(element.getAttribute("data-sticky-single-table-section") || "").trim();
+    entries.push({
+      selector: "",
+      sectionKey,
+      scrollTop: element.scrollTop,
+      scrollLeft: element.scrollLeft,
+    });
+    seen.add(element);
+  });
+  return entries;
+};
 
 const _restoreWrapScrollPositions = (positions) => {
   positions.forEach((entry) => {
-    const element = document.querySelector(entry.selector);
+    let element = null;
+    if (entry.sectionKey) {
+      const escapedSectionKey = String(entry.sectionKey).replace(/"/g, "\\\"");
+      element = document.querySelector(`[data-sticky-single-table-section="${escapedSectionKey}"]`);
+    }
+    if (!element && entry.selector) {
+      element = document.querySelector(entry.selector);
+    }
     if (!element) return;
     element.scrollTop = entry.scrollTop;
     element.scrollLeft = entry.scrollLeft;

--- a/assets/js/weather_page.js
+++ b/assets/js/weather_page.js
@@ -546,8 +546,8 @@ const _renderSunSection = (reports, emptyMessage = "No resorts match the current
     const hour12 = hour24 % 12 || 12;
     return `${hour12}:${minute} ${suffix}`;
   };
-  const leftRows = reports.length ? reports.map((report) => `<tr${_filterAttrs(report)}>${_resortCellHtml(report)}</tr>`).join("") : _emptyStateRow(2, emptyMessage);
-  const rightRows = reports.length ? reports.map((report) => {
+  const totalColumns = 2 + (displayDays * 2);
+  const rows = reports.length ? reports.map((report) => {
     const attrs = _filterAttrs(report);
     const cells = Array.from({ length: displayDays }, (_, idx) => {
       const day = _dailyAt(report, idx);
@@ -557,8 +557,8 @@ const _renderSunSection = (reports, emptyMessage = "No resorts match the current
       const sunset = hhmm(sunsetRaw, appState.sunTimeToggleMode);
       return `<td data-sun-time-raw="${_escapeHtml(sunriseRaw)}">${_escapeHtml(sunrise)}</td><td data-sun-time-raw="${_escapeHtml(sunsetRaw)}">${_escapeHtml(sunset)}</td>`;
     }).join("");
-    return `<tr${attrs}>${cells}</tr>`;
-  }).join("") : _emptyStateRow(Math.max(1, displayDays * 2), emptyMessage);
+    return `<tr${attrs}>${_resortCellHtml(report)}${cells}</tr>`;
+  }).join("") : _emptyStateRow(totalColumns, emptyMessage);
   return `
     <section>
       <div class="section-header">
@@ -568,21 +568,19 @@ const _renderSunSection = (reports, emptyMessage = "No resorts match the current
           <button type="button" class="unit-btn" data-unit-mode="imperial">12h</button>
         </div>
       </div>
-      <div class="sun-split-wrap">
-        <div class="sun-left-wrap" id="sun-left-wrap">
-          <table class="sun-left-table" id="sun-left-table">
-            <colgroup><col class="col-favorite"><col class="col-query"></colgroup>
-            <thead><tr><th rowspan='2' class='favorite-col favorite-head'>${_favoriteAllButtonHtml(reports)}</th><th rowspan='2' class='query-col'>Resort</th></tr><tr></tr></thead>
-            <tbody>${leftRows}</tbody>
-          </table>
-        </div>
-        <div class="sun-right-wrap" id="sun-right-wrap">
-          <table class="sun-right-table" id="sun-right-table">
-            <colgroup>${Array.from({ length: displayDays * 2 }, () => "<col class='col-sun'>").join("")}</colgroup>
-            <thead><tr>${labels.map((label) => `<th colspan='2'>${_dayLabelHtml(label)}</th>`).join("")}</tr><tr>${Array.from({ length: displayDays }, () => "<th>sunrise</th><th>sunset</th>").join("")}</tr></thead>
-            <tbody>${rightRows}</tbody>
-          </table>
-        </div>
+      <div
+        class="sun-single-wrap"
+        id="sun-single-wrap"
+        data-sticky-single-table-section="${STICKY_SINGLE_TABLE_SECTION_KEYS.sun}"
+        data-sticky-leading-cols="2"
+        data-sticky-header-rows="2"
+        data-sticky-max-visible-rows="10"
+      >
+        <table class="sun-single-table" id="sun-single-table">
+          <colgroup><col class="col-favorite"><col class="col-query">${Array.from({ length: displayDays * 2 }, () => "<col class='col-sun'>").join("")}</colgroup>
+          <thead><tr><th rowspan='2' class='favorite-col favorite-head'>${_favoriteAllButtonHtml(reports)}</th><th rowspan='2' class='query-col'>Resort</th>${labels.map((label) => `<th colspan='2'>${_dayLabelHtml(label)}</th>`).join("")}</tr><tr>${Array.from({ length: displayDays }, () => "<th>sunrise</th><th>sunset</th>").join("")}</tr></thead>
+          <tbody>${rows}</tbody>
+        </table>
       </div>
     </section>`;
 };
@@ -1311,7 +1309,6 @@ const attachSplitScrollSync = () => {
     [".rain-left-wrap#rain-left-wrap-mobile", ".rain-right-wrap#rain-right-wrap-mobile"],
     [".temperature-left-wrap", ".temperature-right-wrap"],
     [".weather-left-wrap", ".weather-right-wrap"],
-    [".sun-left-wrap", ".sun-right-wrap"],
   ].forEach(([leftSelector, rightSelector]) => {
     attachVerticalSync(document.querySelector(leftSelector), document.querySelector(rightSelector));
   });
@@ -1404,8 +1401,8 @@ const autoSizeSplitTables = () => {
       capToMobileHalfScreen: true,
     });
     _autoSizeQueryOnly({
-      tableSelector: ".sun-left-wrap .sun-left-table",
-      wrapSelector: ".sun-left-wrap",
+      tableSelector: ".sun-single-wrap .sun-single-table",
+      wrapSelector: ".sun-single-wrap",
       queryVarName: "--sun-query-w",
       minWidth: 150,
       maxWidth: 220,
@@ -1454,8 +1451,8 @@ const autoSizeSplitTables = () => {
     minWidth: 50,
   });
   _autoSizeQueryOnly({
-    tableSelector: ".sun-left-wrap .sun-left-table",
-    wrapSelector: ".sun-left-wrap",
+    tableSelector: ".sun-single-wrap .sun-single-table",
+    wrapSelector: ".sun-single-wrap",
     queryVarName: "--sun-query-w",
   });
   _stretchColumnsToWrap({
@@ -1465,8 +1462,8 @@ const autoSizeSplitTables = () => {
     minWidth: 68,
   });
   _stretchColumnsToWrap({
-    wrapSelector: ".sun-right-wrap",
-    tableSelector: ".sun-right-table",
+    wrapSelector: ".sun-single-wrap",
+    tableSelector: ".sun-single-table",
     colSelector: "col.col-sun",
     minWidth: 58,
   });
@@ -1509,14 +1506,12 @@ const syncSplitTableHeights = () => {
       [".rain-left-wrap#rain-left-wrap-mobile .rain-left-table", ".rain-right-wrap#rain-right-wrap-mobile .rain-right-table", ".rain-split-wrap.mobile-only", "--rain-header-row1-h"],
       [".temperature-left-table", ".temperature-right-table", ".temperature-split-wrap", "--temp-header-row1-h"],
       [".weather-left-table", ".weather-right-table", ".weather-split-wrap", "--weather-header-row1-h"],
-      [".sun-left-table", ".sun-right-table", ".sun-split-wrap", "--sun-header-row1-h"],
     ]
     : [
       [".snowfall-left-wrap#snowfall-left-wrap .snowfall-left-table", ".snowfall-right-wrap#snowfall-right-wrap .snowfall-right-table", ".snowfall-split-wrap.desktop-only", "--snow-header-row1-h"],
       [".rain-left-wrap#rain-left-wrap .rain-left-table", ".rain-right-wrap#rain-right-wrap .rain-right-table", ".rain-split-wrap.desktop-only", "--rain-header-row1-h"],
       [".temperature-left-table", ".temperature-right-table", ".temperature-split-wrap", "--temp-header-row1-h"],
       [".weather-left-table", ".weather-right-table", ".weather-split-wrap", "--weather-header-row1-h"],
-      [".sun-left-table", ".sun-right-table", ".sun-split-wrap", "--sun-header-row1-h"],
     ];
   tablePairs.forEach(([leftSelector, rightSelector, wrapSelector, stickyVar]) => {
     const leftTable = document.querySelector(leftSelector);
@@ -1577,8 +1572,7 @@ const observeLayoutContainers = () => {
     ".temperature-right-wrap",
     ".weather-left-wrap",
     ".weather-right-wrap",
-    ".sun-left-wrap",
-    ".sun-right-wrap",
+    ".sun-single-wrap",
   ].forEach((selector) => {
     const element = document.querySelector(selector);
     if (!element || observed.has(element)) return;
@@ -1808,8 +1802,7 @@ const _SCROLLABLE_WRAP_SELECTORS = [
   ".temperature-right-wrap",
   ".weather-left-wrap",
   ".weather-right-wrap",
-  ".sun-left-wrap",
-  ".sun-right-wrap",
+  ".sun-single-wrap",
 ];
 
 const _captureWrapScrollPositions = () => {

--- a/src/web/templates/weather_page.html
+++ b/src/web/templates/weather_page.html
@@ -103,6 +103,7 @@
     window.CLOSESNOW_INITIAL_PAYLOAD = {{initial_payload_json}};
   </script>
   <script src="assets/js/compact_daily_summary.js"></script>
+  <script src="assets/js/sticky_single_table_layout.js"></script>
   <script src="assets/js/weather_page.js"></script>
 </body>
 </html>

--- a/src/web/weather_page_assets.py
+++ b/src/web/weather_page_assets.py
@@ -9,6 +9,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 ASSET_MIME_TYPES: Dict[str, str] = {
     "assets/css/weather_page.css": "text/css; charset=utf-8",
     "assets/js/compact_daily_summary.js": "application/javascript; charset=utf-8",
+    "assets/js/sticky_single_table_layout.js": "application/javascript; charset=utf-8",
     "assets/js/weather_page.js": "application/javascript; charset=utf-8",
     "assets/css/resort_hourly.css": "text/css; charset=utf-8",
     "assets/js/resort_hourly.js": "application/javascript; charset=utf-8",

--- a/tests/frontend/test_assets.py
+++ b/tests/frontend/test_assets.py
@@ -8,11 +8,13 @@ from src.web.weather_page_assets import ASSET_MIME_TYPES, asset_path, read_asset
 def test_asset_path_points_to_repo_assets():
     css_path = asset_path("assets/css/weather_page.css")
     compact_js_path = asset_path("assets/js/compact_daily_summary.js")
+    sticky_layout_js_path = asset_path("assets/js/sticky_single_table_layout.js")
     js_path = asset_path("assets/js/weather_page.js")
     hourly_css_path = asset_path("assets/css/resort_hourly.css")
     hourly_js_path = asset_path("assets/js/resort_hourly.js")
     assert str(css_path).endswith("assets/css/weather_page.css")
     assert str(compact_js_path).endswith("assets/js/compact_daily_summary.js")
+    assert str(sticky_layout_js_path).endswith("assets/js/sticky_single_table_layout.js")
     assert str(js_path).endswith("assets/js/weather_page.js")
     assert str(hourly_css_path).endswith("assets/css/resort_hourly.css")
     assert str(hourly_js_path).endswith("assets/js/resort_hourly.js")
@@ -21,21 +23,25 @@ def test_asset_path_points_to_repo_assets():
 def test_read_asset_bytes_reads_known_assets():
     css = read_asset_bytes("assets/css/weather_page.css")
     compact_js = read_asset_bytes("assets/js/compact_daily_summary.js")
+    sticky_layout_js = read_asset_bytes("assets/js/sticky_single_table_layout.js")
     js = read_asset_bytes("assets/js/weather_page.js")
     hourly_css = read_asset_bytes("assets/css/resort_hourly.css")
     hourly_js = read_asset_bytes("assets/js/resort_hourly.js")
     assert len(css) > 100
     assert len(compact_js) > 100
+    assert len(sticky_layout_js) > 100
     assert len(js) > 100
     assert len(hourly_css) > 100
     assert len(hourly_js) > 100
     assert ASSET_MIME_TYPES["assets/css/weather_page.css"].startswith("text/css")
     assert ASSET_MIME_TYPES["assets/js/compact_daily_summary.js"].startswith("application/javascript")
+    assert ASSET_MIME_TYPES["assets/js/sticky_single_table_layout.js"].startswith("application/javascript")
     assert ASSET_MIME_TYPES["assets/js/weather_page.js"].startswith("application/javascript")
     assert ASSET_MIME_TYPES["assets/css/resort_hourly.css"].startswith("text/css")
     assert ASSET_MIME_TYPES["assets/js/resort_hourly.js"].startswith("application/javascript")
     css_text = css.decode("utf-8", errors="ignore")
     compact_js_text = compact_js.decode("utf-8", errors="ignore")
+    sticky_layout_js_text = sticky_layout_js.decode("utf-8", errors="ignore")
     hourly_css_text = hourly_css.decode("utf-8", errors="ignore")
     hourly_js_text = hourly_js.decode("utf-8", errors="ignore")
     js_text = js.decode("utf-8", errors="ignore")
@@ -61,6 +67,9 @@ def test_read_asset_bytes_reads_known_assets():
     assert "width: 100%;" in hourly_css_text
     assert "min-width: 0;" in hourly_css_text
     assert "window.CloseSnowCompactDailySummary" in compact_js_text
+    assert "window.CloseSnowStickySingleTableLayout" in sticky_layout_js_text
+    assert "STICKY_VIEWPORT_ROW_CAP = 10" in sticky_layout_js_text
+    assert "[data-sticky-single-table-section]" in sticky_layout_js_text
     assert "renderSingleResortHtml" in compact_js_text
     assert "labelMode" in compact_js_text
     assert 'return "Today";' in compact_js_text
@@ -72,6 +81,9 @@ def test_read_asset_bytes_reads_known_assets():
     assert "compact-day-cell-phase-start" not in compact_js_text
     assert "window.CLOSESNOW_PAGE_BOOTSTRAP" in js_text
     assert "window.CLOSESNOW_INITIAL_PAYLOAD" in js_text
+    assert "STICKY_SINGLE_TABLE_SECTION_KEYS" in js_text
+    assert "stickySingleTableLayout.applyFromDom" in js_text
+    assert "data-sticky-single-table-section" in js_text
     assert "No resorts match the current filters." in js_text
     assert "report.state_name" in js_text
     assert "report.country_name" in js_text

--- a/tests/frontend/test_assets.py
+++ b/tests/frontend/test_assets.py
@@ -84,6 +84,8 @@ def test_read_asset_bytes_reads_known_assets():
     assert "STICKY_SINGLE_TABLE_SECTION_KEYS" in js_text
     assert "stickySingleTableLayout.applyFromDom" in js_text
     assert "data-sticky-single-table-section" in js_text
+    assert "temperature-sticky-wrap" in js_text
+    assert "temperature-single-table" in js_text
     assert "No resorts match the current filters." in js_text
     assert "report.state_name" in js_text
     assert "report.country_name" in js_text

--- a/tests/frontend/test_renderers.py
+++ b/tests/frontend/test_renderers.py
@@ -248,6 +248,7 @@ def test_build_html_contains_meta_sections():
     assert "Feature requests" in html
     assert "<h2>Daily Summary</h2>" in html
     assert "<h2>Sunrise / Sunset</h2>" in html
+    assert 'src="assets/js/sticky_single_table_layout.js"' in html
     assert html.index("<h2>Temperature</h2>") < html.index("<h2>Weather</h2>")
     assert 'id="resort-search-input"' in html
     assert 'id="filter-open-btn"' in html


### PR DESCRIPTION
## Summary
- introduce the shared sticky single-table contract across homepage forecast sections
- convert weather, temperature, sun, snowfall, and rainfall to the unified sticky-table interactions required by this feature branch
- keep precipitation weekly columns fixed, cap daily summary to 5 visible rows, and align weather mobile/desktop to the same frontend path

## Testing
- python3 -m pytest tests/frontend/test_assets.py -q
- python3 -m pytest tests/frontend/test_renderers.py -q
- python3 -m src.cli static --output-dir /tmp/closesnow-homepage-sticky-tables-branch-preview --max-workers 8