### PR TITLE
Publish backend request/hourly services

### DIFF
--- a/src/backend/services/__init__.py
+++ b/src/backend/services/__init__.py
@@ -1,5 +1,27 @@
+from src.backend.services.hourly_payload_service import build_hourly_payload_for_resort
+from src.backend.services.resort_selection_service import (
+    apply_catalog_filters,
+    available_filters,
+    build_empty_payload,
+    catalog_item_with_display_name,
+    default_applied_filters,
+    load_supported_resort_catalog,
+    select_resorts_from_query,
+    split_query_values,
+    supported_catalog,
+)
 from src.backend.services.weather_service import build_weather_payload
 
 __all__ = [
+    "apply_catalog_filters",
+    "available_filters",
+    "build_empty_payload",
+    "build_hourly_payload_for_resort",
     "build_weather_payload",
+    "catalog_item_with_display_name",
+    "default_applied_filters",
+    "load_supported_resort_catalog",
+    "select_resorts_from_query",
+    "split_query_values",
+    "supported_catalog",
 ]

--- a/src/backend/services/hourly_payload_service.py
+++ b/src/backend/services/hourly_payload_service.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from src.backend.airport_catalog import find_nearby_airports, load_airport_catalog
+from src.backend.cache import JsonCache, ResortCoordinateCache, dated_cache_path
+from src.backend.constants import COORDINATES_CACHE_FILE
+from src.backend.io import seed_coordinate_cache_from_entries
+from src.backend.open_meteo import fetch_hourly_forecast, geocode
+from src.backend.services.resort_selection_service import load_supported_resort_catalog
+
+
+def build_hourly_payload_for_resort(
+    *,
+    resort_id: str,
+    hours: int,
+    cache_file: str,
+    geocode_cache_hours: int,
+    forecast_cache_hours: int,
+) -> Dict[str, object] | None:
+    catalog = load_supported_resort_catalog()
+    item = next((r for r in catalog if str(r.get("resort_id", "")) == resort_id), None)
+    if item is None:
+        return None
+
+    cache_path = dated_cache_path(cache_file)
+    cache = JsonCache(cache_path)
+    coord_cache = ResortCoordinateCache(COORDINATES_CACHE_FILE)
+    query = str(item.get("query", "")).strip()
+    seed_coordinate_cache_from_entries(coord_cache, [item])
+    location = geocode(
+        query,
+        cache=cache,
+        ttl_seconds=geocode_cache_hours * 3600,
+        coord_cache=coord_cache,
+    )
+    if location is None:
+        return {
+            "error": f"Unable to geocode resort '{query}'",
+            "resort_id": resort_id,
+            "query": query,
+        }
+
+    forecast = fetch_hourly_forecast(
+        location,
+        cache=cache,
+        ttl_seconds=forecast_cache_hours * 3600,
+        hours=hours,
+    )
+    cache.save()
+    coord_cache.save()
+    try:
+        airports = load_airport_catalog()
+    except Exception:
+        airports = []
+    nearby_airports = find_nearby_airports(
+        resort_latitude=location.latitude,
+        resort_longitude=location.longitude,
+        airports=airports,
+        radius_miles=250.0,
+    )
+
+    hourly = forecast.get("hourly", {}) if isinstance(forecast, dict) else {}
+    times = list(hourly.get("time", []))
+    n = min(hours, len(times))
+    metric_keys = [
+        "snowfall",
+        "rain",
+        "precipitation_probability",
+        "snow_depth",
+        "wind_speed_10m",
+        "wind_direction_10m",
+        "visibility",
+    ]
+    trimmed_hourly: Dict[str, object] = {"time": times[:n]}
+    for key in metric_keys:
+        values = hourly.get(key, [])
+        if isinstance(values, list):
+            trimmed_hourly[key] = values[:n]
+        else:
+            trimmed_hourly[key] = []
+
+    return {
+        "resort_id": resort_id,
+        "query": query,
+        "display_name": str(item.get("display_name") or query).strip(),
+        "website": str(item.get("website") or "").strip(),
+        "matched_name": location.name,
+        "country": item.get("country"),
+        "region": item.get("region"),
+        "subregion": item.get("subregion"),
+        "pass_types": item.get("pass_types", []),
+        "timezone": forecast.get("timezone"),
+        "model": "ecmwf_ifs025",
+        "input_latitude": location.latitude,
+        "input_longitude": location.longitude,
+        "resolved_latitude": forecast.get("latitude"),
+        "resolved_longitude": forecast.get("longitude"),
+        "nearby_airports": nearby_airports,
+        "hours": n,
+        "hourly": trimmed_hourly,
+    }

