### PR TITLE
Extend request payload adapters

### DIFF
--- a/src/web/data_sources/__init__.py
+++ b/src/web/data_sources/__init__.py
@@ -1,10 +1,13 @@
 from src.web.data_sources.gateway import build_payload_client, load_payload
 from src.web.data_sources.hourly_source import load_hourly_payload
 from src.web.data_sources.local_source import load_local_payload
+from src.web.data_sources.request_source import load_request_payload, strip_server_filter_query
 
 __all__ = [
     "load_hourly_payload",
     "load_payload",
     "build_payload_client",
     "load_local_payload",
+    "load_request_payload",
+    "strip_server_filter_query",
 ]

--- a/src/web/data_sources/request_source.py
+++ b/src/web/data_sources/request_source.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+from urllib.parse import parse_qs, urlencode, urlsplit, urlunsplit
+
+from src.backend.services.resort_selection_service import (
+    available_filters,
+    build_empty_payload,
+    default_applied_filters,
+    load_supported_resort_catalog,
+    select_resorts_from_query,
+)
+from src.web.data_sources.gateway import load_payload
+from src.web.data_sources.local_source import load_local_payload
+
+SERVER_FILTER_QUERY_KEYS = (
+    "pass_type",
+    "region",
+    "subregion",
+    "country",
+    "search",
+    "include_all",
+    "include_default",
+    "search_all",
+)
+
+
+def _append_query_values(base_url: str, qs: Dict[str, List[str]]) -> str:
+    if not qs:
+        return base_url
+    parsed = urlsplit(base_url)
+    merged = parse_qs(parsed.query, keep_blank_values=True)
+    for key, values in qs.items():
+        merged[key] = list(values)
+    query = urlencode(merged, doseq=True)
+    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, query, parsed.fragment))
+
+
+def strip_server_filter_query(qs: Dict[str, List[str]]) -> Dict[str, List[str]]:
+    return {key: list(values) for key, values in qs.items() if key not in SERVER_FILTER_QUERY_KEYS}
+
+
+def _ensure_filter_metadata(payload: Dict[str, Any]) -> Dict[str, Any]:
+    if "available_filters" not in payload:
+        try:
+            catalog = load_supported_resort_catalog()
+            payload["available_filters"] = available_filters(catalog)
+        except Exception:
+            payload["available_filters"] = {"pass_type": {}, "region": {}, "subregion": {}, "country": {}}
+    if "applied_filters" not in payload:
+        payload["applied_filters"] = default_applied_filters()
+    return payload
+
+
+def load_request_payload(
+    mode: str,
+    source: str,
+    *,
+    query_params: Dict[str, List[str]] | None = None,
+    apply_server_filters: bool = True,
+    timeout: int = 20,
+    cache_file: str = ".cache/open_meteo_cache.json",
+    geocode_cache_hours: int = 24 * 30,
+    forecast_cache_hours: int = 3,
+    max_workers: int = 8,
+) -> Dict[str, Any]:
+    qs = {key: list(values) for key, values in (query_params or {}).items()}
+    resorts = [x.strip() for x in qs.get("resort", []) if x.strip()]
+
+    has_server_side_filters = apply_server_filters and any(qs.get(key) for key in SERVER_FILTER_QUERY_KEYS)
+    if mode == "local" and has_server_side_filters:
+        selected, _, applied, available, no_match = select_resorts_from_query(qs)
+        if no_match:
+            payload = build_empty_payload(
+                cache_file=cache_file,
+                geocode_cache_hours=geocode_cache_hours,
+                forecast_cache_hours=forecast_cache_hours,
+            )
+        else:
+            payload = load_local_payload(
+                resorts=selected,
+                cache_file=cache_file,
+                geocode_cache_hours=geocode_cache_hours,
+                forecast_cache_hours=forecast_cache_hours,
+                max_workers=max_workers,
+            )
+        payload["available_filters"] = available
+        payload["applied_filters"] = applied
+        return payload
+
+    request_source = source
+    if mode == "api":
+        request_source = _append_query_values(source, qs)
+
+    payload = load_payload(
+        mode=mode,
+        source=request_source,
+        timeout=timeout,
+        resorts=resorts,
+        cache_file=cache_file,
+        geocode_cache_hours=geocode_cache_hours,
+        forecast_cache_hours=forecast_cache_hours,
+        max_workers=max_workers,
+    )
+    return _ensure_filter_metadata(payload)

