### PR TITLE
Migrate web server tests to adapter seams

### DIFF
--- a/tests/smoke/test_dynamic_server_smoke.py
+++ b/tests/smoke/test_dynamic_server_smoke.py
@@ -20,7 +20,7 @@ def _start_server(handler_cls):
 
 @pytest.mark.smoke
 def test_dynamic_server_smoke(monkeypatch, valid_payload):
-    monkeypatch.setattr("src.web.weather_page_server.load_payload", lambda **kwargs: valid_payload)
+    monkeypatch.setattr("src.web.weather_page_server.load_request_payload", lambda **kwargs: valid_payload)
 
     handler = make_handler(
         cache_file=".cache/open_meteo_cache.json",


### PR DESCRIPTION
## Summary
- align dynamic server smoke coverage with the request adapter seam
- remove remaining patching of removed weather_page_server.load_payload symbol
- keep web adapter boundary checks green for the refactor branch

## Validation
- python3 -m pytest tests/integration/test_web_server.py tests/integration/test_cli.py tests/integration/test_entrypoints.py tests/smoke/test_dynamic_server_smoke.py -q
- rg -n "from src\.backend\.pipelines\.live_pipeline" src/web -S
- rg -n "from src\.backend\.weather_data_server" src/web -S
- python3 -m compileall src