--- a/src/backend/services/resort_selection_service.py
+++ b/src/backend/services/resort_selection_service.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+from src.backend.compute.payload_metadata import build_payload_metadata
+from src.backend.resort_catalog import load_resort_catalog, search_resort_catalog
+from src.shared.config import DEFAULT_RESORTS_FILE
+
+_SUPPORTED_PASS_TYPES = {"epic", "ikon"}
+
+
+def split_query_values(values: List[str], *, to_upper: bool = False) -> List[str]:
+    out: List[str] = []
+    for raw in values:
+        for part in raw.split(","):
+            val = part.strip().upper() if to_upper else part.strip().lower()
+            if val:
+                out.append(val)
+    seen = set()
+    return [x for x in out if not (x in seen or seen.add(x))]
+
+
+def to_bool_flag(raw: str) -> bool:
+    return (raw or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def supported_catalog(catalog: List[Dict[str, object]]) -> List[Dict[str, object]]:
+    out: List[Dict[str, object]] = []
+    for item in catalog:
+        raw_pass_types = item.get("pass_types")
+        if not isinstance(raw_pass_types, list):
+            continue
+        pass_types = {str(v).strip().lower() for v in raw_pass_types if str(v).strip()}
+        if pass_types.intersection(_SUPPORTED_PASS_TYPES):
+            out.append(item)
+    return out
+
+
+def load_supported_resort_catalog(resorts_file: str = DEFAULT_RESORTS_FILE) -> List[Dict[str, object]]:
+    return supported_catalog(load_resort_catalog(resorts_file))
+
+
+def catalog_item_with_display_name(item: Dict[str, object]) -> Dict[str, object]:
+    out = dict(item)
+    out["display_name"] = str(item.get("display_name") or item.get("query") or "").strip()
+    out["website"] = str(item.get("website") or "").strip()
+    return out
+
+
+def available_filters(catalog: List[Dict[str, object]]) -> Dict[str, Dict[str, int]]:
+    pass_type_counts: Dict[str, int] = {}
+    region_counts: Dict[str, int] = {}
+    subregion_counts: Dict[str, int] = {}
+    country_counts: Dict[str, int] = {}
+    for item in catalog:
+        region = str(item.get("region", "")).strip().lower()
+        if region:
+            region_counts[region] = region_counts.get(region, 0) + 1
+        subregion = str(item.get("subregion", "")).strip().lower()
+        if subregion:
+            subregion_counts[subregion] = subregion_counts.get(subregion, 0) + 1
+        country = str(item.get("country", "")).strip().upper()
+        if country:
+            country_counts[country] = country_counts.get(country, 0) + 1
+        for pass_type in item.get("pass_types", []) if isinstance(item.get("pass_types"), list) else []:
+            pt = str(pass_type).strip().lower()
+            if pt:
+                pass_type_counts[pt] = pass_type_counts.get(pt, 0) + 1
+    return {
+        "pass_type": pass_type_counts,
+        "region": region_counts,
+        "subregion": subregion_counts,
+        "country": country_counts,
+    }
+
+
+def apply_catalog_filters(
+    catalog: List[Dict[str, object]],
+    *,
+    pass_types: List[str],
+    region: str,
+    subregions: List[str],
+    countries: List[str],
+    search: str,
+) -> List[Dict[str, object]]:
+    items = search_resort_catalog(catalog, search)
+    if pass_types:
+        allowed = set(pass_types)
+        items = [
+            item
+            for item in items
+            if allowed.intersection(
+                {str(v).strip().lower() for v in (item.get("pass_types") or []) if str(v).strip()}
+            )
+        ]
+    if region:
+        want = region.lower()
+        items = [item for item in items if str(item.get("region", "")).strip().lower() == want]
+    if subregions:
+        allowed_subregions = set(subregions)
+        items = [item for item in items if str(item.get("subregion", "")).strip().lower() in allowed_subregions]
+    if countries:
+        allowed_countries = set(countries)
+        items = [item for item in items if str(item.get("country", "")).strip().upper() in allowed_countries]
+    return items
+
+
+def build_empty_payload(cache_file: str, geocode_cache_hours: int, forecast_cache_hours: int) -> Dict[str, object]:
+    return build_payload_metadata(
+        cache_path=cache_file,
+        cache_hits=0,
+        cache_misses=0,
+        geocode_cache_hours=geocode_cache_hours,
+        forecast_cache_hours=forecast_cache_hours,
+        reports=[],
+        failed=[],
+    )
+
+
+def default_applied_filters() -> Dict[str, object]:
+    return {
+        "pass_type": [],
+        "region": "",
+        "subregion": [],
+        "country": [],
+        "search": "",
+        "search_all": True,
+        "include_default": True,
+        "include_all": False,
+    }
+
+
+def select_resorts_from_query(qs: dict) -> tuple[List[str], str, dict, dict, bool]:
+    resorts = [x.strip() for x in qs.get("resort", []) if x.strip()]
+    pass_types = split_query_values(qs.get("pass_type", []))
+    region = (qs.get("region", [""])[0] or "").strip().lower()
+    subregions = split_query_values(qs.get("subregion", []))
+    countries = split_query_values(qs.get("country", []), to_upper=True)
+    search_text = (qs.get("search", [""])[0] or "").strip()
+    has_search_all = "search_all" in qs
+    search_all = to_bool_flag((qs.get("search_all", [""])[0] or "")) if has_search_all else True
+    has_include_default = "include_default" in qs
+    include_default = to_bool_flag((qs.get("include_default", [""])[0] or "")) if has_include_default else False
+    include_all = to_bool_flag((qs.get("include_all", [""])[0] or ""))
+    applied = {
+        "pass_type": pass_types,
+        "region": region,
+        "subregion": subregions,
+        "country": countries,
+        "search": search_text,
+        "search_all": search_all,
+        "include_default": include_default,
+        "include_all": include_all,
+    }
+
+    catalog = load_supported_resort_catalog(DEFAULT_RESORTS_FILE)
+    available = available_filters(catalog)
+    has_filters = bool(
+        pass_types or region or subregions or countries or search_text or include_all or has_include_default or has_search_all
+    )
+    if not has_filters:
+        applied["search_all"] = True
+        applied["include_default"] = not bool(resorts)
+        applied["include_all"] = False
+        resorts_file = "" if resorts else DEFAULT_RESORTS_FILE
+        return resorts, resorts_file, applied, available, False
+
+    if search_text and search_all:
+        # Search-all mode ignores pass/region/country/default scope and searches full supported catalog.
+        filtered_catalog = search_resort_catalog(catalog, search_text)
+    elif include_default:
+        default_catalog = [item for item in catalog if bool(item.get("default_enabled", False))]
+        filtered_catalog = apply_catalog_filters(
+            default_catalog,
+            pass_types=pass_types,
+            region=region,
+            subregions=subregions,
+            countries=countries,
+            search=search_text,
+        )
+    elif include_all and not (pass_types or region or subregions or countries or search_text):
+        filtered_catalog = list(catalog)
+    else:
+        filtered_catalog = apply_catalog_filters(
+            catalog,
+            pass_types=pass_types,
+            region=region,
+            subregions=subregions,
+            countries=countries,
+            search=search_text,
+        )
+
+    allowed_queries = {
+        str(item.get("query", "")).strip()
+        for item in filtered_catalog
+        if str(item.get("query", "")).strip()
+    }
+    if resorts:
+        selected = [r for r in resorts if r in allowed_queries]
+    else:
+        selected = [
+            str(item["query"]).strip()
+            for item in filtered_catalog
+            if str(item.get("query", "")).strip()
+        ]
+    no_match = len(selected) == 0
+    return selected, "", applied, available, no_match

--- a/src/backend/weather_data_server.py
+++ b/src/backend/weather_data_server.py
@@ -13,18 +13,20 @@ from urllib.parse import parse_qs, urlparse
 if str(Path(__file__).resolve().parents[2]) not in sys.path:
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from src.backend.cache import JsonCache, ResortCoordinateCache, dated_cache_path
-from src.backend.airport_catalog import find_nearby_airports, load_airport_catalog
-from src.backend.constants import COORDINATES_CACHE_FILE
-from src.backend.io import seed_coordinate_cache_from_entries
-from src.backend.compute.payload_metadata import build_payload_metadata
-from src.backend.open_meteo import fetch_hourly_forecast, geocode
 from src.backend.pipelines.live_pipeline import run_live_payload
-from src.backend.resort_catalog import load_resort_catalog, search_resort_catalog
+from src.backend.services.hourly_payload_service import build_hourly_payload_for_resort
+from src.backend.services.resort_selection_service import (
+    apply_catalog_filters,
+    available_filters,
+    build_empty_payload,
+    catalog_item_with_display_name,
+    default_applied_filters,
+    load_supported_resort_catalog,
+    select_resorts_from_query,
+    split_query_values,
+    supported_catalog,
+)
 from src.shared.config import DEFAULT_RESORTS_FILE
-
-_SUPPORTED_PASS_TYPES = {"epic", "ikon"}
-
 
 def _append_common_headers(handler: BaseHTTPRequestHandler, allow_origin: str) -> None:
     handler.send_header("Access-Control-Allow-Origin", allow_origin)
@@ -33,64 +35,19 @@ def _append_common_headers(handler: BaseHTTPRequestHandler, allow_origin: str) -
 
 
 def _split_query_values(values: List[str], *, to_upper: bool = False) -> List[str]:
-    out: List[str] = []
-    for raw in values:
-        for part in raw.split(","):
-            val = part.strip().upper() if to_upper else part.strip().lower()
-            if val:
-                out.append(val)
-    seen = set()
-    return [x for x in out if not (x in seen or seen.add(x))]
-
-
-def _to_bool_flag(raw: str) -> bool:
-    return (raw or "").strip().lower() in {"1", "true", "yes", "on"}
+    return split_query_values(values, to_upper=to_upper)
 
 
 def _supported_catalog(catalog: List[Dict[str, object]]) -> List[Dict[str, object]]:
-    out: List[Dict[str, object]] = []
-    for item in catalog:
-        raw_pass_types = item.get("pass_types")
-        if not isinstance(raw_pass_types, list):
-            continue
-        pass_types = {str(v).strip().lower() for v in raw_pass_types if str(v).strip()}
-        if pass_types.intersection(_SUPPORTED_PASS_TYPES):
-            out.append(item)
-    return out
+    return supported_catalog(catalog)
 
 
 def _catalog_item_with_display_name(item: Dict[str, object]) -> Dict[str, object]:
-    out = dict(item)
-    out["display_name"] = str(item.get("display_name") or item.get("query") or "").strip()
-    out["website"] = str(item.get("website") or "").strip()
-    return out
+    return catalog_item_with_display_name(item)
 
 
 def _available_filters(catalog: List[Dict[str, object]]) -> Dict[str, Dict[str, int]]:
-    pass_type_counts: Dict[str, int] = {}
-    region_counts: Dict[str, int] = {}
-    subregion_counts: Dict[str, int] = {}
-    country_counts: Dict[str, int] = {}
-    for item in catalog:
-        region = str(item.get("region", "")).strip().lower()
-        if region:
-            region_counts[region] = region_counts.get(region, 0) + 1
-        subregion = str(item.get("subregion", "")).strip().lower()
-        if subregion:
-            subregion_counts[subregion] = subregion_counts.get(subregion, 0) + 1
-        country = str(item.get("country", "")).strip().upper()
-        if country:
-            country_counts[country] = country_counts.get(country, 0) + 1
-        for pass_type in item.get("pass_types", []) if isinstance(item.get("pass_types"), list) else []:
-            pt = str(pass_type).strip().lower()
-            if pt:
-                pass_type_counts[pt] = pass_type_counts.get(pt, 0) + 1
-    return {
-        "pass_type": pass_type_counts,
-        "region": region_counts,
-        "subregion": subregion_counts,
-        "country": country_counts,
-    }
+    return available_filters(catalog)
 
 
 def _apply_catalog_filters(
@@ -102,136 +59,22 @@ def _apply_catalog_filters(
     countries: List[str],
     search: str,
 ) -> List[Dict[str, object]]:
-    items = search_resort_catalog(catalog, search)
-    if pass_types:
-        allowed = set(pass_types)
-        items = [
-            item
-            for item in items
-            if allowed.intersection(
-                {str(v).strip().lower() for v in (item.get("pass_types") or []) if str(v).strip()}
-            )
-        ]
-    if region:
-        want = region.lower()
-        items = [item for item in items if str(item.get("region", "")).strip().lower() == want]
-    if subregions:
-        allowed_subregions = set(subregions)
-        items = [item for item in items if str(item.get("subregion", "")).strip().lower() in allowed_subregions]
-    if countries:
-        allowed_countries = set(countries)
-        items = [item for item in items if str(item.get("country", "")).strip().upper() in allowed_countries]
-    return items
+    return apply_catalog_filters(
+        catalog,
+        pass_types=pass_types,
+        region=region,
+        subregions=subregions,
+        countries=countries,
+        search=search,
+    )
 
 
 def _empty_payload(cache_file: str, geocode_cache_hours: int, forecast_cache_hours: int) -> Dict[str, object]:
-    return build_payload_metadata(
-        cache_path=cache_file,
-        cache_hits=0,
-        cache_misses=0,
-        geocode_cache_hours=geocode_cache_hours,
-        forecast_cache_hours=forecast_cache_hours,
-        reports=[],
-        failed=[],
-    )
+    return build_empty_payload(cache_file, geocode_cache_hours, forecast_cache_hours)
 
 
 def _default_applied_filters() -> Dict[str, object]:
-    return {
-        "pass_type": [],
-        "region": "",
-        "subregion": [],
-        "country": [],
-        "search": "",
-        "search_all": True,
-        "include_default": True,
-        "include_all": False,
-    }
-
-
-def select_resorts_from_query(qs: dict) -> tuple[List[str], str, dict, dict, bool]:
-    resorts = [x.strip() for x in qs.get("resort", []) if x.strip()]
-    pass_types = _split_query_values(qs.get("pass_type", []))
-    region = (qs.get("region", [""])[0] or "").strip().lower()
-    subregions = _split_query_values(qs.get("subregion", []))
-    countries = _split_query_values(qs.get("country", []), to_upper=True)
-    search_text = (qs.get("search", [""])[0] or "").strip()
-    has_search_all = "search_all" in qs
-    search_all = _to_bool_flag((qs.get("search_all", [""])[0] or "")) if has_search_all else True
-    has_include_default = "include_default" in qs
-    include_default = _to_bool_flag((qs.get("include_default", [""])[0] or "")) if has_include_default else False
-    include_all = _to_bool_flag((qs.get("include_all", [""])[0] or ""))
-    applied = {
-        "pass_type": pass_types,
-        "region": region,
-        "subregion": subregions,
-        "country": countries,
-        "search": search_text,
-        "search_all": search_all,
-        "include_default": include_default,
-        "include_all": include_all,
-    }
-
-    catalog = _supported_catalog(load_resort_catalog(DEFAULT_RESORTS_FILE))
-    available = _available_filters(catalog)
-    has_filters = bool(
-        pass_types or region or subregions or countries or search_text or include_all or has_include_default or has_search_all
-    )
-    if not has_filters:
-        applied["search_all"] = True
-        applied["include_default"] = not bool(resorts)
-        applied["include_all"] = False
-        resorts_file = "" if resorts else DEFAULT_RESORTS_FILE
-        return resorts, resorts_file, applied, available, False
-
-    if search_text and search_all:
-        # Search-all mode ignores pass/region/country/default scope and searches full supported catalog.
-        filtered_catalog = search_resort_catalog(catalog, search_text)
-    elif include_default:
-        default_catalog = [item for item in catalog if bool(item.get("default_enabled", False))]
-        filtered_catalog = _apply_catalog_filters(
-            default_catalog,
-            pass_types=pass_types,
-            region=region,
-            subregions=subregions,
-            countries=countries,
-            search=search_text,
-        )
-    elif include_all and not (pass_types or region or subregions or countries or search_text):
-        filtered_catalog = list(catalog)
-    else:
-        filtered_catalog = _apply_catalog_filters(
-            catalog,
-            pass_types=pass_types,
-            region=region,
-            subregions=subregions,
-            countries=countries,
-            search=search_text,
-        )
-
-    allowed_queries = {
-        str(item.get("query", "")).strip()
-        for item in filtered_catalog
-        if str(item.get("query", "")).strip()
-    }
-    if resorts:
-        selected = [r for r in resorts if r in allowed_queries]
-    else:
-        selected = [
-            str(item["query"]).strip()
-            for item in filtered_catalog
-            if str(item.get("query", "")).strip()
-        ]
-    no_match = len(selected) == 0
-    return selected, "", applied, available, no_match
-
-
-def _parse_hours(raw: str, default: int = 72) -> int:
-    try:
-        value = int(raw)
-    except (TypeError, ValueError):
-        value = default
-    return max(1, min(240, value))
+    return default_applied_filters()
 
 
 def _hourly_payload_for_resort(
@@ -242,88 +85,21 @@ def _hourly_payload_for_resort(
     geocode_cache_hours: int,
     forecast_cache_hours: int,
 ) -> Dict[str, object] | None:
-    catalog = _supported_catalog(load_resort_catalog(DEFAULT_RESORTS_FILE))
-    item = next((r for r in catalog if str(r.get("resort_id", "")) == resort_id), None)
-    if item is None:
-        return None
-
-    cache_path = dated_cache_path(cache_file)
-    cache = JsonCache(cache_path)
-    coord_cache = ResortCoordinateCache(COORDINATES_CACHE_FILE)
-    query = str(item.get("query", "")).strip()
-    seed_coordinate_cache_from_entries(coord_cache, [item])
-    location = geocode(
-        query,
-        cache=cache,
-        ttl_seconds=geocode_cache_hours * 3600,
-        coord_cache=coord_cache,
-    )
-    if location is None:
-        return {
-            "error": f"Unable to geocode resort '{query}'",
-            "resort_id": resort_id,
-            "query": query,
-        }
-
-    forecast = fetch_hourly_forecast(
-        location,
-        cache=cache,
-        ttl_seconds=forecast_cache_hours * 3600,
+    return build_hourly_payload_for_resort(
+        resort_id=resort_id,
         hours=hours,
+        cache_file=cache_file,
+        geocode_cache_hours=geocode_cache_hours,
+        forecast_cache_hours=forecast_cache_hours,
     )
-    cache.save()
-    coord_cache.save()
+
+
+def _parse_hours(raw: str, default: int = 72) -> int:
     try:
-        airports = load_airport_catalog()
-    except Exception:
-        airports = []
-    nearby_airports = find_nearby_airports(
-        resort_latitude=location.latitude,
-        resort_longitude=location.longitude,
-        airports=airports,
-        radius_miles=250.0,
-    )
-
-    hourly = forecast.get("hourly", {}) if isinstance(forecast, dict) else {}
-    times = list(hourly.get("time", []))
-    n = min(hours, len(times))
-    metric_keys = [
-        "snowfall",
-        "rain",
-        "precipitation_probability",
-        "snow_depth",
-        "wind_speed_10m",
-        "wind_direction_10m",
-        "visibility",
-    ]
-    trimmed_hourly: Dict[str, object] = {"time": times[:n]}
-    for key in metric_keys:
-        values = hourly.get(key, [])
-        if isinstance(values, list):
-            trimmed_hourly[key] = values[:n]
-        else:
-            trimmed_hourly[key] = []
-
-    return {
-        "resort_id": resort_id,
-        "query": query,
-        "display_name": str(item.get("display_name") or query).strip(),
-        "website": str(item.get("website") or "").strip(),
-        "matched_name": location.name,
-        "country": item.get("country"),
-                "region": item.get("region"),
-                "subregion": item.get("subregion"),
-                "pass_types": item.get("pass_types", []),
-        "timezone": forecast.get("timezone"),
-        "model": "ecmwf_ifs025",
-        "input_latitude": location.latitude,
-        "input_longitude": location.longitude,
-        "resolved_latitude": forecast.get("latitude"),
-        "resolved_longitude": forecast.get("longitude"),
-        "nearby_airports": nearby_airports,
-        "hours": n,
-        "hourly": trimmed_hourly,
-    }
+        value = int(raw)
+    except (TypeError, ValueError):
+        value = default
+    return max(1, min(240, value))
 
 
 def make_handler(
@@ -372,7 +148,7 @@ def make_handler(
                     return
                 hours = _parse_hours((qs.get("hours", ["72"])[0] or "72"), default=72)
                 try:
-                    result = _hourly_payload_for_resort(
+                    result = build_hourly_payload_for_resort(
                         resort_id=resort_id,
                         hours=hours,
                         cache_file=cache_file,
@@ -393,7 +169,7 @@ def make_handler(
             if parsed.path == "/api/resorts":
                 search_text = (qs.get("search", [""])[0] or "").strip()
                 try:
-                    catalog = _supported_catalog(load_resort_catalog(DEFAULT_RESORTS_FILE))
+                    catalog = load_supported_resort_catalog(DEFAULT_RESORTS_FILE)
                 except Exception as exc:
                     self._write_json(500, {"error": f"Failed to load resort catalog: {exc}"})
                     return

--- a/src/web/pipelines/static_site.py
+++ b/src/web/pipelines/static_site.py
@@ -52,9 +52,9 @@ def _build_hourly_payload(
     geocode_cache_hours: int,
     forecast_cache_hours: int,
 ) -> Optional[Dict[str, Any]]:
-    from src.backend.weather_data_server import _hourly_payload_for_resort
+    from src.backend.services.hourly_payload_service import build_hourly_payload_for_resort
 
-    return _hourly_payload_for_resort(
+    return build_hourly_payload_for_resort(
         resort_id=resort_id,
         hours=hours,
         cache_file=cache_file,

--- a/src/web/weather_page_server.py
+++ b/src/web/weather_page_server.py
@@ -28,16 +28,14 @@ from src.web.resort_hourly_context import build_resort_daily_summary_context
 from src.web.weather_page_assets import ASSET_MIME_TYPES, read_asset_bytes
 from src.web.weather_page_render_core import render_payload_html
 from src.backend.pipelines.live_pipeline import run_live_payload
-from src.backend.resort_catalog import load_resort_catalog
-from src.backend.weather_data_server import (
-    _available_filters,
-    _default_applied_filters,
-    _empty_payload,
-    _hourly_payload_for_resort,
-    _supported_catalog,
+from src.backend.services.hourly_payload_service import build_hourly_payload_for_resort
+from src.backend.services.resort_selection_service import (
+    available_filters,
+    build_empty_payload,
+    default_applied_filters,
+    load_supported_resort_catalog,
     select_resorts_from_query,
 )
-from src.shared.config import DEFAULT_RESORTS_FILE
 
 _HOURLY_TEMPLATE = (Path(__file__).resolve().parent / "templates" / "resort_hourly_page.html").read_text(
     encoding="utf-8"
@@ -130,7 +128,7 @@ def make_handler(
             if data_mode == "local" and apply_server_filters and has_server_side_filters:
                 selected, resorts_file, applied, available, no_match = select_resorts_from_query(qs)
                 if no_match:
-                    payload = _empty_payload(
+                    payload = build_empty_payload(
                         cache_file=cache_file,
                         geocode_cache_hours=geocode_cache_hours,
                         forecast_cache_hours=forecast_cache_hours,
@@ -164,17 +162,17 @@ def make_handler(
             )
             if "available_filters" not in payload:
                 try:
-                    catalog = _supported_catalog(load_resort_catalog(DEFAULT_RESORTS_FILE))
-                    payload["available_filters"] = _available_filters(catalog)
+                    catalog = load_supported_resort_catalog()
+                    payload["available_filters"] = available_filters(catalog)
                 except Exception:
                     payload["available_filters"] = {"pass_type": {}, "region": {}, "subregion": {}, "country": {}}
             if "applied_filters" not in payload:
-                payload["applied_filters"] = _default_applied_filters()
+                payload["applied_filters"] = default_applied_filters()
             return payload
 
         def _load_hourly_payload(self, resort_id: str, hours: int) -> tuple[int, Dict[str, Any]]:
             if data_mode == "local":
-                payload = _hourly_payload_for_resort(
+                payload = build_hourly_payload_for_resort(
                     resort_id=resort_id,
                     hours=hours,
                     cache_file=cache_file,

--- a/tests/backend/test_weather_data_server_filters.py
+++ b/tests/backend/test_weather_data_server_filters.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from src.backend.weather_data_server import DEFAULT_RESORTS_FILE, select_resorts_from_query
+from src.backend.services.resort_selection_service import select_resorts_from_query
+from src.shared.config import DEFAULT_RESORTS_FILE
 
 
 def _sample_catalog():
@@ -39,7 +40,7 @@ def _sample_catalog():
 
 
 def test_select_resorts_defaults_to_default_scope(monkeypatch):
-    monkeypatch.setattr("src.backend.weather_data_server.load_resort_catalog", lambda path: _sample_catalog())
+    monkeypatch.setattr("src.backend.services.resort_selection_service.load_resort_catalog", lambda path: _sample_catalog())
 
     selected, resorts_file, applied, available, no_match = select_resorts_from_query({})
 
@@ -56,7 +57,7 @@ def test_select_resorts_defaults_to_default_scope(monkeypatch):
 
 
 def test_select_resorts_search_all_ignores_other_filters(monkeypatch):
-    monkeypatch.setattr("src.backend.weather_data_server.load_resort_catalog", lambda path: _sample_catalog())
+    monkeypatch.setattr("src.backend.services.resort_selection_service.load_resort_catalog", lambda path: _sample_catalog())
 
     selected, resorts_file, applied, available, no_match = select_resorts_from_query(
         {
@@ -81,7 +82,7 @@ def test_select_resorts_search_all_ignores_other_filters(monkeypatch):
 
 
 def test_select_resorts_search_filtered_respects_filters(monkeypatch):
-    monkeypatch.setattr("src.backend.weather_data_server.load_resort_catalog", lambda path: _sample_catalog())
+    monkeypatch.setattr("src.backend.services.resort_selection_service.load_resort_catalog", lambda path: _sample_catalog())
 
     selected, resorts_file, applied, _available, no_match = select_resorts_from_query(
         {
@@ -103,7 +104,7 @@ def test_select_resorts_search_filtered_respects_filters(monkeypatch):
 
 
 def test_select_resorts_accepts_multi_value_subregion_and_country(monkeypatch):
-    monkeypatch.setattr("src.backend.weather_data_server.load_resort_catalog", lambda path: _sample_catalog())
+    monkeypatch.setattr("src.backend.services.resort_selection_service.load_resort_catalog", lambda path: _sample_catalog())
 
     selected, resorts_file, applied, _available, no_match = select_resorts_from_query(
         {
@@ -121,7 +122,7 @@ def test_select_resorts_accepts_multi_value_subregion_and_country(monkeypatch):
 
 
 def test_select_resorts_supports_long_form_state_country_and_city(monkeypatch):
-    monkeypatch.setattr("src.backend.weather_data_server.load_resort_catalog", lambda path: _sample_catalog())
+    monkeypatch.setattr("src.backend.services.resort_selection_service.load_resort_catalog", lambda path: _sample_catalog())
 
     selected_state, _file, _applied, _available, no_match_state = select_resorts_from_query(
         {"search": ["utah"], "search_all": ["1"], "include_all": ["1"]}

--- a/tests/backend/test_weather_data_server_hourly.py
+++ b/tests/backend/test_weather_data_server_hourly.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from src.backend.models import ResortLocation
-from src.backend.weather_data_server import _hourly_payload_for_resort
+from src.backend.services.hourly_payload_service import build_hourly_payload_for_resort
 
 
 class _DummyJsonCache:
@@ -23,8 +23,8 @@ class _DummyCoordCache:
 
 def test_hourly_payload_uses_catalog_coordinate_override(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "src.backend.weather_data_server.load_resort_catalog",
-        lambda path: [
+        "src.backend.services.hourly_payload_service.load_supported_resort_catalog",
+        lambda: [
             {
                 "resort_id": "crystal-mountain-wa",
                 "query": "Crystal Mountain, WA",
@@ -41,12 +41,12 @@ def test_hourly_payload_uses_catalog_coordinate_override(monkeypatch, tmp_path):
             }
         ],
     )
-    monkeypatch.setattr("src.backend.weather_data_server.dated_cache_path", lambda path: str(tmp_path / "dated_cache.json"))
-    monkeypatch.setattr("src.backend.weather_data_server.JsonCache", lambda path: _DummyJsonCache())
+    monkeypatch.setattr("src.backend.services.hourly_payload_service.dated_cache_path", lambda path: str(tmp_path / "dated_cache.json"))
+    monkeypatch.setattr("src.backend.services.hourly_payload_service.JsonCache", lambda path: _DummyJsonCache())
     coord_cache = _DummyCoordCache()
-    monkeypatch.setattr("src.backend.weather_data_server.ResortCoordinateCache", lambda path: coord_cache)
+    monkeypatch.setattr("src.backend.services.hourly_payload_service.ResortCoordinateCache", lambda path: coord_cache)
     monkeypatch.setattr(
-        "src.backend.weather_data_server.load_airport_catalog",
+        "src.backend.services.hourly_payload_service.load_airport_catalog",
         lambda: [
             {
                 "airport_id": "sea-seattle-tacoma",
@@ -72,9 +72,9 @@ def test_hourly_payload_uses_catalog_coordinate_override(monkeypatch, tmp_path):
             admin1=str(seed["admin1"]),
         )
 
-    monkeypatch.setattr("src.backend.weather_data_server.geocode", fake_geocode)
+    monkeypatch.setattr("src.backend.services.hourly_payload_service.geocode", fake_geocode)
     monkeypatch.setattr(
-        "src.backend.weather_data_server.fetch_hourly_forecast",
+        "src.backend.services.hourly_payload_service.fetch_hourly_forecast",
         lambda location, cache, ttl_seconds, hours: {
             "latitude": location.latitude,
             "longitude": location.longitude,
@@ -83,7 +83,7 @@ def test_hourly_payload_uses_catalog_coordinate_override(monkeypatch, tmp_path):
         },
     )
 
-    payload = _hourly_payload_for_resort(
+    payload = build_hourly_payload_for_resort(
         resort_id="crystal-mountain-wa",
         hours=72,
         cache_file=".cache/open_meteo_cache.json",

--- a/tests/integration/test_backend_data_server.py
+++ b/tests/integration/test_backend_data_server.py
@@ -22,7 +22,7 @@ def _serve_once(handler_cls):
 def test_backend_data_server_api_and_health(monkeypatch, valid_payload):
     monkeypatch.setattr("src.backend.weather_data_server.run_live_payload", lambda **kwargs: valid_payload)
     monkeypatch.setattr(
-        "src.backend.weather_data_server.load_resort_catalog",
+        "src.backend.services.resort_selection_service.load_resort_catalog",
         lambda path: [
             {
                 "resort_id": "snowbird-ut",
@@ -94,7 +94,7 @@ def test_backend_data_server_data_filters(monkeypatch, valid_payload):
 
     monkeypatch.setattr("src.backend.weather_data_server.run_live_payload", fake_run_live_payload)
     monkeypatch.setattr(
-        "src.backend.weather_data_server.load_resort_catalog",
+        "src.backend.services.resort_selection_service.load_resort_catalog",
         lambda path: [
             {
                 "resort_id": "snowbird-ut",
@@ -161,7 +161,7 @@ def test_backend_data_server_data_include_all(monkeypatch, valid_payload):
 
     monkeypatch.setattr("src.backend.weather_data_server.run_live_payload", fake_run_live_payload)
     monkeypatch.setattr(
-        "src.backend.weather_data_server.load_resort_catalog",
+        "src.backend.services.resort_selection_service.load_resort_catalog",
         lambda path: [
             {
                 "resort_id": "snowbird-ut",
@@ -221,7 +221,7 @@ def test_backend_data_server_data_include_default(monkeypatch, valid_payload):
 
     monkeypatch.setattr("src.backend.weather_data_server.run_live_payload", fake_run_live_payload)
     monkeypatch.setattr(
-        "src.backend.weather_data_server.load_resort_catalog",
+        "src.backend.services.resort_selection_service.load_resort_catalog",
         lambda path: [
             {
                 "resort_id": "snowbird-ut",
@@ -275,7 +275,7 @@ def test_backend_data_server_search_all_ignores_filters(monkeypatch, valid_paylo
 
     monkeypatch.setattr("src.backend.weather_data_server.run_live_payload", fake_run_live_payload)
     monkeypatch.setattr(
-        "src.backend.weather_data_server.load_resort_catalog",
+        "src.backend.services.resort_selection_service.load_resort_catalog",
         lambda path: [
             {
                 "resort_id": "snowbird-ut",
@@ -346,7 +346,7 @@ def test_backend_data_server_search_supports_long_form_locations(monkeypatch, va
 
     monkeypatch.setattr("src.backend.weather_data_server.run_live_payload", fake_run_live_payload)
     monkeypatch.setattr(
-        "src.backend.weather_data_server.load_resort_catalog",
+        "src.backend.services.resort_selection_service.load_resort_catalog",
         lambda path: [
             {
                 "resort_id": "arapahoe-basin-co",
@@ -421,7 +421,7 @@ def test_backend_data_server_hourly_endpoint(monkeypatch):
             },
         }
 
-    monkeypatch.setattr("src.backend.weather_data_server._hourly_payload_for_resort", fake_hourly)
+    monkeypatch.setattr("src.backend.weather_data_server.build_hourly_payload_for_resort", fake_hourly)
     handler = make_handler(
         cache_file=".cache/x.json",
         geocode_cache_hours=720,

--- a/tests/integration/test_web_server.py
+++ b/tests/integration/test_web_server.py
@@ -402,7 +402,7 @@ def test_server_hourly_api_and_hourly_page_route(monkeypatch):
         },
     )
     monkeypatch.setattr(
-        "src.web.weather_page_server._hourly_payload_for_resort",
+        "src.web.weather_page_server.build_hourly_payload_for_resort",
         lambda **kwargs: {
             "resort_id": kwargs["resort_id"],
             "query": "Snowbird, UT",


### PR DESCRIPTION
## Summary\n- extract public backend service modules for resort selection/filter metadata and hourly payload generation\n- delegate backend weather data server endpoints to the new service APIs\n- update web and static hourly adapters to consume public backend services instead of backend server internals\n- migrate backend/hourly integration tests to service-level monkeypatch points\n\n## Validation\n- python3 -m pytest tests/backend/test_weather_data_server_filters.py tests/backend/test_weather_data_server_hourly.py tests/integration/test_backend_data_server.py tests/integration/test_web_server.py -q\n- python3 -m compileall src