--- a/src/web/weather_page_server.py
+++ b/src/web/weather_page_server.py
@@ -16,23 +16,15 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 import sys
 from typing import Any, Dict, List
-from urllib.parse import parse_qs, urlencode, urlparse, urlsplit, urlunsplit
+from urllib.parse import parse_qs, urlparse
 
 if str(Path(__file__).resolve().parents[2]) not in sys.path:
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from src.web.data_sources import load_hourly_payload, load_payload
+from src.web.data_sources import load_hourly_payload, load_request_payload, strip_server_filter_query
 from src.web.resort_hourly_context import build_resort_daily_summary_context
 from src.web.weather_page_assets import ASSET_MIME_TYPES, read_asset_bytes
 from src.web.weather_page_render_core import render_payload_html
-from src.backend.pipelines.live_pipeline import run_live_payload
-from src.backend.services.resort_selection_service import (
-    available_filters,
-    build_empty_payload,
-    default_applied_filters,
-    load_supported_resort_catalog,
-    select_resorts_from_query,
-)
 
 _HOURLY_TEMPLATE = (Path(__file__).resolve().parent / "templates" / "resort_hourly_page.html").read_text(
     encoding="utf-8"
@@ -69,25 +61,6 @@ def _asset_name_from_path(path: str) -> str:
         return path[idx + 1 :]
     return path.lstrip("/")
 
-
-def _append_query_values(base_url: str, qs: Dict[str, List[str]]) -> str:
-    if not qs:
-        return base_url
-    parsed = urlsplit(base_url)
-    merged = parse_qs(parsed.query, keep_blank_values=True)
-    for key, values in qs.items():
-        merged[key] = list(values)
-    query = urlencode(merged, doseq=True)
-    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, query, parsed.fragment))
-
-
-_SERVER_FILTER_QUERY_KEYS = ("pass_type", "region", "subregion", "country", "search", "include_all", "include_default", "search_all")
-
-
-def _qs_without_server_filters(qs: Dict[str, List[str]]) -> Dict[str, List[str]]:
-    return {key: list(values) for key, values in qs.items() if key not in _SERVER_FILTER_QUERY_KEYS}
-
-
 def make_handler(
     cache_file: str,
     geocode_cache_hours: int,
@@ -111,56 +84,17 @@ def make_handler(
             self.wfile.write(body)
 
         def _load_request_payload(self, qs: Dict[str, List[str]], *, apply_server_filters: bool = True) -> Dict[str, Any]:
-            resorts = [x.strip() for x in qs.get("resort", []) if x.strip()]
-            has_server_side_filters = any(
-                qs.get(key)
-                for key in _SERVER_FILTER_QUERY_KEYS
-            )
-
-            if data_mode == "local" and apply_server_filters and has_server_side_filters:
-                selected, resorts_file, applied, available, no_match = select_resorts_from_query(qs)
-                if no_match:
-                    payload = build_empty_payload(
-                        cache_file=cache_file,
-                        geocode_cache_hours=geocode_cache_hours,
-                        forecast_cache_hours=forecast_cache_hours,
-                    )
-                else:
-                    payload = run_live_payload(
-                        resorts=selected,
-                        resorts_file=resorts_file,
-                        cache_file=cache_file,
-                        geocode_cache_hours=geocode_cache_hours,
-                        forecast_cache_hours=forecast_cache_hours,
-                        max_workers=max_workers,
-                    )
-                payload["available_filters"] = available
-                payload["applied_filters"] = applied
-                return payload
-
-            source = data_source
-            if data_mode == "api":
-                source = _append_query_values(data_source, qs)
-
-            payload = load_payload(
+            return load_request_payload(
                 mode=data_mode,
-                source=source,
+                source=data_source,
+                query_params=qs,
+                apply_server_filters=apply_server_filters,
                 timeout=data_timeout,
-                resorts=resorts,
                 cache_file=cache_file,
                 geocode_cache_hours=geocode_cache_hours,
                 forecast_cache_hours=forecast_cache_hours,
                 max_workers=max_workers,
             )
-            if "available_filters" not in payload:
-                try:
-                    catalog = load_supported_resort_catalog()
-                    payload["available_filters"] = available_filters(catalog)
-                except Exception:
-                    payload["available_filters"] = {"pass_type": {}, "region": {}, "subregion": {}, "country": {}}
-            if "applied_filters" not in payload:
-                payload["applied_filters"] = default_applied_filters()
-            return payload
 
         def _load_hourly_payload(self, resort_id: str, hours: int) -> tuple[int, Dict[str, Any]]:
             return load_hourly_payload(
@@ -229,7 +163,7 @@ def make_handler(
                 self._write(200, body, "application/json; charset=utf-8")
                 return
 
-            page_qs = _qs_without_server_filters(qs)
+            page_qs = strip_server_filter_query(qs)
             payload = self._load_request_payload(page_qs, apply_server_filters=False)
             html = render_payload_html(payload, data_url="./api/data")
             self._write(200, html.encode("utf-8"), "text/html; charset=utf-8")

--- a/tests/integration/test_data_sources.py
+++ b/tests/integration/test_data_sources.py
@@ -9,6 +9,7 @@ from src.shared.config import DEFAULT_RESORTS_FILE
 from src.web.data_sources.api_source import load_api_payload
 from src.web.data_sources.gateway import build_payload_client, load_payload
 from src.web.data_sources.hourly_source import load_hourly_payload
+from src.web.data_sources.request_source import load_request_payload, strip_server_filter_query
 from src.web.data_sources.static_json_source import load_static_payload
 
 
@@ -185,6 +186,176 @@ def test_build_payload_client_types():
     assert type(api_client).__name__ == "HttpPayloadClient"
     assert type(file_client).__name__ == "FilePayloadClient"
     assert type(local_client).__name__ == "LocalPayloadClient"
+
+
+def test_strip_server_filter_query():
+    qs = {
+        "resort": ["Snowbird, UT"],
+        "pass_type": ["ikon"],
+        "region": ["west"],
+        "search": ["powder"],
+        "include_all": ["1"],
+    }
+    assert strip_server_filter_query(qs) == {"resort": ["Snowbird, UT"]}
+
+
+def test_load_request_payload_local_with_server_filters(monkeypatch):
+    calls = {}
+
+    monkeypatch.setattr(
+        "src.web.data_sources.request_source.select_resorts_from_query",
+        lambda qs: (
+            ["Snowbird, UT"],
+            "",
+            {"pass_type": ["ikon"], "region": "west"},
+            {"pass_type": {"ikon": 1}, "region": {"west": 1}},
+            False,
+        ),
+    )
+
+    def fake_load_local_payload(**kwargs):  # noqa: ANN001
+        calls.update(kwargs)
+        return {
+            "schema_version": "weather_payload_v1",
+            "generated_at_utc": "2026-03-03T23:00:00Z",
+            "source": "Open-Meteo",
+            "model": "ecmwf_ifs025",
+            "forecast_days": 15,
+            "units": {},
+            "cache": {},
+            "resorts_count": 1,
+            "failed_count": 0,
+            "failed": [],
+            "reports": [{"query": "Snowbird, UT", "daily": []}],
+        }
+
+    monkeypatch.setattr("src.web.data_sources.request_source.load_local_payload", fake_load_local_payload)
+
+    payload = load_request_payload(
+        mode="local",
+        source="",
+        query_params={"pass_type": ["ikon"], "region": ["west"]},
+        cache_file=".cache/x.json",
+        geocode_cache_hours=100,
+        forecast_cache_hours=2,
+        max_workers=4,
+    )
+    assert calls["resorts"] == ["Snowbird, UT"]
+    assert calls["cache_file"] == ".cache/x.json"
+    assert calls["max_workers"] == 4
+    assert payload["available_filters"]["pass_type"]["ikon"] == 1
+    assert payload["applied_filters"]["pass_type"] == ["ikon"]
+
+
+def test_load_request_payload_local_filter_no_match(monkeypatch):
+    monkeypatch.setattr(
+        "src.web.data_sources.request_source.select_resorts_from_query",
+        lambda qs: (
+            [],
+            "",
+            {"pass_type": ["ikon"]},
+            {"pass_type": {"ikon": 1}},
+            True,
+        ),
+    )
+
+    def fake_build_empty_payload(**kwargs):  # noqa: ANN001
+        return {
+            "schema_version": "weather_payload_v1",
+            "generated_at_utc": "2026-03-03T23:00:00Z",
+            "source": "Open-Meteo",
+            "model": "ecmwf_ifs025",
+            "forecast_days": 15,
+            "units": {},
+            "cache": {},
+            "resorts_count": 0,
+            "failed_count": 0,
+            "failed": [],
+            "reports": [],
+        }
+
+    monkeypatch.setattr("src.web.data_sources.request_source.build_empty_payload", fake_build_empty_payload)
+
+    payload = load_request_payload(
+        mode="local",
+        source="",
+        query_params={"pass_type": ["ikon"]},
+    )
+    assert payload["reports"] == []
+    assert payload["available_filters"]["pass_type"]["ikon"] == 1
+    assert payload["applied_filters"]["pass_type"] == ["ikon"]
+
+
+def test_load_request_payload_api_forwards_query(monkeypatch):
+    calls = {}
+
+    def fake_load_payload(mode, source, timeout=20, **kwargs):  # noqa: ANN001
+        calls["mode"] = mode
+        calls["source"] = source
+        calls["timeout"] = timeout
+        calls["kwargs"] = kwargs
+        return {
+            "schema_version": "weather_payload_v1",
+            "generated_at_utc": "2026-03-03T23:00:00Z",
+            "source": "Open-Meteo",
+            "model": "ecmwf_ifs025",
+            "forecast_days": 15,
+            "units": {},
+            "cache": {},
+            "resorts_count": 0,
+            "failed_count": 0,
+            "failed": [],
+            "reports": [],
+        }
+
+    monkeypatch.setattr("src.web.data_sources.request_source.load_payload", fake_load_payload)
+
+    load_request_payload(
+        mode="api",
+        source="https://example.test/api/data?existing=1",
+        timeout=11,
+        query_params={
+            "resort": ["A", "B"],
+            "pass_type": ["ikon"],
+            "region": ["west"],
+            "include_all": ["1"],
+        },
+    )
+    assert calls["mode"] == "api"
+    assert "existing=1" in calls["source"]
+    assert "resort=A" in calls["source"]
+    assert "resort=B" in calls["source"]
+    assert "pass_type=ikon" in calls["source"]
+    assert "region=west" in calls["source"]
+    assert "include_all=1" in calls["source"]
+    assert calls["timeout"] == 11
+    assert calls["kwargs"]["resorts"] == ["A", "B"]
+
+
+def test_load_request_payload_populates_filter_metadata_fallback(monkeypatch):
+    monkeypatch.setattr(
+        "src.web.data_sources.request_source.load_payload",
+        lambda **kwargs: {
+            "schema_version": "weather_payload_v1",
+            "generated_at_utc": "2026-03-03T23:00:00Z",
+            "source": "Open-Meteo",
+            "model": "ecmwf_ifs025",
+            "forecast_days": 15,
+            "units": {},
+            "cache": {},
+            "resorts_count": 0,
+            "failed_count": 0,
+            "failed": [],
+            "reports": [],
+        },
+    )
+    monkeypatch.setattr("src.web.data_sources.request_source.load_supported_resort_catalog", lambda: [{"query": "A"}])
+    monkeypatch.setattr("src.web.data_sources.request_source.available_filters", lambda catalog: {"pass_type": {"ikon": 1}})
+    monkeypatch.setattr("src.web.data_sources.request_source.default_applied_filters", lambda: {"search": ""})
+
+    payload = load_request_payload(mode="file", source="/tmp/payload.json")
+    assert payload["available_filters"] == {"pass_type": {"ikon": 1}}
+    assert payload["applied_filters"] == {"search": ""}
 
 
 def test_load_hourly_payload_local_mode(monkeypatch):

--- a/tests/integration/test_web_server.py
+++ b/tests/integration/test_web_server.py
@@ -33,7 +33,7 @@ def test_server_api_root_and_asset(monkeypatch):
         "failed": [],
         "reports": [{"query": "A", "daily": []}],
     }
-    monkeypatch.setattr("src.web.weather_page_server.load_payload", lambda **kwargs: sample_payload)
+    monkeypatch.setattr("src.web.weather_page_server.load_request_payload", lambda **kwargs: sample_payload)
     monkeypatch.setattr("src.web.weather_page_server.render_payload_html", lambda payload, **kwargs: "<html>ok</html>")
     monkeypatch.setattr("src.web.weather_page_server.read_asset_bytes", lambda name: b"body{}")
 
@@ -64,7 +64,7 @@ def test_server_api_root_and_asset(monkeypatch):
 
 
 def test_server_asset_not_found(monkeypatch):
-    monkeypatch.setattr("src.web.weather_page_server.load_payload", lambda **kwargs: {"reports": []})
+    monkeypatch.setattr("src.web.weather_page_server.load_request_payload", lambda **kwargs: {"reports": []})
     monkeypatch.setattr("src.web.weather_page_server.read_asset_bytes", lambda name: (_ for _ in ()).throw(OSError("x")))
 
     handler = make_handler(
@@ -87,7 +87,7 @@ def test_server_asset_not_found(monkeypatch):
 def test_server_query_resort_pass_through(monkeypatch):
     captured = {}
 
-    def fake_load_payload(**kwargs):  # noqa: ANN001
+    def fake_load_request_payload(**kwargs):  # noqa: ANN001
         captured.update(kwargs)
         return {
             "schema_version": "weather_payload_v1",
@@ -103,7 +103,7 @@ def test_server_query_resort_pass_through(monkeypatch):
             "reports": [],
         }
 
-    monkeypatch.setattr("src.web.weather_page_server.load_payload", fake_load_payload)
+    monkeypatch.setattr("src.web.weather_page_server.load_request_payload", fake_load_request_payload)
     monkeypatch.setattr("src.web.weather_page_server.render_payload_html", lambda payload, **kwargs: "<html>ok</html>")
 
     handler = make_handler(
@@ -116,7 +116,7 @@ def test_server_query_resort_pass_through(monkeypatch):
     try:
         urllib.request.urlopen(f"{base}/api/data?resort=A&resort=B", timeout=3).read()
         assert captured["mode"] == "local"
-        assert captured["resorts"] == ["A", "B"]
+        assert captured["query_params"]["resort"] == ["A", "B"]
         assert captured["source"] == ""
     finally:
         server.shutdown()
@@ -124,10 +124,10 @@ def test_server_query_resort_pass_through(monkeypatch):
         thread.join(timeout=3)
 
 
-def test_server_api_mode_loads_remote_payload(monkeypatch):
+def test_server_api_mode_passes_query_to_request_adapter(monkeypatch):
     calls = {}
 
-    def fake_load_payload(mode, source, timeout=20, **kwargs):  # noqa: ANN001
+    def fake_load_request_payload(mode, source, timeout=20, **kwargs):  # noqa: ANN001
         calls["mode"] = mode
         calls["source"] = source
         calls["timeout"] = timeout
@@ -146,7 +146,7 @@ def test_server_api_mode_loads_remote_payload(monkeypatch):
             "reports": [],
         }
 
-    monkeypatch.setattr("src.web.weather_page_server.load_payload", fake_load_payload)
+    monkeypatch.setattr("src.web.weather_page_server.load_request_payload", fake_load_request_payload)
     monkeypatch.setattr("src.web.weather_page_server.render_payload_html", lambda payload, **kwargs: "<html>ok</html>")
 
     handler = make_handler(
@@ -165,17 +165,17 @@ def test_server_api_mode_loads_remote_payload(monkeypatch):
             timeout=3,
         ).read()
         assert calls["mode"] == "api"
-        assert "resort=A" in calls["source"]
-        assert "resort=B" in calls["source"]
-        assert "pass_type=ikon" in calls["source"]
-        assert "region=west" in calls["source"]
-        assert "subregion=rockies" in calls["source"]
-        assert "country=US" in calls["source"]
-        assert "search=snow" in calls["source"]
-        assert "include_all=1" in calls["source"]
-        assert "search_all=0" in calls["source"]
+        assert calls["source"] == "http://127.0.0.1:8020/api/data"
+        assert calls["kwargs"]["query_params"]["resort"] == ["A", "B"]
+        assert calls["kwargs"]["query_params"]["pass_type"] == ["ikon"]
+        assert calls["kwargs"]["query_params"]["region"] == ["west"]
+        assert calls["kwargs"]["query_params"]["subregion"] == ["rockies"]
+        assert calls["kwargs"]["query_params"]["country"] == ["US"]
+        assert calls["kwargs"]["query_params"]["search"] == ["snow"]
+        assert calls["kwargs"]["query_params"]["include_all"] == ["1"]
+        assert calls["kwargs"]["query_params"]["search_all"] == ["0"]
+        assert calls["kwargs"]["apply_server_filters"] is True
         assert calls["timeout"] == 11
-        assert calls["kwargs"]["resorts"] == ["A", "B"]
     finally:
         server.shutdown()
         server.server_close()
@@ -185,7 +185,7 @@ def test_server_api_mode_loads_remote_payload(monkeypatch):
 def test_server_root_ignores_filter_query_in_local_mode(monkeypatch):
     captured = {}
 
-    def fake_load_payload(**kwargs):  # noqa: ANN001
+    def fake_load_request_payload(**kwargs):  # noqa: ANN001
         captured.update(kwargs)
         return {
             "schema_version": "weather_payload_v1",
@@ -201,11 +201,7 @@ def test_server_root_ignores_filter_query_in_local_mode(monkeypatch):
             "reports": [],
         }
 
-    monkeypatch.setattr("src.web.weather_page_server.load_payload", fake_load_payload)
-    monkeypatch.setattr(
-        "src.web.weather_page_server.select_resorts_from_query",
-        lambda qs: (_ for _ in ()).throw(AssertionError("select_resorts_from_query should not be used for HTML root")),
-    )
+    monkeypatch.setattr("src.web.weather_page_server.load_request_payload", fake_load_request_payload)
     monkeypatch.setattr("src.web.weather_page_server.render_payload_html", lambda payload, **kwargs: "<html>ok</html>")
 
     handler = make_handler(
@@ -223,7 +219,8 @@ def test_server_root_ignores_filter_query_in_local_mode(monkeypatch):
         assert body.decode("utf-8") == "<html>ok</html>"
         assert captured["mode"] == "local"
         assert captured["source"] == ""
-        assert captured["resorts"] == []
+        assert captured["query_params"] == {}
+        assert captured["apply_server_filters"] is False
     finally:
         server.shutdown()
         server.server_close()
@@ -233,7 +230,7 @@ def test_server_root_ignores_filter_query_in_local_mode(monkeypatch):
 def test_server_root_api_mode_does_not_forward_filter_query(monkeypatch):
     calls = {}
 
-    def fake_load_payload(mode, source, timeout=20, **kwargs):  # noqa: ANN001
+    def fake_load_request_payload(mode, source, timeout=20, **kwargs):  # noqa: ANN001
         calls["mode"] = mode
         calls["source"] = source
         calls["timeout"] = timeout
@@ -252,7 +249,7 @@ def test_server_root_api_mode_does_not_forward_filter_query(monkeypatch):
             "reports": [],
         }
 
-    monkeypatch.setattr("src.web.weather_page_server.load_payload", fake_load_payload)
+    monkeypatch.setattr("src.web.weather_page_server.load_request_payload", fake_load_request_payload)
     monkeypatch.setattr("src.web.weather_page_server.render_payload_html", lambda payload, **kwargs: "<html>ok</html>")
 
     handler = make_handler(
@@ -271,37 +268,20 @@ def test_server_root_api_mode_does_not_forward_filter_query(monkeypatch):
             timeout=3,
         ).read()
         assert calls["mode"] == "api"
-        assert "resort=A" in calls["source"]
-        assert "pass_type=ikon" not in calls["source"]
-        assert "region=west" not in calls["source"]
-        assert "subregion=rockies" not in calls["source"]
-        assert "country=US" not in calls["source"]
-        assert "search=snow" not in calls["source"]
-        assert "include_all=1" not in calls["source"]
-        assert "search_all=0" not in calls["source"]
+        assert calls["source"] == "http://127.0.0.1:8020/api/data"
+        assert calls["kwargs"]["query_params"] == {"resort": ["A"]}
+        assert calls["kwargs"]["apply_server_filters"] is False
         assert calls["timeout"] == 11
-        assert calls["kwargs"]["resorts"] == ["A"]
     finally:
         server.shutdown()
         server.server_close()
         thread.join(timeout=3)
 
 
-def test_server_local_mode_uses_backend_selection_for_filter_queries(monkeypatch):
+def test_server_local_mode_uses_request_adapter_for_filter_queries(monkeypatch):
     captured = {}
 
-    monkeypatch.setattr(
-        "src.web.weather_page_server.select_resorts_from_query",
-        lambda qs: (
-            ["Snowbird, UT"],
-            "",
-            {"pass_type": ["ikon"], "region": "west", "country": "US", "search": "snow", "include_all": False},
-            {"pass_type": {"ikon": 1}, "region": {"west": 1}, "country": {"US": 1}},
-            False,
-        ),
-    )
-
-    def fake_run_live_payload(**kwargs):  # noqa: ANN001
+    def fake_load_request_payload(**kwargs):  # noqa: ANN001
         captured.update(kwargs)
         return {
             "schema_version": "weather_payload_v1",
@@ -315,9 +295,20 @@ def test_server_local_mode_uses_backend_selection_for_filter_queries(monkeypatch
             "failed_count": 0,
             "failed": [],
             "reports": [{"query": "Snowbird, UT", "daily": []}],
+            "available_filters": {"pass_type": {"ikon": 1}, "region": {"west": 1}, "country": {"US": 1}},
+            "applied_filters": {
+                "pass_type": ["ikon"],
+                "region": "west",
+                "country": ["US"],
+                "search": "snow",
+                "subregion": [],
+                "include_all": False,
+                "include_default": False,
+                "search_all": False,
+            },
         }
 
-    monkeypatch.setattr("src.web.weather_page_server.run_live_payload", fake_run_live_payload)
+    monkeypatch.setattr("src.web.weather_page_server.load_request_payload", fake_load_request_payload)
     monkeypatch.setattr("src.web.weather_page_server.render_payload_html", lambda payload, **kwargs: "<html>ok</html>")
 
     handler = make_handler(
@@ -330,7 +321,8 @@ def test_server_local_mode_uses_backend_selection_for_filter_queries(monkeypatch
     try:
         body = urllib.request.urlopen(f"{base}/api/data?pass_type=ikon&region=west&country=US&search=snow", timeout=3)
         payload = json.loads(body.read().decode("utf-8"))
-        assert captured["resorts"] == ["Snowbird, UT"]
+        assert captured["apply_server_filters"] is True
+        assert captured["query_params"]["pass_type"] == ["ikon"]
         assert payload["available_filters"]["pass_type"]["ikon"] == 1
         assert payload["applied_filters"]["pass_type"] == ["ikon"]
         assert payload["applied_filters"]["search"] == "snow"
@@ -341,7 +333,7 @@ def test_server_local_mode_uses_backend_selection_for_filter_queries(monkeypatch
 
 
 def test_server_health_endpoint(monkeypatch):
-    monkeypatch.setattr("src.web.weather_page_server.load_payload", lambda **kwargs: {"reports": []})
+    monkeypatch.setattr("src.web.weather_page_server.load_request_payload", lambda **kwargs: {"reports": []})
     handler = make_handler(
         cache_file=".cache/x.json",
         geocode_cache_hours=720,
@@ -373,7 +365,7 @@ def test_server_requires_data_source_for_api_mode():
 
 def test_server_hourly_api_and_hourly_page_route(monkeypatch):
     monkeypatch.setattr(
-        "src.web.weather_page_server.load_payload",
+        "src.web.weather_page_server.load_request_payload",
         lambda **kwargs: {
             "reports": [
                 {


### PR DESCRIPTION
## Summary
- add request-payload adapter entrypoint in src/web/data_sources
- move /api/data request shaping and filter metadata fallback out of weather_page_server
- update integration tests to patch adapter entrypoints rather than backend helpers in the server module

## Validation
- python3 -m pytest tests/integration/test_data_sources.py tests/integration/test_web_server.py -q
- python3 -m compileall src