### PR TITLE
Add hourly payload adapters

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -176,7 +176,12 @@ def run_render(args: argparse.Namespace) -> int:
     payload = load_payload(mode="file", source=args.input_json)
     output_html = _index_html_for_output_dir(args.output_dir, input_json=args.input_json)
     out = render_html(output_html, payload, data_url=_relative_url(output_html, args.input_json))
-    hourly_pages = render_hourly_pages(output_html, payload)
+    hourly_pages = render_hourly_pages(
+        output_html,
+        payload,
+        hourly_mode="file",
+        hourly_source=args.input_json,
+    )
     output_dir = str(Path(output_html).parent)
     copied_assets = _copy_static_assets(output_dir)
     print(f"Done: {out}")
@@ -202,6 +207,8 @@ def run_static(args: argparse.Namespace) -> int:
             output_html,
             payload,
             include_hourly_data=True,
+            hourly_mode="local",
+            hourly_source="",
             cache_file=args.cache_file,
             geocode_cache_hours=args.geocode_cache_hours,
             forecast_cache_hours=args.forecast_cache_hours,

--- a/src/web/data_sources/__init__.py
+++ b/src/web/data_sources/__init__.py
@@ -1,7 +1,9 @@
 from src.web.data_sources.gateway import build_payload_client, load_payload
