### PR TITLE
Refactor web request and hourly loading through adapters

### DIFF
--- a/src/backend/services/__init__.py
+++ b/src/backend/services/__init__.py
@@ -1,5 +1,27 @@
+from src.backend.services.hourly_payload_service import build_hourly_payload_for_resort
+from src.backend.services.resort_selection_service import (
+    apply_catalog_filters,
+    available_filters,
+    build_empty_payload,
+    catalog_item_with_display_name,
+    default_applied_filters,
+    load_supported_resort_catalog,
+    select_resorts_from_query,
+    split_query_values,
+    supported_catalog,
+)
 from src.backend.services.weather_service import build_weather_payload
 
 __all__ = [
+    "apply_catalog_filters",
+    "available_filters",
+    "build_empty_payload",
+    "build_hourly_payload_for_resort",
     "build_weather_payload",
+    "catalog_item_with_display_name",
+    "default_applied_filters",
+    "load_supported_resort_catalog",
+    "select_resorts_from_query",
+    "split_query_values",
+    "supported_catalog",
 ]

--- a/src/backend/services/hourly_payload_service.py
+++ b/src/backend/services/hourly_payload_service.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from src.backend.airport_catalog import find_nearby_airports, load_airport_catalog
+from src.backend.cache import JsonCache, ResortCoordinateCache, dated_cache_path
+from src.backend.constants import COORDINATES_CACHE_FILE
+from src.backend.io import seed_coordinate_cache_from_entries
+from src.backend.open_meteo import fetch_hourly_forecast, geocode
+from src.backend.services.resort_selection_service import load_supported_resort_catalog
+
+
+def build_hourly_payload_for_resort(
+    *,
+    resort_id: str,
+    hours: int,
+    cache_file: str,
+    geocode_cache_hours: int,
+    forecast_cache_hours: int,
+) -> Dict[str, object] | None:
+    catalog = load_supported_resort_catalog()
+    item = next((r for r in catalog if str(r.get("resort_id", "")) == resort_id), None)
+    if item is None:
+        return None
+
+    cache_path = dated_cache_path(cache_file)
+    cache = JsonCache(cache_path)
+    coord_cache = ResortCoordinateCache(COORDINATES_CACHE_FILE)
+    query = str(item.get("query", "")).strip()
+    seed_coordinate_cache_from_entries(coord_cache, [item])
+    location = geocode(
+        query,
+        cache=cache,
+        ttl_seconds=geocode_cache_hours * 3600,
+        coord_cache=coord_cache,
+    )
+    if location is None:
+        return {
+            "error": f"Unable to geocode resort '{query}'",
+            "resort_id": resort_id,
+            "query": query,
+        }
+
+    forecast = fetch_hourly_forecast(
+        location,
+        cache=cache,
+        ttl_seconds=forecast_cache_hours * 3600,
+        hours=hours,
+    )
+    cache.save()
+    coord_cache.save()
+    try:
+        airports = load_airport_catalog()
+    except Exception:
+        airports = []
+    nearby_airports = find_nearby_airports(
+        resort_latitude=location.latitude,
+        resort_longitude=location.longitude,
+        airports=airports,
+        radius_miles=250.0,
+    )
+
+    hourly = forecast.get("hourly", {}) if isinstance(forecast, dict) else {}
+    times = list(hourly.get("time", []))
+    n = min(hours, len(times))
+    metric_keys = [
+        "snowfall",
+        "rain",
+        "precipitation_probability",
+        "snow_depth",
+        "wind_speed_10m",
+        "wind_direction_10m",
+        "visibility",
+    ]
+    trimmed_hourly: Dict[str, object] = {"time": times[:n]}
+    for key in metric_keys:
+        values = hourly.get(key, [])
+        if isinstance(values, list):
+            trimmed_hourly[key] = values[:n]
+        else:
+            trimmed_hourly[key] = []
+
+    return {
+        "resort_id": resort_id,
+        "query": query,
+        "display_name": str(item.get("display_name") or query).strip(),
+        "website": str(item.get("website") or "").strip(),
+        "matched_name": location.name,
+        "country": item.get("country"),
+        "region": item.get("region"),
+        "subregion": item.get("subregion"),
+        "pass_types": item.get("pass_types", []),
+        "timezone": forecast.get("timezone"),
+        "model": "ecmwf_ifs025",
+        "input_latitude": location.latitude,
+        "input_longitude": location.longitude,
+        "resolved_latitude": forecast.get("latitude"),
+        "resolved_longitude": forecast.get("longitude"),
+        "nearby_airports": nearby_airports,
+        "hours": n,
+        "hourly": trimmed_hourly,
+    }