+from src.web.data_sources.hourly_source import load_hourly_payload
 from src.web.data_sources.local_source import load_local_payload
 
 __all__ = [
+    "load_hourly_payload",
     "load_payload",
     "build_payload_client",
     "load_local_payload",

--- a/src/web/data_sources/hourly_source.py
+++ b/src/web/data_sources/hourly_source.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Tuple
+import urllib.error
+import urllib.request
+from urllib.parse import urlencode, urlsplit, urlunsplit
+
+from src.backend.services.hourly_payload_service import build_hourly_payload_for_resort
+
+
+def _hourly_endpoint_from_data_source(base_url: str) -> str:
+    parsed = urlsplit(base_url)
+    return urlunsplit((parsed.scheme, parsed.netloc, "/api/resort-hourly", "", ""))
+
+
+def _load_local_hourly_payload(
+    *,
+    resort_id: str,
+    hours: int,
+    cache_file: str,
+    geocode_cache_hours: int,
+    forecast_cache_hours: int,
+) -> Tuple[int, Dict[str, Any]]:
+    payload = build_hourly_payload_for_resort(
+        resort_id=resort_id,
+        hours=hours,
+        cache_file=cache_file,
+        geocode_cache_hours=geocode_cache_hours,
+        forecast_cache_hours=forecast_cache_hours,
+    )
+    if payload is None:
+        return 404, {"error": f"Unknown resort_id: {resort_id}"}
+    if "error" in payload:
+        return 502, payload
+    return 200, payload
+
+
+def _load_api_hourly_payload(
+    *,
+    source: str,
+    resort_id: str,
+    hours: int,
+    timeout: int,
+) -> Tuple[int, Dict[str, Any]]:
+    hourly_base = _hourly_endpoint_from_data_source(source)
+    hourly_url = f"{hourly_base}?{urlencode({'resort_id': resort_id, 'hours': str(hours)})}"
+    try:
+        with urllib.request.urlopen(hourly_url, timeout=timeout) as resp:
+            body = resp.read().decode("utf-8")
+            return 200, json.loads(body)
+    except urllib.error.HTTPError as exc:
+        error_body = exc.read().decode("utf-8", errors="ignore")
+        try:
+            payload = json.loads(error_body)
+        except Exception:
+            payload = {"error": error_body or f"HTTP {exc.code}"}
+        return exc.code, payload
+    except urllib.error.URLError as exc:
+        return 502, {"error": str(exc)}
+    except Exception as exc:
+        return 500, {"error": str(exc)}
+
+
+def load_hourly_payload(
+    mode: str,
+    source: str,
+    *,
+    resort_id: str,
+    hours: int,
+    timeout: int = 20,
+    cache_file: str = ".cache/open_meteo_cache.json",
+    geocode_cache_hours: int = 24 * 30,
+    forecast_cache_hours: int = 3,
+) -> Tuple[int, Dict[str, Any]]:
+    if mode == "local":
+        return _load_local_hourly_payload(
+            resort_id=resort_id,
+            hours=hours,
+            cache_file=cache_file,
+            geocode_cache_hours=geocode_cache_hours,
+            forecast_cache_hours=forecast_cache_hours,
+        )
+    if mode == "api":
+        return _load_api_hourly_payload(
+            source=source,
+            resort_id=resort_id,
+            hours=hours,
+            timeout=timeout,
+        )
+    if mode == "file":
+        return 501, {"error": "Hourly endpoint unavailable in file mode"}
+    raise ValueError(f"Unsupported data source mode: {mode}")

--- a/src/web/pipelines/static_site.py
+++ b/src/web/pipelines/static_site.py
@@ -46,21 +46,30 @@ def _iter_resort_ids(payload: Dict[str, Any]) -> List[str]:
 
 def _build_hourly_payload(
     *,
+    mode: str,
+    source: str,
     resort_id: str,
     hours: int,
+    timeout: int,
     cache_file: str,
     geocode_cache_hours: int,
     forecast_cache_hours: int,
 ) -> Optional[Dict[str, Any]]:
-    from src.backend.services.hourly_payload_service import build_hourly_payload_for_resort
+    from src.web.data_sources import load_hourly_payload
 
-    return build_hourly_payload_for_resort(
+    code, payload = load_hourly_payload(
+        mode=mode,
+        source=source,
         resort_id=resort_id,
         hours=hours,
+        timeout=timeout,
         cache_file=cache_file,
         geocode_cache_hours=geocode_cache_hours,
         forecast_cache_hours=forecast_cache_hours,
     )
+    if code != 200 or "error" in payload:
+        return None
+    return payload
 
 
 def render_hourly_pages(
@@ -68,6 +77,9 @@ def render_hourly_pages(
     payload: Dict[str, Any],
     *,
     include_hourly_data: bool = True,
+    hourly_mode: str = "local",
+    hourly_source: str = "",
+    hourly_timeout: int = 20,
     hourly_hours: int = 120,
     cache_file: str = ".cache/open_meteo_cache.json",
     geocode_cache_hours: int = 24 * 30,
@@ -87,8 +99,11 @@ def render_hourly_pages(
             hourly_context["dailySummary"] = daily_summary
         if include_hourly_data:
             hourly_payload = _build_hourly_payload(
+                mode=hourly_mode,
+                source=hourly_source,
                 resort_id=resort_id,
                 hours=hourly_hours,
+                timeout=hourly_timeout,
                 cache_file=cache_file,
                 geocode_cache_hours=geocode_cache_hours,
                 forecast_cache_hours=forecast_cache_hours,

--- a/src/web/weather_page_server.py
+++ b/src/web/weather_page_server.py
@@ -16,19 +16,16 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 import sys
 from typing import Any, Dict, List
-import urllib.error
-import urllib.request
 from urllib.parse import parse_qs, urlencode, urlparse, urlsplit, urlunsplit
 
 if str(Path(__file__).resolve().parents[2]) not in sys.path:
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from src.web.data_sources import load_payload
+from src.web.data_sources import load_hourly_payload, load_payload
 from src.web.resort_hourly_context import build_resort_daily_summary_context
 from src.web.weather_page_assets import ASSET_MIME_TYPES, read_asset_bytes
 from src.web.weather_page_render_core import render_payload_html
 from src.backend.pipelines.live_pipeline import run_live_payload
-from src.backend.services.hourly_payload_service import build_hourly_payload_for_resort
 from src.backend.services.resort_selection_service import (
     available_filters,
     build_empty_payload,
@@ -82,11 +79,6 @@ def _append_query_values(base_url: str, qs: Dict[str, List[str]]) -> str:
         merged[key] = list(values)
     query = urlencode(merged, doseq=True)
     return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, query, parsed.fragment))
-
-
-def _hourly_endpoint_from_data_source(base_url: str) -> str:
-    parsed = urlsplit(base_url)
-    return urlunsplit((parsed.scheme, parsed.netloc, "/api/resort-hourly", "", ""))
 
 
 _SERVER_FILTER_QUERY_KEYS = ("pass_type", "region", "subregion", "country", "search", "include_all", "include_default", "search_all")
@@ -171,40 +163,16 @@ def make_handler(
             return payload
 
         def _load_hourly_payload(self, resort_id: str, hours: int) -> tuple[int, Dict[str, Any]]:
-            if data_mode == "local":
-                payload = build_hourly_payload_for_resort(
-                    resort_id=resort_id,
-                    hours=hours,
-                    cache_file=cache_file,
-                    geocode_cache_hours=geocode_cache_hours,
-                    forecast_cache_hours=forecast_cache_hours,
-                )
-                if payload is None:
-                    return 404, {"error": f"Unknown resort_id: {resort_id}"}
-                if "error" in payload:
-                    return 502, payload
-                return 200, payload
-
-            if data_mode == "api":
-                hourly_base = _hourly_endpoint_from_data_source(data_source)
-                hourly_url = f"{hourly_base}?{urlencode({'resort_id': resort_id, 'hours': str(hours)})}"
-                try:
-                    with urllib.request.urlopen(hourly_url, timeout=data_timeout) as resp:
-                        body = resp.read().decode("utf-8")
-                        return 200, json.loads(body)
-                except urllib.error.HTTPError as exc:
-                    error_body = exc.read().decode("utf-8", errors="ignore")
-                    try:
-                        payload = json.loads(error_body)
-                    except Exception:
-                        payload = {"error": error_body or f"HTTP {exc.code}"}
-                    return exc.code, payload
-                except urllib.error.URLError as exc:
-                    return 502, {"error": str(exc)}
-                except Exception as exc:
-                    return 500, {"error": str(exc)}
-
-            return 501, {"error": "Hourly endpoint unavailable in file mode"}
+            return load_hourly_payload(
+                mode=data_mode,
+                source=data_source,
+                resort_id=resort_id,
+                hours=hours,
+                timeout=data_timeout,
+                cache_file=cache_file,
+                geocode_cache_hours=geocode_cache_hours,
+                forecast_cache_hours=forecast_cache_hours,
+            )
 
         def do_GET(self) -> None:  # noqa: N802
             parsed = urlparse(self.path)

--- a/src/web/weather_page_static_render.py
+++ b/src/web/weather_page_static_render.py
@@ -71,6 +71,8 @@ def main() -> int:
         output_html,
         payload,
         include_hourly_data=True,
+        hourly_mode="local",
+        hourly_source="",
         cache_file=args.cache_file,
         geocode_cache_hours=args.geocode_cache_hours,
         forecast_cache_hours=args.forecast_cache_hours,

--- a/tests/integration/test_data_sources.py
+++ b/tests/integration/test_data_sources.py
@@ -8,6 +8,7 @@ from src.contract.validators import ContractValidationError
 from src.shared.config import DEFAULT_RESORTS_FILE
 from src.web.data_sources.api_source import load_api_payload
 from src.web.data_sources.gateway import build_payload_client, load_payload
+from src.web.data_sources.hourly_source import load_hourly_payload
 from src.web.data_sources.static_json_source import load_static_payload
 
 
@@ -184,3 +185,64 @@ def test_build_payload_client_types():
     assert type(api_client).__name__ == "HttpPayloadClient"
     assert type(file_client).__name__ == "FilePayloadClient"
     assert type(local_client).__name__ == "LocalPayloadClient"
+
+
+def test_load_hourly_payload_local_mode(monkeypatch):
+    captured = {}
+
+    def fake_build_hourly_payload_for_resort(**kwargs):  # noqa: ANN001
+        captured.update(kwargs)
+        return {
+            "resort_id": kwargs["resort_id"],
+            "hours": kwargs["hours"],
+            "hourly": {"time": []},
+        }
+
+    monkeypatch.setattr(
+        "src.web.data_sources.hourly_source.build_hourly_payload_for_resort",
+        fake_build_hourly_payload_for_resort,
+    )
+    code, payload = load_hourly_payload(
+        "local",
+        "",
+        resort_id="snowbird-ut",
+        hours=6,
+        cache_file=".cache/hourly.json",
+        geocode_cache_hours=100,
+        forecast_cache_hours=2,
+    )
+    assert code == 200
+    assert payload["resort_id"] == "snowbird-ut"
+    assert captured["cache_file"] == ".cache/hourly.json"
+    assert captured["geocode_cache_hours"] == 100
+    assert captured["forecast_cache_hours"] == 2
+
+
+def test_load_hourly_payload_api_mode(monkeypatch):
+    captured = {}
+
+    def fake_urlopen(url, timeout):  # noqa: ANN001
+        captured["url"] = url
+        captured["timeout"] = timeout
+        return _DummyResponse(json.dumps({"resort_id": "snowbird-ut", "hourly": {"time": []}}).encode("utf-8"))
+
+    monkeypatch.setattr("src.web.data_sources.hourly_source.urllib.request.urlopen", fake_urlopen)
+    code, payload = load_hourly_payload(
+        "api",
+        "https://example.test/api/data?resort=snowbird-ut",
+        resort_id="snowbird-ut",
+        hours=12,
+        timeout=11,
+    )
+    assert code == 200
+    assert payload["resort_id"] == "snowbird-ut"
+    assert captured["timeout"] == 11
+    assert captured["url"].startswith("https://example.test/api/resort-hourly?")
+    assert "resort_id=snowbird-ut" in captured["url"]
+    assert "hours=12" in captured["url"]
+
+
+def test_load_hourly_payload_file_mode_is_explicitly_unavailable():
+    code, payload = load_hourly_payload("file", "/tmp/data.json", resort_id="snowbird-ut", hours=12)
+    assert code == 501
+    assert payload["error"] == "Hourly endpoint unavailable in file mode"

--- a/tests/integration/test_web_server.py
+++ b/tests/integration/test_web_server.py
@@ -402,24 +402,27 @@ def test_server_hourly_api_and_hourly_page_route(monkeypatch):
         },
     )
     monkeypatch.setattr(
-        "src.web.weather_page_server.build_hourly_payload_for_resort",
-        lambda **kwargs: {
-            "resort_id": kwargs["resort_id"],
-            "query": "Snowbird, UT",
-            "timezone": "America/Denver",
-            "nearby_airports": [{"airport_id": "slc-salt-lake-city", "iata_code": "SLC"}],
-            "hours": 2,
-            "hourly": {
-                "time": ["2026-03-04T00:00", "2026-03-04T01:00"],
-                "snowfall": [0.0, 0.1],
-                "rain": [0.0, 0.0],
-                "precipitation_probability": [20, 10],
-                "snow_depth": [100, 100],
-                "wind_speed_10m": [5.0, 6.0],
-                "wind_direction_10m": [120, 110],
-                "visibility": [9000, 8800],
+        "src.web.weather_page_server.load_hourly_payload",
+        lambda **kwargs: (
+            200,
+            {
+                "resort_id": kwargs["resort_id"],
+                "query": "Snowbird, UT",
+                "timezone": "America/Denver",
+                "nearby_airports": [{"airport_id": "slc-salt-lake-city", "iata_code": "SLC"}],
+                "hours": 2,
+                "hourly": {
+                    "time": ["2026-03-04T00:00", "2026-03-04T01:00"],
+                    "snowfall": [0.0, 0.1],
+                    "rain": [0.0, 0.0],
+                    "precipitation_probability": [20, 10],
+                    "snow_depth": [100, 100],
+                    "wind_speed_10m": [5.0, 6.0],
+                    "wind_direction_10m": [120, 110],
+                    "visibility": [9000, 8800],
+                },
             },
-        },
+        ),
     )
 
     handler = make_handler(


### PR DESCRIPTION
## Summary
- add a shared hourly adapter entrypoint under src/web/data_sources covering local/api/file semantics
- route dynamic /api/resort-hourly and static hourly generation through the shared adapter
- keep file-mode hourly explicitly unavailable and make CLI render path use file-mode semantics
- add adapter tests covering local + api + file-mode-unavailable flows

## Validation
- python3 -m pytest tests/integration/test_data_sources.py tests/frontend/test_static_site_pipeline.py tests/integration/test_web_server.py tests/backend/test_weather_data_server_hourly.py -q
- python3 -m compileall src