--- a/src/backend/services/resort_selection_service.py
+++ b/src/backend/services/resort_selection_service.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+from src.backend.compute.payload_metadata import build_payload_metadata
+from src.backend.resort_catalog import load_resort_catalog, search_resort_catalog
+from src.shared.config import DEFAULT_RESORTS_FILE
+
+_SUPPORTED_PASS_TYPES = {"epic", "ikon"}
+
+
+def split_query_values(values: List[str], *, to_upper: bool = False) -> List[str]:
+    out: List[str] = []
+    for raw in values:
+        for part in raw.split(","):
+            val = part.strip().upper() if to_upper else part.strip().lower()
+            if val:
+                out.append(val)
+    seen = set()
+    return [x for x in out if not (x in seen or seen.add(x))]
+
+
+def to_bool_flag(raw: str) -> bool:
+    return (raw or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def supported_catalog(catalog: List[Dict[str, object]]) -> List[Dict[str, object]]:
+    out: List[Dict[str, object]] = []
+    for item in catalog:
+        raw_pass_types = item.get("pass_types")
+        if not isinstance(raw_pass_types, list):
+            continue
+        pass_types = {str(v).strip().lower() for v in raw_pass_types if str(v).strip()}
+        if pass_types.intersection(_SUPPORTED_PASS_TYPES):
+            out.append(item)
+    return out
+
+
+def load_supported_resort_catalog(resorts_file: str = DEFAULT_RESORTS_FILE) -> List[Dict[str, object]]:
+    return supported_catalog(load_resort_catalog(resorts_file))
+
+
+def catalog_item_with_display_name(item: Dict[str, object]) -> Dict[str, object]:
+    out = dict(item)
+    out["display_name"] = str(item.get("display_name") or item.get("query") or "").strip()
+    out["website"] = str(item.get("website") or "").strip()
+    return out
+
+
+def available_filters(catalog: List[Dict[str, object]]) -> Dict[str, Dict[str, int]]:
+    pass_type_counts: Dict[str, int] = {}
+    region_counts: Dict[str, int] = {}
+    subregion_counts: Dict[str, int] = {}
+    country_counts: Dict[str, int] = {}
+    for item in catalog:
+        region = str(item.get("region", "")).strip().lower()
+        if region:
+            region_counts[region] = region_counts.get(region, 0) + 1
+        subregion = str(item.get("subregion", "")).strip().lower()
+        if subregion:
+            subregion_counts[subregion] = subregion_counts.get(subregion, 0) + 1
+        country = str(item.get("country", "")).strip().upper()
+        if country:
+            country_counts[country] = country_counts.get(country, 0) + 1
+        for pass_type in item.get("pass_types", []) if isinstance(item.get("pass_types"), list) else []:
+            pt = str(pass_type).strip().lower()
+            if pt:
+                pass_type_counts[pt] = pass_type_counts.get(pt, 0) + 1
+    return {
+        "pass_type": pass_type_counts,
+        "region": region_counts,
+        "subregion": subregion_counts,
+        "country": country_counts,
+    }
+
+
+def apply_catalog_filters(
+    catalog: List[Dict[str, object]],
+    *,
+    pass_types: List[str],
+    region: str,
+    subregions: List[str],
+    countries: List[str],
+    search: str,
+) -> List[Dict[str, object]]:
+    items = search_resort_catalog(catalog, search)
+    if pass_types:
+        allowed = set(pass_types)
+        items = [
+            item
+            for item in items
+            if allowed.intersection(
+                {str(v).strip().lower() for v in (item.get("pass_types") or []) if str(v).strip()}
+            )
+        ]
+    if region:
+        want = region.lower()
+        items = [item for item in items if str(item.get("region", "")).strip().lower() == want]
+    if subregions:
+        allowed_subregions = set(subregions)
+        items = [item for item in items if str(item.get("subregion", "")).strip().lower() in allowed_subregions]
+    if countries:
+        allowed_countries = set(countries)
+        items = [item for item in items if str(item.get("country", "")).strip().upper() in allowed_countries]
+    return items
+
+
+def build_empty_payload(cache_file: str, geocode_cache_hours: int, forecast_cache_hours: int) -> Dict[str, object]:
+    return build_payload_metadata(
+        cache_path=cache_file,
+        cache_hits=0,
+        cache_misses=0,
+        geocode_cache_hours=geocode_cache_hours,
+        forecast_cache_hours=forecast_cache_hours,
+        reports=[],
+        failed=[],
+    )
+
+
+def default_applied_filters() -> Dict[str, object]:
+    return {
+        "pass_type": [],
+        "region": "",
+        "subregion": [],
+        "country": [],
+        "search": "",
+        "search_all": True,
+        "include_default": True,
+        "include_all": False,
+    }
+
+
+def select_resorts_from_query(qs: dict) -> tuple[List[str], str, dict, dict, bool]:
+    resorts = [x.strip() for x in qs.get("resort", []) if x.strip()]
+    pass_types = split_query_values(qs.get("pass_type", []))
+    region = (qs.get("region", [""])[0] or "").strip().lower()
+    subregions = split_query_values(qs.get("subregion", []))
+    countries = split_query_values(qs.get("country", []), to_upper=True)
+    search_text = (qs.get("search", [""])[0] or "").strip()
+    has_search_all = "search_all" in qs
+    search_all = to_bool_flag((qs.get("search_all", [""])[0] or "")) if has_search_all else True
+    has_include_default = "include_default" in qs
+    include_default = to_bool_flag((qs.get("include_default", [""])[0] or "")) if has_include_default else False
+    include_all = to_bool_flag((qs.get("include_all", [""])[0] or ""))
+    applied = {
+        "pass_type": pass_types,
+        "region": region,
+        "subregion": subregions,
+        "country": countries,
+        "search": search_text,
+        "search_all": search_all,
+        "include_default": include_default,
+        "include_all": include_all,
+    }
+
+    catalog = load_supported_resort_catalog(DEFAULT_RESORTS_FILE)
+    available = available_filters(catalog)
+    has_filters = bool(
+        pass_types or region or subregions or countries or search_text or include_all or has_include_default or has_search_all
+    )
+    if not has_filters:
+        applied["search_all"] = True
+        applied["include_default"] = not bool(resorts)
+        applied["include_all"] = False
+        resorts_file = "" if resorts else DEFAULT_RESORTS_FILE
+        return resorts, resorts_file, applied, available, False
+
+    if search_text and search_all:
+        # Search-all mode ignores pass/region/country/default scope and searches full supported catalog.
+        filtered_catalog = search_resort_catalog(catalog, search_text)
+    elif include_default:
+        default_catalog = [item for item in catalog if bool(item.get("default_enabled", False))]
+        filtered_catalog = apply_catalog_filters(
+            default_catalog,
+            pass_types=pass_types,
+            region=region,
+            subregions=subregions,
+            countries=countries,
+            search=search_text,
+        )
+    elif include_all and not (pass_types or region or subregions or countries or search_text):
+        filtered_catalog = list(catalog)
+    else:
+        filtered_catalog = apply_catalog_filters(
+            catalog,
+            pass_types=pass_types,
+            region=region,
+            subregions=subregions,
+            countries=countries,
+            search=search_text,
+        )
+
+    allowed_queries = {
+        str(item.get("query", "")).strip()
+        for item in filtered_catalog
+        if str(item.get("query", "")).strip()
+    }
+    if resorts:
+        selected = [r for r in resorts if r in allowed_queries]
+    else:
+        selected = [
+            str(item["query"]).strip()
+            for item in filtered_catalog
+            if str(item.get("query", "")).strip()
+        ]
+    no_match = len(selected) == 0
+    return selected, "", applied, available, no_match

--- a/src/backend/weather_data_server.py
+++ b/src/backend/weather_data_server.py
@@ -13,18 +13,20 @@ from urllib.parse import parse_qs, urlparse
 if str(Path(__file__).resolve().parents[2]) not in sys.path:
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from src.backend.cache import JsonCache, ResortCoordinateCache, dated_cache_path
-from src.backend.airport_catalog import find_nearby_airports, load_airport_catalog
-from src.backend.constants import COORDINATES_CACHE_FILE
-from src.backend.io import seed_coordinate_cache_from_entries
-from src.backend.compute.payload_metadata import build_payload_metadata
-from src.backend.open_meteo import fetch_hourly_forecast, geocode
 from src.backend.pipelines.live_pipeline import run_live_payload
-from src.backend.resort_catalog import load_resort_catalog, search_resort_catalog
+from src.backend.services.hourly_payload_service import build_hourly_payload_for_resort
+from src.backend.services.resort_selection_service import (
+    apply_catalog_filters,
+    available_filters,
+    build_empty_payload,
+    catalog_item_with_display_name,
+    default_applied_filters,
+    load_supported_resort_catalog,
+    select_resorts_from_query,
+    split_query_values,
+    supported_catalog,
+)
 from src.shared.config import DEFAULT_RESORTS_FILE
-
-_SUPPORTED_PASS_TYPES = {"epic", "ikon"}
-
 
 def _append_common_headers(handler: BaseHTTPRequestHandler, allow_origin: str) -> None:
     handler.send_header("Access-Control-Allow-Origin", allow_origin)
@@ -33,64 +35,19 @@ def _append_common_headers(handler: BaseHTTPRequestHandler, allow_origin: str) -
 
 
 def _split_query_values(values: List[str], *, to_upper: bool = False) -> List[str]:
-    out: List[str] = []
-    for raw in values:
-        for part in raw.split(","):
-            val = part.strip().upper() if to_upper else part.strip().lower()
-            if val:
-                out.append(val)
-    seen = set()
-    return [x for x in out if not (x in seen or seen.add(x))]
-
-
-def _to_bool_flag(raw: str) -> bool:
-    return (raw or "").strip().lower() in {"1", "true", "yes", "on"}
+    return split_query_values(values, to_upper=to_upper)
 
 
 def _supported_catalog(catalog: List[Dict[str, object]]) -> List[Dict[str, object]]:
-    out: List[Dict[str, object]] = []
-    for item in catalog:
-        raw_pass_types = item.get("pass_types")
-        if not isinstance(raw_pass_types, list):
-            continue
-        pass_types = {str(v).strip().lower() for v in raw_pass_types if str(v).strip()}
-        if pass_types.intersection(_SUPPORTED_PASS_TYPES):
-            out.append(item)
-    return out
+    return supported_catalog(catalog)
 
 
 def _catalog_item_with_display_name(item: Dict[str, object]) -> Dict[str, object]:
-    out = dict(item)
-    out["display_name"] = str(item.get("display_name") or item.get("query") or "").strip()
-    out["website"] = str(item.get("website") or "").strip()
-    return out
+    return catalog_item_with_display_name(item)
 
 
 def _available_filters(catalog: List[Dict[str, object]]) -> Dict[str, Dict[str, int]]:
-    pass_type_counts: Dict[str, int] = {}
-    region_counts: Dict[str, int] = {}
-    subregion_counts: Dict[str, int] = {}
-    country_counts: Dict[str, int] = {}
-    for item in catalog:
-        region = str(item.get("region", "")).strip().lower()
-        if region:
-            region_counts[region] = region_counts.get(region, 0) + 1
-        subregion = str(item.get("subregion", "")).strip().lower()
-        if subregion:
-            subregion_counts[subregion] = subregion_counts.get(subregion, 0) + 1
-        country = str(item.get("country", "")).strip().upper()
-        if country:
-            country_counts[country] = country_counts.get(country, 0) + 1
-        for pass_type in item.get("pass_types", []) if isinstance(item.get("pass_types"), list) else []:
-            pt = str(pass_type).strip().lower()
-            if pt:
-                pass_type_counts[pt] = pass_type_counts.get(pt, 0) + 1
-    return {
-        "pass_type": pass_type_counts,
-        "region": region_counts,
-        "subregion": subregion_counts,
-        "country": country_counts,
-    }
+    return available_filters(catalog)
 
 
 def _apply_catalog_filters(
@@ -102,136 +59,22 @@ def _apply_catalog_filters(
     countries: List[str],
     search: str,
 ) -> List[Dict[str, object]]:
-    items = search_resort_catalog(catalog, search)
-    if pass_types:
-        allowed = set(pass_types)
-        items = [
-            item
-            for item in items
-            if allowed.intersection(
-                {str(v).strip().lower() for v in (item.get("pass_types") or []) if str(v).strip()}
-            )
-        ]
-    if region:
-        want = region.lower()
-        items = [item for item in items if str(item.get("region", "")).strip().lower() == want]
-    if subregions:
-        allowed_subregions = set(subregions)
-        items = [item for item in items if str(item.get("subregion", "")).strip().lower() in allowed_subregions]
-    if countries:
-        allowed_countries = set(countries)
-        items = [item for item in items if str(item.get("country", "")).strip().upper() in allowed_countries]
-    return items
+    return apply_catalog_filters(
+        catalog,
+        pass_types=pass_types,
+        region=region,
+        subregions=subregions,
+        countries=countries,
+        search=search,
+    )
 
 
 def _empty_payload(cache_file: str, geocode_cache_hours: int, forecast_cache_hours: int) -> Dict[str, object]:
-    return build_payload_metadata(
-        cache_path=cache_file,
-        cache_hits=0,
-        cache_misses=0,
-        geocode_cache_hours=geocode_cache_hours,
-        forecast_cache_hours=forecast_cache_hours,
-        reports=[],
-        failed=[],
-    )
+    return build_empty_payload(cache_file, geocode_cache_hours, forecast_cache_hours)
 
 
 def _default_applied_filters() -> Dict[str, object]:
-    return {
-        "pass_type": [],
-        "region": "",
-        "subregion": [],
-        "country": [],
-        "search": "",
-        "search_all": True,
-        "include_default": True,
-        "include_all": False,
-    }
-
-
-def select_resorts_from_query(qs: dict) -> tuple[List[str], str, dict, dict, bool]:
-    resorts = [x.strip() for x in qs.get("resort", []) if x.strip()]
-    pass_types = _split_query_values(qs.get("pass_type", []))
-    region = (qs.get("region", [""])[0] or "").strip().lower()
-    subregions = _split_query_values(qs.get("subregion", []))
-    countries = _split_query_values(qs.get("country", []), to_upper=True)
-    search_text = (qs.get("search", [""])[0] or "").strip()
-    has_search_all = "search_all" in qs
-    search_all = _to_bool_flag((qs.get("search_all", [""])[0] or "")) if has_search_all else True
-    has_include_default = "include_default" in qs
-    include_default = _to_bool_flag((qs.get("include_default", [""])[0] or "")) if has_include_default else False
-    include_all = _to_bool_flag((qs.get("include_all", [""])[0] or ""))
-    applied = {
-        "pass_type": pass_types,
-        "region": region,
-        "subregion": subregions,
-        "country": countries,
-        "search": search_text,
-        "search_all": search_all,
-        "include_default": include_default,
-        "include_all": include_all,
-    }
-
-    catalog = _supported_catalog(load_resort_catalog(DEFAULT_RESORTS_FILE))
-    available = _available_filters(catalog)
-    has_filters = bool(
-        pass_types or region or subregions or countries or search_text or include_all or has_include_default or has_search_all
-    )
-    if not has_filters:
-        applied["search_all"] = True
-        applied["include_default"] = not bool(resorts)
-        applied["include_all"] = False
-        resorts_file = "" if resorts else DEFAULT_RESORTS_FILE
-        return resorts, resorts_file, applied, available, False
-
-    if search_text and search_all:
-        # Search-all mode ignores pass/region/country/default scope and searches full supported catalog.
-        filtered_catalog = search_resort_catalog(catalog, search_text)
-    elif include_default:
-        default_catalog = [item for item in catalog if bool(item.get("default_enabled", False))]
-        filtered_catalog = _apply_catalog_filters(
-            default_catalog,
-            pass_types=pass_types,
-            region=region,
-            subregions=subregions,
-            countries=countries,
-            search=search_text,
-        )
-    elif include_all and not (pass_types or region or subregions or countries or search_text):
-        filtered_catalog = list(catalog)
-    else:
-        filtered_catalog = _apply_catalog_filters(
-            catalog,
-            pass_types=pass_types,
-            region=region,
-            subregions=subregions,
-            countries=countries,
-            search=search_text,
-        )
-
-    allowed_queries = {
-        str(item.get("query", "")).strip()
-        for item in filtered_catalog
-        if str(item.get("query", "")).strip()
-    }
-    if resorts:
-        selected = [r for r in resorts if r in allowed_queries]
-    else:
-        selected = [
-            str(item["query"]).strip()
-            for item in filtered_catalog
-            if str(item.get("query", "")).strip()
-        ]
-    no_match = len(selected) == 0
-    return selected, "", applied, available, no_match
-
-
-def _parse_hours(raw: str, default: int = 72) -> int:
-    try:
-        value = int(raw)
-    except (TypeError, ValueError):
-        value = default
-    return max(1, min(240, value))
+    return default_applied_filters()
 
 
 def _hourly_payload_for_resort(
@@ -242,88 +85,21 @@ def _hourly_payload_for_resort(
     geocode_cache_hours: int,
     forecast_cache_hours: int,
 ) -> Dict[str, object] | None:
-    catalog = _supported_catalog(load_resort_catalog(DEFAULT_RESORTS_FILE))
-    item = next((r for r in catalog if str(r.get("resort_id", "")) == resort_id), None)
-    if item is None:
-        return None
-
-    cache_path = dated_cache_path(cache_file)
-    cache = JsonCache(cache_path)
-    coord_cache = ResortCoordinateCache(COORDINATES_CACHE_FILE)
-    query = str(item.get("query", "")).strip()
-    seed_coordinate_cache_from_entries(coord_cache, [item])
-    location = geocode(
-        query,
-        cache=cache,
-        ttl_seconds=geocode_cache_hours * 3600,
-        coord_cache=coord_cache,
-    )
-    if location is None:
-        return {
-            "error": f"Unable to geocode resort '{query}'",
-            "resort_id": resort_id,
-            "query": query,
-        }
-
-    forecast = fetch_hourly_forecast(
-        location,
-        cache=cache,
-        ttl_seconds=forecast_cache_hours * 3600,
+    return build_hourly_payload_for_resort(
+        resort_id=resort_id,
         hours=hours,
+        cache_file=cache_file,
+        geocode_cache_hours=geocode_cache_hours,
+        forecast_cache_hours=forecast_cache_hours,
     )
-    cache.save()
-    coord_cache.save()
+
+
+def _parse_hours(raw: str, default: int = 72) -> int:
     try:
-        airports = load_airport_catalog()
-    except Exception:
-        airports = []
-    nearby_airports = find_nearby_airports(
-        resort_latitude=location.latitude,
-        resort_longitude=location.longitude,
-        airports=airports,
-        radius_miles=250.0,
-    )
-
-    hourly = forecast.get("hourly", {}) if isinstance(forecast, dict) else {}
-    times = list(hourly.get("time", []))
-    n = min(hours, len(times))
-    metric_keys = [
-        "snowfall",
-        "rain",
-        "precipitation_probability",
-        "snow_depth",
-        "wind_speed_10m",
-        "wind_direction_10m",
-        "visibility",
-    ]
-    trimmed_hourly: Dict[str, object] = {"time": times[:n]}
-    for key in metric_keys:
-        values = hourly.get(key, [])
-        if isinstance(values, list):
-            trimmed_hourly[key] = values[:n]
-        else:
-            trimmed_hourly[key] = []
-
-    return {
-        "resort_id": resort_id,
-        "query": query,
-        "display_name": str(item.get("display_name") or query).strip(),
-        "website": str(item.get("website") or "").strip(),
-        "matched_name": location.name,
-        "country": item.get("country"),
-                "region": item.get("region"),
-                "subregion": item.get("subregion"),
-                "pass_types": item.get("pass_types", []),
-        "timezone": forecast.get("timezone"),
-        "model": "ecmwf_ifs025",
-        "input_latitude": location.latitude,
-        "input_longitude": location.longitude,
-        "resolved_latitude": forecast.get("latitude"),
-        "resolved_longitude": forecast.get("longitude"),
-        "nearby_airports": nearby_airports,
-        "hours": n,
-        "hourly": trimmed_hourly,
-    }
+        value = int(raw)
+    except (TypeError, ValueError):
+        value = default
+    return max(1, min(240, value))
 
 
 def make_handler(
@@ -372,7 +148,7 @@ def make_handler(
                     return
                 hours = _parse_hours((qs.get("hours", ["72"])[0] or "72"), default=72)
                 try:
-                    result = _hourly_payload_for_resort(
+                    result = build_hourly_payload_for_resort(
                         resort_id=resort_id,
                         hours=hours,
                         cache_file=cache_file,
@@ -393,7 +169,7 @@ def make_handler(
             if parsed.path == "/api/resorts":
                 search_text = (qs.get("search", [""])[0] or "").strip()
                 try:
-                    catalog = _supported_catalog(load_resort_catalog(DEFAULT_RESORTS_FILE))
+                    catalog = load_supported_resort_catalog(DEFAULT_RESORTS_FILE)
                 except Exception as exc:
                     self._write_json(500, {"error": f"Failed to load resort catalog: {exc}"})
                     return

--- a/src/cli.py
+++ b/src/cli.py
@@ -176,7 +176,12 @@ def run_render(args: argparse.Namespace) -> int:
     payload = load_payload(mode="file", source=args.input_json)
     output_html = _index_html_for_output_dir(args.output_dir, input_json=args.input_json)
     out = render_html(output_html, payload, data_url=_relative_url(output_html, args.input_json))
-    hourly_pages = render_hourly_pages(output_html, payload)
+    hourly_pages = render_hourly_pages(
+        output_html,
+        payload,
+        hourly_mode="file",
+        hourly_source=args.input_json,
+    )
     output_dir = str(Path(output_html).parent)
     copied_assets = _copy_static_assets(output_dir)
     print(f"Done: {out}")
@@ -202,6 +207,8 @@ def run_static(args: argparse.Namespace) -> int:
             output_html,
             payload,
             include_hourly_data=True,
+            hourly_mode="local",
+            hourly_source="",
             cache_file=args.cache_file,
             geocode_cache_hours=args.geocode_cache_hours,
             forecast_cache_hours=args.forecast_cache_hours,

--- a/src/web/data_sources/__init__.py
+++ b/src/web/data_sources/__init__.py
@@ -1,10 +1,13 @@
 from src.web.data_sources.gateway import build_payload_client, load_payload
 from src.web.data_sources.hourly_source import load_hourly_payload
 from src.web.data_sources.local_source import load_local_payload
+from src.web.data_sources.request_source import load_request_payload, strip_server_filter_query
 
 __all__ = [
     "load_hourly_payload",
     "load_payload",
     "build_payload_client",
     "load_local_payload",
+    "load_request_payload",
+    "strip_server_filter_query",
 ]

--- a/src/web/data_sources/__init__.py
+++ b/src/web/data_sources/__init__.py
@@ -1,7 +1,9 @@
 from src.web.data_sources.gateway import build_payload_client, load_payload
+from src.web.data_sources.hourly_source import load_hourly_payload
 from src.web.data_sources.local_source import load_local_payload
 
 __all__ = [
+    "load_hourly_payload",
     "load_payload",
     "build_payload_client",
     "load_local_payload",

--- a/src/web/data_sources/hourly_source.py
+++ b/src/web/data_sources/hourly_source.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Tuple
+import urllib.error
+import urllib.request
+from urllib.parse import urlencode, urlsplit, urlunsplit
+
+from src.backend.services.hourly_payload_service import build_hourly_payload_for_resort
+
+
+def _hourly_endpoint_from_data_source(base_url: str) -> str:
+    parsed = urlsplit(base_url)
+    return urlunsplit((parsed.scheme, parsed.netloc, "/api/resort-hourly", "", ""))
+
+
+def _load_local_hourly_payload(
+    *,
+    resort_id: str,
+    hours: int,
+    cache_file: str,
+    geocode_cache_hours: int,
+    forecast_cache_hours: int,
+) -> Tuple[int, Dict[str, Any]]:
+    payload = build_hourly_payload_for_resort(
+        resort_id=resort_id,
+        hours=hours,
+        cache_file=cache_file,
+        geocode_cache_hours=geocode_cache_hours,
+        forecast_cache_hours=forecast_cache_hours,
+    )
+    if payload is None:
+        return 404, {"error": f"Unknown resort_id: {resort_id}"}
+    if "error" in payload:
+        return 502, payload
+    return 200, payload
+
+
+def _load_api_hourly_payload(
+    *,
+    source: str,
+    resort_id: str,
+    hours: int,
+    timeout: int,
+) -> Tuple[int, Dict[str, Any]]:
+    hourly_base = _hourly_endpoint_from_data_source(source)
+    hourly_url = f"{hourly_base}?{urlencode({'resort_id': resort_id, 'hours': str(hours)})}"
+    try:
+        with urllib.request.urlopen(hourly_url, timeout=timeout) as resp:
+            body = resp.read().decode("utf-8")
+            return 200, json.loads(body)
+    except urllib.error.HTTPError as exc:
+        error_body = exc.read().decode("utf-8", errors="ignore")
+        try:
+            payload = json.loads(error_body)
+        except Exception:
+            payload = {"error": error_body or f"HTTP {exc.code}"}
+        return exc.code, payload
+    except urllib.error.URLError as exc:
+        return 502, {"error": str(exc)}
+    except Exception as exc:
+        return 500, {"error": str(exc)}
+
+
+def load_hourly_payload(
+    mode: str,
+    source: str,
+    *,
+    resort_id: str,
+    hours: int,
+    timeout: int = 20,
+    cache_file: str = ".cache/open_meteo_cache.json",
+    geocode_cache_hours: int = 24 * 30,
+    forecast_cache_hours: int = 3,
+) -> Tuple[int, Dict[str, Any]]:
+    if mode == "local":
+        return _load_local_hourly_payload(
+            resort_id=resort_id,
+            hours=hours,
+            cache_file=cache_file,
+            geocode_cache_hours=geocode_cache_hours,
+            forecast_cache_hours=forecast_cache_hours,
+        )
+    if mode == "api":
+        return _load_api_hourly_payload(
+            source=source,
+            resort_id=resort_id,
+            hours=hours,
+            timeout=timeout,
+        )
+    if mode == "file":
+        return 501, {"error": "Hourly endpoint unavailable in file mode"}
+    raise ValueError(f"Unsupported data source mode: {mode}")

--- a/src/web/data_sources/request_source.py
+++ b/src/web/data_sources/request_source.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+from urllib.parse import parse_qs, urlencode, urlsplit, urlunsplit
+
+from src.backend.services.resort_selection_service import (
+    available_filters,
+    build_empty_payload,
+    default_applied_filters,
+    load_supported_resort_catalog,
+    select_resorts_from_query,
+)
+from src.web.data_sources.gateway import load_payload
+from src.web.data_sources.local_source import load_local_payload
+
+SERVER_FILTER_QUERY_KEYS = (
+    "pass_type",
+    "region",
+    "subregion",
+    "country",
+    "search",
+    "include_all",
+    "include_default",
+    "search_all",
+)
+
+
+def _append_query_values(base_url: str, qs: Dict[str, List[str]]) -> str:
+    if not qs:
+        return base_url
+    parsed = urlsplit(base_url)
+    merged = parse_qs(parsed.query, keep_blank_values=True)
+    for key, values in qs.items():
+        merged[key] = list(values)
+    query = urlencode(merged, doseq=True)
+    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, query, parsed.fragment))
+
+
+def strip_server_filter_query(qs: Dict[str, List[str]]) -> Dict[str, List[str]]:
+    return {key: list(values) for key, values in qs.items() if key not in SERVER_FILTER_QUERY_KEYS}
+
+
+def _ensure_filter_metadata(payload: Dict[str, Any]) -> Dict[str, Any]:
+    if "available_filters" not in payload:
+        try:
+            catalog = load_supported_resort_catalog()
+            payload["available_filters"] = available_filters(catalog)
+        except Exception:
+            payload["available_filters"] = {"pass_type": {}, "region": {}, "subregion": {}, "country": {}}
+    if "applied_filters" not in payload:
+        payload["applied_filters"] = default_applied_filters()
+    return payload
+
+
+def load_request_payload(
+    mode: str,
+    source: str,
+    *,
+    query_params: Dict[str, List[str]] | None = None,
+    apply_server_filters: bool = True,
+    timeout: int = 20,
+    cache_file: str = ".cache/open_meteo_cache.json",
+    geocode_cache_hours: int = 24 * 30,
+    forecast_cache_hours: int = 3,
+    max_workers: int = 8,
+) -> Dict[str, Any]:
+    qs = {key: list(values) for key, values in (query_params or {}).items()}
+    resorts = [x.strip() for x in qs.get("resort", []) if x.strip()]
+
+    has_server_side_filters = apply_server_filters and any(qs.get(key) for key in SERVER_FILTER_QUERY_KEYS)
+    if mode == "local" and has_server_side_filters:
+        selected, _, applied, available, no_match = select_resorts_from_query(qs)
+        if no_match:
+            payload = build_empty_payload(
+                cache_file=cache_file,
+                geocode_cache_hours=geocode_cache_hours,
+                forecast_cache_hours=forecast_cache_hours,
+            )
+        else:
+            payload = load_local_payload(
+                resorts=selected,
+                cache_file=cache_file,
+                geocode_cache_hours=geocode_cache_hours,
+                forecast_cache_hours=forecast_cache_hours,
+                max_workers=max_workers,
+            )
+        payload["available_filters"] = available
+        payload["applied_filters"] = applied
+        return payload
+
+    request_source = source
+    if mode == "api":
+        request_source = _append_query_values(source, qs)
+
+    payload = load_payload(
+        mode=mode,
+        source=request_source,
+        timeout=timeout,
+        resorts=resorts,
+        cache_file=cache_file,
+        geocode_cache_hours=geocode_cache_hours,
+        forecast_cache_hours=forecast_cache_hours,
+        max_workers=max_workers,
+    )
+    return _ensure_filter_metadata(payload)

--- a/src/web/pipelines/static_site.py
+++ b/src/web/pipelines/static_site.py
@@ -46,21 +46,30 @@ def _iter_resort_ids(payload: Dict[str, Any]) -> List[str]:
 
 def _build_hourly_payload(
     *,
+    mode: str,
+    source: str,
     resort_id: str,
     hours: int,
+    timeout: int,
     cache_file: str,
     geocode_cache_hours: int,
     forecast_cache_hours: int,
 ) -> Optional[Dict[str, Any]]:
-    from src.backend.services.hourly_payload_service import build_hourly_payload_for_resort
+    from src.web.data_sources import load_hourly_payload
 
-    return build_hourly_payload_for_resort(
+    code, payload = load_hourly_payload(
+        mode=mode,
+        source=source,
         resort_id=resort_id,
         hours=hours,
+        timeout=timeout,
         cache_file=cache_file,
         geocode_cache_hours=geocode_cache_hours,
         forecast_cache_hours=forecast_cache_hours,
     )
+    if code != 200 or "error" in payload:
+        return None
+    return payload
 
 
 def render_hourly_pages(
@@ -68,6 +77,9 @@ def render_hourly_pages(
     payload: Dict[str, Any],
     *,
     include_hourly_data: bool = True,
+    hourly_mode: str = "local",
+    hourly_source: str = "",
+    hourly_timeout: int = 20,
     hourly_hours: int = 120,
     cache_file: str = ".cache/open_meteo_cache.json",
     geocode_cache_hours: int = 24 * 30,
@@ -87,8 +99,11 @@ def render_hourly_pages(
             hourly_context["dailySummary"] = daily_summary
         if include_hourly_data:
             hourly_payload = _build_hourly_payload(
+                mode=hourly_mode,
+                source=hourly_source,
                 resort_id=resort_id,
                 hours=hourly_hours,
+                timeout=hourly_timeout,
                 cache_file=cache_file,
                 geocode_cache_hours=geocode_cache_hours,
                 forecast_cache_hours=forecast_cache_hours,

--- a/src/web/pipelines/static_site.py
+++ b/src/web/pipelines/static_site.py
@@ -52,9 +52,9 @@ def _build_hourly_payload(
     geocode_cache_hours: int,
     forecast_cache_hours: int,
 ) -> Optional[Dict[str, Any]]:
-    from src.backend.weather_data_server import _hourly_payload_for_resort
+    from src.backend.services.hourly_payload_service import build_hourly_payload_for_resort
 
-    return _hourly_payload_for_resort(
+    return build_hourly_payload_for_resort(
         resort_id=resort_id,
         hours=hours,
         cache_file=cache_file,

--- a/src/web/weather_page_server.py
+++ b/src/web/weather_page_server.py
@@ -28,16 +28,14 @@ from src.web.resort_hourly_context import build_resort_daily_summary_context
 from src.web.weather_page_assets import ASSET_MIME_TYPES, read_asset_bytes
 from src.web.weather_page_render_core import render_payload_html
 from src.backend.pipelines.live_pipeline import run_live_payload
-from src.backend.resort_catalog import load_resort_catalog
-from src.backend.weather_data_server import (
-    _available_filters,
-    _default_applied_filters,
-    _empty_payload,
-    _hourly_payload_for_resort,
-    _supported_catalog,
+from src.backend.services.hourly_payload_service import build_hourly_payload_for_resort
+from src.backend.services.resort_selection_service import (
+    available_filters,
+    build_empty_payload,
+    default_applied_filters,
+    load_supported_resort_catalog,
     select_resorts_from_query,
 )
-from src.shared.config import DEFAULT_RESORTS_FILE
 
 _HOURLY_TEMPLATE = (Path(__file__).resolve().parent / "templates" / "resort_hourly_page.html").read_text(
     encoding="utf-8"
@@ -130,7 +128,7 @@ def make_handler(
             if data_mode == "local" and apply_server_filters and has_server_side_filters:
                 selected, resorts_file, applied, available, no_match = select_resorts_from_query(qs)
                 if no_match:
-                    payload = _empty_payload(
+                    payload = build_empty_payload(
                         cache_file=cache_file,
                         geocode_cache_hours=geocode_cache_hours,
                         forecast_cache_hours=forecast_cache_hours,
@@ -164,17 +162,17 @@ def make_handler(
             )
             if "available_filters" not in payload:
                 try:
-                    catalog = _supported_catalog(load_resort_catalog(DEFAULT_RESORTS_FILE))
-                    payload["available_filters"] = _available_filters(catalog)
+                    catalog = load_supported_resort_catalog()
+                    payload["available_filters"] = available_filters(catalog)
                 except Exception:
                     payload["available_filters"] = {"pass_type": {}, "region": {}, "subregion": {}, "country": {}}
             if "applied_filters" not in payload:
-                payload["applied_filters"] = _default_applied_filters()
+                payload["applied_filters"] = default_applied_filters()
             return payload
 
         def _load_hourly_payload(self, resort_id: str, hours: int) -> tuple[int, Dict[str, Any]]:
             if data_mode == "local":
-                payload = _hourly_payload_for_resort(
+                payload = build_hourly_payload_for_resort(
                     resort_id=resort_id,
                     hours=hours,
                     cache_file=cache_file,

--- a/src/web/weather_page_server.py
+++ b/src/web/weather_page_server.py
@@ -16,19 +16,16 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 import sys
 from typing import Any, Dict, List
-import urllib.error
-import urllib.request
 from urllib.parse import parse_qs, urlencode, urlparse, urlsplit, urlunsplit
 
 if str(Path(__file__).resolve().parents[2]) not in sys.path:
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from src.web.data_sources import load_payload
+from src.web.data_sources import load_hourly_payload, load_payload
 from src.web.resort_hourly_context import build_resort_daily_summary_context
 from src.web.weather_page_assets import ASSET_MIME_TYPES, read_asset_bytes
 from src.web.weather_page_render_core import render_payload_html
 from src.backend.pipelines.live_pipeline import run_live_payload
-from src.backend.services.hourly_payload_service import build_hourly_payload_for_resort
 from src.backend.services.resort_selection_service import (
     available_filters,
     build_empty_payload,
@@ -82,11 +79,6 @@ def _append_query_values(base_url: str, qs: Dict[str, List[str]]) -> str:
         merged[key] = list(values)
     query = urlencode(merged, doseq=True)
     return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, query, parsed.fragment))
-
-
-def _hourly_endpoint_from_data_source(base_url: str) -> str:
-    parsed = urlsplit(base_url)
-    return urlunsplit((parsed.scheme, parsed.netloc, "/api/resort-hourly", "", ""))
 
 
 _SERVER_FILTER_QUERY_KEYS = ("pass_type", "region", "subregion", "country", "search", "include_all", "include_default", "search_all")
@@ -171,40 +163,16 @@ def make_handler(
             return payload
 
         def _load_hourly_payload(self, resort_id: str, hours: int) -> tuple[int, Dict[str, Any]]:
-            if data_mode == "local":
-                payload = build_hourly_payload_for_resort(
-                    resort_id=resort_id,
-                    hours=hours,
-                    cache_file=cache_file,
-                    geocode_cache_hours=geocode_cache_hours,
-                    forecast_cache_hours=forecast_cache_hours,
-                )
-                if payload is None:
-                    return 404, {"error": f"Unknown resort_id: {resort_id}"}
-                if "error" in payload:
-                    return 502, payload
-                return 200, payload
-
-            if data_mode == "api":
-                hourly_base = _hourly_endpoint_from_data_source(data_source)
-                hourly_url = f"{hourly_base}?{urlencode({'resort_id': resort_id, 'hours': str(hours)})}"
-                try:
-                    with urllib.request.urlopen(hourly_url, timeout=data_timeout) as resp:
-                        body = resp.read().decode("utf-8")
-                        return 200, json.loads(body)
-                except urllib.error.HTTPError as exc:
-                    error_body = exc.read().decode("utf-8", errors="ignore")
-                    try:
-                        payload = json.loads(error_body)
-                    except Exception:
-                        payload = {"error": error_body or f"HTTP {exc.code}"}
-                    return exc.code, payload
-                except urllib.error.URLError as exc:
-                    return 502, {"error": str(exc)}
-                except Exception as exc:
-                    return 500, {"error": str(exc)}
-
-            return 501, {"error": "Hourly endpoint unavailable in file mode"}
+            return load_hourly_payload(
+                mode=data_mode,
+                source=data_source,
+                resort_id=resort_id,
+                hours=hours,
+                timeout=data_timeout,
+                cache_file=cache_file,
+                geocode_cache_hours=geocode_cache_hours,
+                forecast_cache_hours=forecast_cache_hours,
+            )
 
         def do_GET(self) -> None:  # noqa: N802
             parsed = urlparse(self.path)

--- a/src/web/weather_page_server.py
+++ b/src/web/weather_page_server.py
@@ -16,23 +16,15 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 import sys
 from typing import Any, Dict, List
-from urllib.parse import parse_qs, urlencode, urlparse, urlsplit, urlunsplit
+from urllib.parse import parse_qs, urlparse
 
 if str(Path(__file__).resolve().parents[2]) not in sys.path:
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from src.web.data_sources import load_hourly_payload, load_payload
+from src.web.data_sources import load_hourly_payload, load_request_payload, strip_server_filter_query
 from src.web.resort_hourly_context import build_resort_daily_summary_context
 from src.web.weather_page_assets import ASSET_MIME_TYPES, read_asset_bytes
 from src.web.weather_page_render_core import render_payload_html
-from src.backend.pipelines.live_pipeline import run_live_payload
-from src.backend.services.resort_selection_service import (
-    available_filters,
-    build_empty_payload,
-    default_applied_filters,
-    load_supported_resort_catalog,
-    select_resorts_from_query,
-)
 
 _HOURLY_TEMPLATE = (Path(__file__).resolve().parent / "templates" / "resort_hourly_page.html").read_text(
     encoding="utf-8"
@@ -69,25 +61,6 @@ def _asset_name_from_path(path: str) -> str:
         return path[idx + 1 :]
     return path.lstrip("/")
 
-
-def _append_query_values(base_url: str, qs: Dict[str, List[str]]) -> str:
-    if not qs:
-        return base_url
-    parsed = urlsplit(base_url)
-    merged = parse_qs(parsed.query, keep_blank_values=True)
-    for key, values in qs.items():
-        merged[key] = list(values)
-    query = urlencode(merged, doseq=True)
-    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, query, parsed.fragment))
-
-
-_SERVER_FILTER_QUERY_KEYS = ("pass_type", "region", "subregion", "country", "search", "include_all", "include_default", "search_all")
-
-
-def _qs_without_server_filters(qs: Dict[str, List[str]]) -> Dict[str, List[str]]:
-    return {key: list(values) for key, values in qs.items() if key not in _SERVER_FILTER_QUERY_KEYS}
-
-
 def make_handler(
     cache_file: str,
     geocode_cache_hours: int,
@@ -111,56 +84,17 @@ def make_handler(
             self.wfile.write(body)
 
         def _load_request_payload(self, qs: Dict[str, List[str]], *, apply_server_filters: bool = True) -> Dict[str, Any]:
-            resorts = [x.strip() for x in qs.get("resort", []) if x.strip()]
-            has_server_side_filters = any(
-                qs.get(key)
-                for key in _SERVER_FILTER_QUERY_KEYS
-            )
-
-            if data_mode == "local" and apply_server_filters and has_server_side_filters:
-                selected, resorts_file, applied, available, no_match = select_resorts_from_query(qs)
-                if no_match:
-                    payload = build_empty_payload(
-                        cache_file=cache_file,
-                        geocode_cache_hours=geocode_cache_hours,
-                        forecast_cache_hours=forecast_cache_hours,
-                    )
-                else:
-                    payload = run_live_payload(
-                        resorts=selected,
-                        resorts_file=resorts_file,
-                        cache_file=cache_file,
-                        geocode_cache_hours=geocode_cache_hours,
-                        forecast_cache_hours=forecast_cache_hours,
-                        max_workers=max_workers,
-                    )
-                payload["available_filters"] = available
-                payload["applied_filters"] = applied
-                return payload
-
-            source = data_source
-            if data_mode == "api":
-                source = _append_query_values(data_source, qs)
-
-            payload = load_payload(
+            return load_request_payload(
                 mode=data_mode,
-                source=source,
+                source=data_source,
+                query_params=qs,
+                apply_server_filters=apply_server_filters,
                 timeout=data_timeout,
-                resorts=resorts,
                 cache_file=cache_file,
                 geocode_cache_hours=geocode_cache_hours,
                 forecast_cache_hours=forecast_cache_hours,
                 max_workers=max_workers,
             )
-            if "available_filters" not in payload:
-                try:
-                    catalog = load_supported_resort_catalog()
-                    payload["available_filters"] = available_filters(catalog)
-                except Exception:
-                    payload["available_filters"] = {"pass_type": {}, "region": {}, "subregion": {}, "country": {}}
-            if "applied_filters" not in payload:
-                payload["applied_filters"] = default_applied_filters()
-            return payload
 
         def _load_hourly_payload(self, resort_id: str, hours: int) -> tuple[int, Dict[str, Any]]:
             return load_hourly_payload(
@@ -229,7 +163,7 @@ def make_handler(
                 self._write(200, body, "application/json; charset=utf-8")
                 return
 
-            page_qs = _qs_without_server_filters(qs)
+            page_qs = strip_server_filter_query(qs)
             payload = self._load_request_payload(page_qs, apply_server_filters=False)
             html = render_payload_html(payload, data_url="./api/data")
             self._write(200, html.encode("utf-8"), "text/html; charset=utf-8")

--- a/src/web/weather_page_static_render.py
+++ b/src/web/weather_page_static_render.py
@@ -71,6 +71,8 @@ def main() -> int:
         output_html,
         payload,
         include_hourly_data=True,
+        hourly_mode="local",
+        hourly_source="",
         cache_file=args.cache_file,
         geocode_cache_hours=args.geocode_cache_hours,
         forecast_cache_hours=args.forecast_cache_hours,

--- a/tests/backend/test_weather_data_server_filters.py
+++ b/tests/backend/test_weather_data_server_filters.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from src.backend.weather_data_server import DEFAULT_RESORTS_FILE, select_resorts_from_query
+from src.backend.services.resort_selection_service import select_resorts_from_query
+from src.shared.config import DEFAULT_RESORTS_FILE
 
 
 def _sample_catalog():
@@ -39,7 +40,7 @@ def _sample_catalog():
 
 
 def test_select_resorts_defaults_to_default_scope(monkeypatch):
-    monkeypatch.setattr("src.backend.weather_data_server.load_resort_catalog", lambda path: _sample_catalog())
+    monkeypatch.setattr("src.backend.services.resort_selection_service.load_resort_catalog", lambda path: _sample_catalog())
 
     selected, resorts_file, applied, available, no_match = select_resorts_from_query({})
 
@@ -56,7 +57,7 @@ def test_select_resorts_defaults_to_default_scope(monkeypatch):
 
 
 def test_select_resorts_search_all_ignores_other_filters(monkeypatch):
-    monkeypatch.setattr("src.backend.weather_data_server.load_resort_catalog", lambda path: _sample_catalog())
+    monkeypatch.setattr("src.backend.services.resort_selection_service.load_resort_catalog", lambda path: _sample_catalog())
 
     selected, resorts_file, applied, available, no_match = select_resorts_from_query(
         {
@@ -81,7 +82,7 @@ def test_select_resorts_search_all_ignores_other_filters(monkeypatch):
 
 
 def test_select_resorts_search_filtered_respects_filters(monkeypatch):
-    monkeypatch.setattr("src.backend.weather_data_server.load_resort_catalog", lambda path: _sample_catalog())
+    monkeypatch.setattr("src.backend.services.resort_selection_service.load_resort_catalog", lambda path: _sample_catalog())
 
     selected, resorts_file, applied, _available, no_match = select_resorts_from_query(
         {
@@ -103,7 +104,7 @@ def test_select_resorts_search_filtered_respects_filters(monkeypatch):
 
 
 def test_select_resorts_accepts_multi_value_subregion_and_country(monkeypatch):
-    monkeypatch.setattr("src.backend.weather_data_server.load_resort_catalog", lambda path: _sample_catalog())
+    monkeypatch.setattr("src.backend.services.resort_selection_service.load_resort_catalog", lambda path: _sample_catalog())
 
     selected, resorts_file, applied, _available, no_match = select_resorts_from_query(
         {
@@ -121,7 +122,7 @@ def test_select_resorts_accepts_multi_value_subregion_and_country(monkeypatch):
 
 
 def test_select_resorts_supports_long_form_state_country_and_city(monkeypatch):
-    monkeypatch.setattr("src.backend.weather_data_server.load_resort_catalog", lambda path: _sample_catalog())
+    monkeypatch.setattr("src.backend.services.resort_selection_service.load_resort_catalog", lambda path: _sample_catalog())
 
     selected_state, _file, _applied, _available, no_match_state = select_resorts_from_query(
         {"search": ["utah"], "search_all": ["1"], "include_all": ["1"]}

--- a/tests/backend/test_weather_data_server_hourly.py
+++ b/tests/backend/test_weather_data_server_hourly.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from src.backend.models import ResortLocation
-from src.backend.weather_data_server import _hourly_payload_for_resort
+from src.backend.services.hourly_payload_service import build_hourly_payload_for_resort
 
 
 class _DummyJsonCache:
@@ -23,8 +23,8 @@ class _DummyCoordCache:
 
 def test_hourly_payload_uses_catalog_coordinate_override(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "src.backend.weather_data_server.load_resort_catalog",
-        lambda path: [
+        "src.backend.services.hourly_payload_service.load_supported_resort_catalog",
+        lambda: [
             {
                 "resort_id": "crystal-mountain-wa",
                 "query": "Crystal Mountain, WA",
@@ -41,12 +41,12 @@ def test_hourly_payload_uses_catalog_coordinate_override(monkeypatch, tmp_path):
             }
         ],
     )
-    monkeypatch.setattr("src.backend.weather_data_server.dated_cache_path", lambda path: str(tmp_path / "dated_cache.json"))
-    monkeypatch.setattr("src.backend.weather_data_server.JsonCache", lambda path: _DummyJsonCache())
+    monkeypatch.setattr("src.backend.services.hourly_payload_service.dated_cache_path", lambda path: str(tmp_path / "dated_cache.json"))
+    monkeypatch.setattr("src.backend.services.hourly_payload_service.JsonCache", lambda path: _DummyJsonCache())
     coord_cache = _DummyCoordCache()
-    monkeypatch.setattr("src.backend.weather_data_server.ResortCoordinateCache", lambda path: coord_cache)
+    monkeypatch.setattr("src.backend.services.hourly_payload_service.ResortCoordinateCache", lambda path: coord_cache)
     monkeypatch.setattr(
-        "src.backend.weather_data_server.load_airport_catalog",
+        "src.backend.services.hourly_payload_service.load_airport_catalog",
         lambda: [
             {
                 "airport_id": "sea-seattle-tacoma",
@@ -72,9 +72,9 @@ def test_hourly_payload_uses_catalog_coordinate_override(monkeypatch, tmp_path):
             admin1=str(seed["admin1"]),
         )
 
-    monkeypatch.setattr("src.backend.weather_data_server.geocode", fake_geocode)
+    monkeypatch.setattr("src.backend.services.hourly_payload_service.geocode", fake_geocode)
     monkeypatch.setattr(
-        "src.backend.weather_data_server.fetch_hourly_forecast",
+        "src.backend.services.hourly_payload_service.fetch_hourly_forecast",
         lambda location, cache, ttl_seconds, hours: {
             "latitude": location.latitude,
             "longitude": location.longitude,
@@ -83,7 +83,7 @@ def test_hourly_payload_uses_catalog_coordinate_override(monkeypatch, tmp_path):
         },
     )
 
-    payload = _hourly_payload_for_resort(
+    payload = build_hourly_payload_for_resort(
         resort_id="crystal-mountain-wa",
         hours=72,
         cache_file=".cache/open_meteo_cache.json",

--- a/tests/integration/test_backend_data_server.py
+++ b/tests/integration/test_backend_data_server.py
@@ -22,7 +22,7 @@ def _serve_once(handler_cls):
 def test_backend_data_server_api_and_health(monkeypatch, valid_payload):
     monkeypatch.setattr("src.backend.weather_data_server.run_live_payload", lambda **kwargs: valid_payload)
     monkeypatch.setattr(
-        "src.backend.weather_data_server.load_resort_catalog",
+        "src.backend.services.resort_selection_service.load_resort_catalog",
         lambda path: [
             {
                 "resort_id": "snowbird-ut",
@@ -94,7 +94,7 @@ def test_backend_data_server_data_filters(monkeypatch, valid_payload):
 
     monkeypatch.setattr("src.backend.weather_data_server.run_live_payload", fake_run_live_payload)
     monkeypatch.setattr(
-        "src.backend.weather_data_server.load_resort_catalog",
+        "src.backend.services.resort_selection_service.load_resort_catalog",
         lambda path: [
             {
                 "resort_id": "snowbird-ut",
@@ -161,7 +161,7 @@ def test_backend_data_server_data_include_all(monkeypatch, valid_payload):
 
     monkeypatch.setattr("src.backend.weather_data_server.run_live_payload", fake_run_live_payload)
     monkeypatch.setattr(
-        "src.backend.weather_data_server.load_resort_catalog",
+        "src.backend.services.resort_selection_service.load_resort_catalog",
         lambda path: [
             {
                 "resort_id": "snowbird-ut",
@@ -221,7 +221,7 @@ def test_backend_data_server_data_include_default(monkeypatch, valid_payload):
 
     monkeypatch.setattr("src.backend.weather_data_server.run_live_payload", fake_run_live_payload)
     monkeypatch.setattr(
-        "src.backend.weather_data_server.load_resort_catalog",
+        "src.backend.services.resort_selection_service.load_resort_catalog",
         lambda path: [
             {
                 "resort_id": "snowbird-ut",
@@ -275,7 +275,7 @@ def test_backend_data_server_search_all_ignores_filters(monkeypatch, valid_paylo
 
     monkeypatch.setattr("src.backend.weather_data_server.run_live_payload", fake_run_live_payload)
     monkeypatch.setattr(
-        "src.backend.weather_data_server.load_resort_catalog",
+        "src.backend.services.resort_selection_service.load_resort_catalog",
         lambda path: [
             {
                 "resort_id": "snowbird-ut",
@@ -346,7 +346,7 @@ def test_backend_data_server_search_supports_long_form_locations(monkeypatch, va
 
     monkeypatch.setattr("src.backend.weather_data_server.run_live_payload", fake_run_live_payload)
     monkeypatch.setattr(
-        "src.backend.weather_data_server.load_resort_catalog",
+        "src.backend.services.resort_selection_service.load_resort_catalog",
         lambda path: [
             {
                 "resort_id": "arapahoe-basin-co",
@@ -421,7 +421,7 @@ def test_backend_data_server_hourly_endpoint(monkeypatch):
             },
         }
 
-    monkeypatch.setattr("src.backend.weather_data_server._hourly_payload_for_resort", fake_hourly)
+    monkeypatch.setattr("src.backend.weather_data_server.build_hourly_payload_for_resort", fake_hourly)
     handler = make_handler(
         cache_file=".cache/x.json",
         geocode_cache_hours=720,

--- a/tests/integration/test_data_sources.py
+++ b/tests/integration/test_data_sources.py
@@ -8,6 +8,7 @@ from src.contract.validators import ContractValidationError
 from src.shared.config import DEFAULT_RESORTS_FILE
 from src.web.data_sources.api_source import load_api_payload
 from src.web.data_sources.gateway import build_payload_client, load_payload
+from src.web.data_sources.hourly_source import load_hourly_payload
 from src.web.data_sources.static_json_source import load_static_payload
 
 
@@ -184,3 +185,64 @@ def test_build_payload_client_types():
     assert type(api_client).__name__ == "HttpPayloadClient"
     assert type(file_client).__name__ == "FilePayloadClient"
     assert type(local_client).__name__ == "LocalPayloadClient"
+
+
+def test_load_hourly_payload_local_mode(monkeypatch):
+    captured = {}
+
+    def fake_build_hourly_payload_for_resort(**kwargs):  # noqa: ANN001
+        captured.update(kwargs)
+        return {
+            "resort_id": kwargs["resort_id"],
+            "hours": kwargs["hours"],
+            "hourly": {"time": []},
+        }
+
+    monkeypatch.setattr(
+        "src.web.data_sources.hourly_source.build_hourly_payload_for_resort",
+        fake_build_hourly_payload_for_resort,
+    )
+    code, payload = load_hourly_payload(
+        "local",
+        "",
+        resort_id="snowbird-ut",
+        hours=6,
+        cache_file=".cache/hourly.json",
+        geocode_cache_hours=100,
+        forecast_cache_hours=2,
+    )
+    assert code == 200
+    assert payload["resort_id"] == "snowbird-ut"
+    assert captured["cache_file"] == ".cache/hourly.json"
+    assert captured["geocode_cache_hours"] == 100
+    assert captured["forecast_cache_hours"] == 2
+
+
+def test_load_hourly_payload_api_mode(monkeypatch):
+    captured = {}
+
+    def fake_urlopen(url, timeout):  # noqa: ANN001
+        captured["url"] = url
+        captured["timeout"] = timeout
+        return _DummyResponse(json.dumps({"resort_id": "snowbird-ut", "hourly": {"time": []}}).encode("utf-8"))
+
+    monkeypatch.setattr("src.web.data_sources.hourly_source.urllib.request.urlopen", fake_urlopen)
+    code, payload = load_hourly_payload(
+        "api",
+        "https://example.test/api/data?resort=snowbird-ut",
+        resort_id="snowbird-ut",
+        hours=12,
+        timeout=11,
+    )
+    assert code == 200
+    assert payload["resort_id"] == "snowbird-ut"
+    assert captured["timeout"] == 11
+    assert captured["url"].startswith("https://example.test/api/resort-hourly?")
+    assert "resort_id=snowbird-ut" in captured["url"]
+    assert "hours=12" in captured["url"]
+
+
+def test_load_hourly_payload_file_mode_is_explicitly_unavailable():
+    code, payload = load_hourly_payload("file", "/tmp/data.json", resort_id="snowbird-ut", hours=12)
+    assert code == 501
+    assert payload["error"] == "Hourly endpoint unavailable in file mode"

--- a/tests/integration/test_data_sources.py
+++ b/tests/integration/test_data_sources.py
@@ -9,6 +9,7 @@ from src.shared.config import DEFAULT_RESORTS_FILE
 from src.web.data_sources.api_source import load_api_payload
 from src.web.data_sources.gateway import build_payload_client, load_payload
 from src.web.data_sources.hourly_source import load_hourly_payload
+from src.web.data_sources.request_source import load_request_payload, strip_server_filter_query
 from src.web.data_sources.static_json_source import load_static_payload
 
 
@@ -185,6 +186,176 @@ def test_build_payload_client_types():
     assert type(api_client).__name__ == "HttpPayloadClient"
     assert type(file_client).__name__ == "FilePayloadClient"
     assert type(local_client).__name__ == "LocalPayloadClient"
+
+
+def test_strip_server_filter_query():
+    qs = {
+        "resort": ["Snowbird, UT"],
+        "pass_type": ["ikon"],
+        "region": ["west"],
+        "search": ["powder"],
+        "include_all": ["1"],
+    }
+    assert strip_server_filter_query(qs) == {"resort": ["Snowbird, UT"]}
+
+
+def test_load_request_payload_local_with_server_filters(monkeypatch):
+    calls = {}
+
+    monkeypatch.setattr(
+        "src.web.data_sources.request_source.select_resorts_from_query",
+        lambda qs: (
+            ["Snowbird, UT"],
+            "",
+            {"pass_type": ["ikon"], "region": "west"},
+            {"pass_type": {"ikon": 1}, "region": {"west": 1}},
+            False,
+        ),
+    )
+
+    def fake_load_local_payload(**kwargs):  # noqa: ANN001
+        calls.update(kwargs)
+        return {
+            "schema_version": "weather_payload_v1",
+            "generated_at_utc": "2026-03-03T23:00:00Z",
+            "source": "Open-Meteo",
+            "model": "ecmwf_ifs025",
+            "forecast_days": 15,
+            "units": {},
+            "cache": {},
+            "resorts_count": 1,
+            "failed_count": 0,
+            "failed": [],
+            "reports": [{"query": "Snowbird, UT", "daily": []}],
+        }
+
+    monkeypatch.setattr("src.web.data_sources.request_source.load_local_payload", fake_load_local_payload)
+
+    payload = load_request_payload(
+        mode="local",
+        source="",
+        query_params={"pass_type": ["ikon"], "region": ["west"]},
+        cache_file=".cache/x.json",
+        geocode_cache_hours=100,
+        forecast_cache_hours=2,
+        max_workers=4,
+    )
+    assert calls["resorts"] == ["Snowbird, UT"]
+    assert calls["cache_file"] == ".cache/x.json"
+    assert calls["max_workers"] == 4
+    assert payload["available_filters"]["pass_type"]["ikon"] == 1
+    assert payload["applied_filters"]["pass_type"] == ["ikon"]
+
+
+def test_load_request_payload_local_filter_no_match(monkeypatch):
+    monkeypatch.setattr(
+        "src.web.data_sources.request_source.select_resorts_from_query",
+        lambda qs: (
+            [],
+            "",
+            {"pass_type": ["ikon"]},
+            {"pass_type": {"ikon": 1}},
+            True,
+        ),
+    )
+
+    def fake_build_empty_payload(**kwargs):  # noqa: ANN001
+        return {
+            "schema_version": "weather_payload_v1",
+            "generated_at_utc": "2026-03-03T23:00:00Z",
+            "source": "Open-Meteo",
+            "model": "ecmwf_ifs025",
+            "forecast_days": 15,
+            "units": {},
+            "cache": {},
+            "resorts_count": 0,
+            "failed_count": 0,
+            "failed": [],
+            "reports": [],
+        }
+
+    monkeypatch.setattr("src.web.data_sources.request_source.build_empty_payload", fake_build_empty_payload)
+
+    payload = load_request_payload(
+        mode="local",
+        source="",
+        query_params={"pass_type": ["ikon"]},
+    )
+    assert payload["reports"] == []
+    assert payload["available_filters"]["pass_type"]["ikon"] == 1
+    assert payload["applied_filters"]["pass_type"] == ["ikon"]
+
+
+def test_load_request_payload_api_forwards_query(monkeypatch):
+    calls = {}
+
+    def fake_load_payload(mode, source, timeout=20, **kwargs):  # noqa: ANN001
+        calls["mode"] = mode
+        calls["source"] = source
+        calls["timeout"] = timeout
+        calls["kwargs"] = kwargs
+        return {
+            "schema_version": "weather_payload_v1",
+            "generated_at_utc": "2026-03-03T23:00:00Z",
+            "source": "Open-Meteo",
+            "model": "ecmwf_ifs025",
+            "forecast_days": 15,
+            "units": {},
+            "cache": {},
+            "resorts_count": 0,
+            "failed_count": 0,
+            "failed": [],
+            "reports": [],
+        }
+
+    monkeypatch.setattr("src.web.data_sources.request_source.load_payload", fake_load_payload)
+
+    load_request_payload(
+        mode="api",
+        source="https://example.test/api/data?existing=1",
+        timeout=11,
+        query_params={
+            "resort": ["A", "B"],
+            "pass_type": ["ikon"],
+            "region": ["west"],
+            "include_all": ["1"],
+        },
+    )
+    assert calls["mode"] == "api"
+    assert "existing=1" in calls["source"]
+    assert "resort=A" in calls["source"]
+    assert "resort=B" in calls["source"]
+    assert "pass_type=ikon" in calls["source"]
+    assert "region=west" in calls["source"]
+    assert "include_all=1" in calls["source"]
+    assert calls["timeout"] == 11
+    assert calls["kwargs"]["resorts"] == ["A", "B"]
+
+
+def test_load_request_payload_populates_filter_metadata_fallback(monkeypatch):
+    monkeypatch.setattr(
+        "src.web.data_sources.request_source.load_payload",
+        lambda **kwargs: {
+            "schema_version": "weather_payload_v1",
+            "generated_at_utc": "2026-03-03T23:00:00Z",
+            "source": "Open-Meteo",
+            "model": "ecmwf_ifs025",
+            "forecast_days": 15,
+            "units": {},
+            "cache": {},
+            "resorts_count": 0,
+            "failed_count": 0,
+            "failed": [],
+            "reports": [],
+        },
+    )
+    monkeypatch.setattr("src.web.data_sources.request_source.load_supported_resort_catalog", lambda: [{"query": "A"}])
+    monkeypatch.setattr("src.web.data_sources.request_source.available_filters", lambda catalog: {"pass_type": {"ikon": 1}})
+    monkeypatch.setattr("src.web.data_sources.request_source.default_applied_filters", lambda: {"search": ""})
+
+    payload = load_request_payload(mode="file", source="/tmp/payload.json")
+    assert payload["available_filters"] == {"pass_type": {"ikon": 1}}
+    assert payload["applied_filters"] == {"search": ""}
 
 
 def test_load_hourly_payload_local_mode(monkeypatch):

--- a/tests/integration/test_web_server.py
+++ b/tests/integration/test_web_server.py
@@ -402,24 +402,27 @@ def test_server_hourly_api_and_hourly_page_route(monkeypatch):
         },
     )
     monkeypatch.setattr(
-        "src.web.weather_page_server.build_hourly_payload_for_resort",
-        lambda **kwargs: {
-            "resort_id": kwargs["resort_id"],
-            "query": "Snowbird, UT",
-            "timezone": "America/Denver",
-            "nearby_airports": [{"airport_id": "slc-salt-lake-city", "iata_code": "SLC"}],
-            "hours": 2,
-            "hourly": {
-                "time": ["2026-03-04T00:00", "2026-03-04T01:00"],
-                "snowfall": [0.0, 0.1],
-                "rain": [0.0, 0.0],
-                "precipitation_probability": [20, 10],
-                "snow_depth": [100, 100],
-                "wind_speed_10m": [5.0, 6.0],
-                "wind_direction_10m": [120, 110],
-                "visibility": [9000, 8800],
+        "src.web.weather_page_server.load_hourly_payload",
+        lambda **kwargs: (
+            200,
+            {
+                "resort_id": kwargs["resort_id"],
+                "query": "Snowbird, UT",
+                "timezone": "America/Denver",
+                "nearby_airports": [{"airport_id": "slc-salt-lake-city", "iata_code": "SLC"}],
+                "hours": 2,
+                "hourly": {
+                    "time": ["2026-03-04T00:00", "2026-03-04T01:00"],
+                    "snowfall": [0.0, 0.1],
+                    "rain": [0.0, 0.0],
+                    "precipitation_probability": [20, 10],
+                    "snow_depth": [100, 100],
+                    "wind_speed_10m": [5.0, 6.0],
+                    "wind_direction_10m": [120, 110],
+                    "visibility": [9000, 8800],
+                },
             },
-        },
+        ),
     )
 
     handler = make_handler(

--- a/tests/integration/test_web_server.py
+++ b/tests/integration/test_web_server.py
@@ -33,7 +33,7 @@ def test_server_api_root_and_asset(monkeypatch):
         "failed": [],
         "reports": [{"query": "A", "daily": []}],
     }
-    monkeypatch.setattr("src.web.weather_page_server.load_payload", lambda **kwargs: sample_payload)
+    monkeypatch.setattr("src.web.weather_page_server.load_request_payload", lambda **kwargs: sample_payload)
     monkeypatch.setattr("src.web.weather_page_server.render_payload_html", lambda payload, **kwargs: "<html>ok</html>")
     monkeypatch.setattr("src.web.weather_page_server.read_asset_bytes", lambda name: b"body{}")
 
@@ -64,7 +64,7 @@ def test_server_api_root_and_asset(monkeypatch):
 
 
 def test_server_asset_not_found(monkeypatch):
-    monkeypatch.setattr("src.web.weather_page_server.load_payload", lambda **kwargs: {"reports": []})
+    monkeypatch.setattr("src.web.weather_page_server.load_request_payload", lambda **kwargs: {"reports": []})
     monkeypatch.setattr("src.web.weather_page_server.read_asset_bytes", lambda name: (_ for _ in ()).throw(OSError("x")))
 
     handler = make_handler(
@@ -87,7 +87,7 @@ def test_server_asset_not_found(monkeypatch):
 def test_server_query_resort_pass_through(monkeypatch):
     captured = {}
 
-    def fake_load_payload(**kwargs):  # noqa: ANN001
+    def fake_load_request_payload(**kwargs):  # noqa: ANN001
         captured.update(kwargs)
         return {
             "schema_version": "weather_payload_v1",
@@ -103,7 +103,7 @@ def test_server_query_resort_pass_through(monkeypatch):
             "reports": [],
         }
 
-    monkeypatch.setattr("src.web.weather_page_server.load_payload", fake_load_payload)
+    monkeypatch.setattr("src.web.weather_page_server.load_request_payload", fake_load_request_payload)
     monkeypatch.setattr("src.web.weather_page_server.render_payload_html", lambda payload, **kwargs: "<html>ok</html>")
 
     handler = make_handler(
@@ -116,7 +116,7 @@ def test_server_query_resort_pass_through(monkeypatch):
     try:
         urllib.request.urlopen(f"{base}/api/data?resort=A&resort=B", timeout=3).read()
         assert captured["mode"] == "local"
-        assert captured["resorts"] == ["A", "B"]
+        assert captured["query_params"]["resort"] == ["A", "B"]
         assert captured["source"] == ""
     finally:
         server.shutdown()
@@ -124,10 +124,10 @@ def test_server_query_resort_pass_through(monkeypatch):
         thread.join(timeout=3)
 
 
-def test_server_api_mode_loads_remote_payload(monkeypatch):
+def test_server_api_mode_passes_query_to_request_adapter(monkeypatch):
     calls = {}
 
-    def fake_load_payload(mode, source, timeout=20, **kwargs):  # noqa: ANN001
+    def fake_load_request_payload(mode, source, timeout=20, **kwargs):  # noqa: ANN001
         calls["mode"] = mode
         calls["source"] = source
         calls["timeout"] = timeout
@@ -146,7 +146,7 @@ def test_server_api_mode_loads_remote_payload(monkeypatch):
             "reports": [],
         }
 
-    monkeypatch.setattr("src.web.weather_page_server.load_payload", fake_load_payload)
+    monkeypatch.setattr("src.web.weather_page_server.load_request_payload", fake_load_request_payload)
     monkeypatch.setattr("src.web.weather_page_server.render_payload_html", lambda payload, **kwargs: "<html>ok</html>")
 
     handler = make_handler(
@@ -165,17 +165,17 @@ def test_server_api_mode_loads_remote_payload(monkeypatch):
             timeout=3,
         ).read()
         assert calls["mode"] == "api"
-        assert "resort=A" in calls["source"]
-        assert "resort=B" in calls["source"]
-        assert "pass_type=ikon" in calls["source"]
-        assert "region=west" in calls["source"]
-        assert "subregion=rockies" in calls["source"]
-        assert "country=US" in calls["source"]
-        assert "search=snow" in calls["source"]
-        assert "include_all=1" in calls["source"]
-        assert "search_all=0" in calls["source"]
+        assert calls["source"] == "http://127.0.0.1:8020/api/data"
+        assert calls["kwargs"]["query_params"]["resort"] == ["A", "B"]
+        assert calls["kwargs"]["query_params"]["pass_type"] == ["ikon"]
+        assert calls["kwargs"]["query_params"]["region"] == ["west"]
+        assert calls["kwargs"]["query_params"]["subregion"] == ["rockies"]
+        assert calls["kwargs"]["query_params"]["country"] == ["US"]
+        assert calls["kwargs"]["query_params"]["search"] == ["snow"]
+        assert calls["kwargs"]["query_params"]["include_all"] == ["1"]
+        assert calls["kwargs"]["query_params"]["search_all"] == ["0"]
+        assert calls["kwargs"]["apply_server_filters"] is True
         assert calls["timeout"] == 11
-        assert calls["kwargs"]["resorts"] == ["A", "B"]
     finally:
         server.shutdown()
         server.server_close()
@@ -185,7 +185,7 @@ def test_server_api_mode_loads_remote_payload(monkeypatch):
 def test_server_root_ignores_filter_query_in_local_mode(monkeypatch):
     captured = {}
 
-    def fake_load_payload(**kwargs):  # noqa: ANN001
+    def fake_load_request_payload(**kwargs):  # noqa: ANN001
         captured.update(kwargs)
         return {
             "schema_version": "weather_payload_v1",
@@ -201,11 +201,7 @@ def test_server_root_ignores_filter_query_in_local_mode(monkeypatch):
             "reports": [],
         }
 
-    monkeypatch.setattr("src.web.weather_page_server.load_payload", fake_load_payload)
-    monkeypatch.setattr(
-        "src.web.weather_page_server.select_resorts_from_query",
-        lambda qs: (_ for _ in ()).throw(AssertionError("select_resorts_from_query should not be used for HTML root")),
-    )
+    monkeypatch.setattr("src.web.weather_page_server.load_request_payload", fake_load_request_payload)
     monkeypatch.setattr("src.web.weather_page_server.render_payload_html", lambda payload, **kwargs: "<html>ok</html>")
 
     handler = make_handler(
@@ -223,7 +219,8 @@ def test_server_root_ignores_filter_query_in_local_mode(monkeypatch):
         assert body.decode("utf-8") == "<html>ok</html>"
         assert captured["mode"] == "local"
         assert captured["source"] == ""
-        assert captured["resorts"] == []
+        assert captured["query_params"] == {}
+        assert captured["apply_server_filters"] is False
     finally:
         server.shutdown()
         server.server_close()
@@ -233,7 +230,7 @@ def test_server_root_ignores_filter_query_in_local_mode(monkeypatch):
 def test_server_root_api_mode_does_not_forward_filter_query(monkeypatch):
     calls = {}
 
-    def fake_load_payload(mode, source, timeout=20, **kwargs):  # noqa: ANN001
+    def fake_load_request_payload(mode, source, timeout=20, **kwargs):  # noqa: ANN001
         calls["mode"] = mode
         calls["source"] = source
         calls["timeout"] = timeout
@@ -252,7 +249,7 @@ def test_server_root_api_mode_does_not_forward_filter_query(monkeypatch):
             "reports": [],
         }
 
-    monkeypatch.setattr("src.web.weather_page_server.load_payload", fake_load_payload)
+    monkeypatch.setattr("src.web.weather_page_server.load_request_payload", fake_load_request_payload)
     monkeypatch.setattr("src.web.weather_page_server.render_payload_html", lambda payload, **kwargs: "<html>ok</html>")
 
     handler = make_handler(
@@ -271,37 +268,20 @@ def test_server_root_api_mode_does_not_forward_filter_query(monkeypatch):
             timeout=3,
         ).read()
         assert calls["mode"] == "api"
-        assert "resort=A" in calls["source"]
-        assert "pass_type=ikon" not in calls["source"]
-        assert "region=west" not in calls["source"]
-        assert "subregion=rockies" not in calls["source"]
-        assert "country=US" not in calls["source"]
-        assert "search=snow" not in calls["source"]
-        assert "include_all=1" not in calls["source"]
-        assert "search_all=0" not in calls["source"]
+        assert calls["source"] == "http://127.0.0.1:8020/api/data"
+        assert calls["kwargs"]["query_params"] == {"resort": ["A"]}
+        assert calls["kwargs"]["apply_server_filters"] is False
         assert calls["timeout"] == 11
-        assert calls["kwargs"]["resorts"] == ["A"]
     finally:
         server.shutdown()
         server.server_close()
         thread.join(timeout=3)
 
 
-def test_server_local_mode_uses_backend_selection_for_filter_queries(monkeypatch):
+def test_server_local_mode_uses_request_adapter_for_filter_queries(monkeypatch):
     captured = {}
 
-    monkeypatch.setattr(
-        "src.web.weather_page_server.select_resorts_from_query",
-        lambda qs: (
-            ["Snowbird, UT"],
-            "",
-            {"pass_type": ["ikon"], "region": "west", "country": "US", "search": "snow", "include_all": False},
-            {"pass_type": {"ikon": 1}, "region": {"west": 1}, "country": {"US": 1}},
-            False,
-        ),
-    )
-
-    def fake_run_live_payload(**kwargs):  # noqa: ANN001
+    def fake_load_request_payload(**kwargs):  # noqa: ANN001
         captured.update(kwargs)
         return {
             "schema_version": "weather_payload_v1",
@@ -315,9 +295,20 @@ def test_server_local_mode_uses_backend_selection_for_filter_queries(monkeypatch
             "failed_count": 0,
             "failed": [],
             "reports": [{"query": "Snowbird, UT", "daily": []}],
+            "available_filters": {"pass_type": {"ikon": 1}, "region": {"west": 1}, "country": {"US": 1}},
+            "applied_filters": {
+                "pass_type": ["ikon"],
+                "region": "west",
+                "country": ["US"],
+                "search": "snow",
+                "subregion": [],
+                "include_all": False,
+                "include_default": False,
+                "search_all": False,
+            },
         }
 
-    monkeypatch.setattr("src.web.weather_page_server.run_live_payload", fake_run_live_payload)
+    monkeypatch.setattr("src.web.weather_page_server.load_request_payload", fake_load_request_payload)
     monkeypatch.setattr("src.web.weather_page_server.render_payload_html", lambda payload, **kwargs: "<html>ok</html>")
 
     handler = make_handler(
@@ -330,7 +321,8 @@ def test_server_local_mode_uses_backend_selection_for_filter_queries(monkeypatch
     try:
         body = urllib.request.urlopen(f"{base}/api/data?pass_type=ikon&region=west&country=US&search=snow", timeout=3)
         payload = json.loads(body.read().decode("utf-8"))
-        assert captured["resorts"] == ["Snowbird, UT"]
+        assert captured["apply_server_filters"] is True
+        assert captured["query_params"]["pass_type"] == ["ikon"]
         assert payload["available_filters"]["pass_type"]["ikon"] == 1
         assert payload["applied_filters"]["pass_type"] == ["ikon"]
         assert payload["applied_filters"]["search"] == "snow"
@@ -341,7 +333,7 @@ def test_server_local_mode_uses_backend_selection_for_filter_queries(monkeypatch
 
 
 def test_server_health_endpoint(monkeypatch):
-    monkeypatch.setattr("src.web.weather_page_server.load_payload", lambda **kwargs: {"reports": []})
+    monkeypatch.setattr("src.web.weather_page_server.load_request_payload", lambda **kwargs: {"reports": []})
     handler = make_handler(
         cache_file=".cache/x.json",
         geocode_cache_hours=720,
@@ -373,7 +365,7 @@ def test_server_requires_data_source_for_api_mode():
 
 def test_server_hourly_api_and_hourly_page_route(monkeypatch):
     monkeypatch.setattr(
-        "src.web.weather_page_server.load_payload",
+        "src.web.weather_page_server.load_request_payload",
         lambda **kwargs: {
             "reports": [
                 {

--- a/tests/integration/test_web_server.py
+++ b/tests/integration/test_web_server.py
@@ -402,7 +402,7 @@ def test_server_hourly_api_and_hourly_page_route(monkeypatch):
         },
     )
     monkeypatch.setattr(
-        "src.web.weather_page_server._hourly_payload_for_resort",
+        "src.web.weather_page_server.build_hourly_payload_for_resort",
         lambda **kwargs: {
             "resort_id": kwargs["resort_id"],
             "query": "Snowbird, UT",

--- a/tests/smoke/test_dynamic_server_smoke.py
+++ b/tests/smoke/test_dynamic_server_smoke.py
@@ -20,7 +20,7 @@ def _start_server(handler_cls):
 
 @pytest.mark.smoke
 def test_dynamic_server_smoke(monkeypatch, valid_payload):
-    monkeypatch.setattr("src.web.weather_page_server.load_payload", lambda **kwargs: valid_payload)
+    monkeypatch.setattr("src.web.weather_page_server.load_request_payload", lambda **kwargs: valid_payload)
 
     handler = make_handler(
         cache_file=".cache/open_meteo_cache.json",


### PR DESCRIPTION
## Summary
- move web request payload handling behind request adapters and backend services
- move hourly payload loading behind adapter/service seams for dynamic and static flows
- remove direct backend server imports from web handlers and validate static/dynamic behavior

## Validation
- python3 -m pytest tests/integration/test_data_sources.py tests/integration/test_web_server.py tests/integration/test_cli.py tests/integration/test_entrypoints.py tests/smoke/test_dynamic_server_smoke.py -q
- python3 -m pytest tests/smoke/test_static_pipeline_smoke.py tests/smoke/test_dynamic_server_smoke.py -q
- python3 -m src.cli static --output-dir <tmp> --max-workers 8 --resort "Snowbird, UT"
- python3 -m src.cli serve --host 127.0.0.1 --port 8047 --max-workers 8 with GET /api/health, /api/data?resort=Snowbird,%20UT, /api/resort-hourly?resort_id=snowbird-ut&hours=2, /, and /resort/snowbird-ut
- rg -n "from src\.backend\.pipelines\.live_pipeline|from src\.backend\.weather_data_server" src/web -S