### PR TITLE
Strengthen payload contract types

### DIFF
--- a/agent_docs/graphs/refactor-stabilization-2026-06.md
+++ b/agent_docs/graphs/refactor-stabilization-2026-06.md
@@ -57,9 +57,9 @@
 - Goal: replace the broad `reports: List[Dict[str, Any]]` contract surface with explicit typed dicts for daily rows, reports, and hourly payloads without changing JSON output.
 - Primary files: `src/contract/weather_payload_v1.py`, `src/contract/validators.py`, builder/service annotations.
 - Validation: contract validator tests and pipeline/report builder tests.
-- Commit: `Strengthen payload contract types`
-- Push: branch pending
-- PR/Merge: pending
+- Commit: `6bfcfb4` (`Strengthen payload contract types`)
+- Push: done (`origin/ljcc/refactor-contract-types`)
+- PR/Merge: [#68](https://github.com/ljcc0930/CloseSnow/pull/68); merge must be verified before slice 6 starts.
 
 ### 6. Deduplicate CLI And Server Option Wiring
 - Status: pending
@@ -84,4 +84,4 @@
 - Slice 2 completed and pushed: `4619789`; `python3 -m pytest tests/backend/test_open_meteo.py tests/integration/test_data_sources.py -q` passed; web-side boundary grep for direct `src.backend.open_meteo`, `src.backend.pipeline`, and `src.backend.cache` imports returned no matches; targeted ruff check passed.
 - Slice 3 completed and pushed: `f4403ad`; extracted homepage formatter helpers to `assets/js/weather_page_formatters.js`; `python3 -m pytest tests/frontend/test_renderers.py tests/integration/test_web_server.py -q`, `python3 -m pytest tests/integration/test_cli.py::test_copy_static_assets_copies_css_and_js -q`, `python3 scripts/lint_assets.py --html`, and targeted ruff passed; `python3 scripts/lint_assets.py --js` is blocked locally by missing Node; browser preview loaded formatter and main scripts with no console errors.
 - Slice 4 completed and pushed: `bae0547`; centralized Python hourly metric keys and trimming in `src/contract/hourly_payload.py`; extracted browser hourly metric defs and static trim to `assets/js/resort_hourly_metrics.js`; `python3 -m pytest tests/integration/test_hourly_payload_contract.py tests/backend/test_weather_data_server_hourly.py tests/integration/test_data_sources.py tests/integration/test_web_server.py tests/frontend/test_static_site_pipeline.py tests/backend/test_open_meteo.py -q`, `python3 scripts/lint_assets.py --html`, and targeted ruff passed; `python3 scripts/lint_assets.py --js` is blocked locally by missing Node; browser preview loaded static resort hourly page with 72 rows, 7 charts, and no console errors.
-- Slice 5 completed: replaced broad report and hourly payload contract annotations with explicit typed dicts; updated builder, pipeline, data source, render, and cache annotations; validators now share field lists from contract definitions; `python3 -m pytest -q`, `python3 scripts/lint_assets.py --html`, and targeted ruff passed.
+- Slice 5 completed on branch `ljcc/refactor-contract-types` and PR [#68](https://github.com/ljcc0930/CloseSnow/pull/68): `6bfcfb4`; replaced broad report and hourly payload contract annotations with explicit typed dicts; updated builder, pipeline, data source, render, and cache annotations; validators now share field lists from contract definitions; `python3 -m pytest -q`, `python3 scripts/lint_assets.py --html`, and targeted ruff passed.

--- a/agent_docs/graphs/refactor-stabilization-2026-06.md
+++ b/agent_docs/graphs/refactor-stabilization-2026-06.md
@@ -14,7 +14,8 @@
 - Keep each slice behavior-preserving unless the slice explicitly removes dead compatibility surface.
 - Run the smallest useful validation first; run broader validation when shared boundaries are touched.
 - Do not commit directly to `main`.
-- For each remaining slice, fetch latest `origin/main`, create a fresh `ljcc/*` branch, commit there, push the branch, open a PR into `main`, enable auto-merge, and wait until the PR is successfully merged before starting the next slice.
+- For each remaining slice, fetch latest `origin/main`, create a fresh `ljcc/*` branch, commit there, push the branch, open a PR into `main`, enable auto-merge when GitHub allows it, and wait until the PR is successfully merged before starting the next slice.
+- Current GitHub rules reject `gh pr merge --auto` because auto-merge requires branch rules that this repository does not expose; if that remains true, wait for required checks to pass and merge the PR with admin privileges rather than pushing directly to `main`.
 - Slices 1-4 were completed with direct `main` pushes before this workflow change; slices 5-7 must use the branch and PR workflow.
 
 ## Refactor Slices
@@ -52,12 +53,12 @@
 - Push: done (`origin/main`)
 
 ### 5. Strengthen Payload And Report Contract Types
-- Status: pending
+- Status: done
 - Goal: replace the broad `reports: List[Dict[str, Any]]` contract surface with explicit typed dicts for daily rows, reports, and hourly payloads without changing JSON output.
 - Primary files: `src/contract/weather_payload_v1.py`, `src/contract/validators.py`, builder/service annotations.
 - Validation: contract validator tests and pipeline/report builder tests.
-- Commit: pending
-- Push: pending
+- Commit: `Strengthen payload contract types`
+- Push: branch pending
 - PR/Merge: pending
 
 ### 6. Deduplicate CLI And Server Option Wiring
@@ -83,3 +84,4 @@
 - Slice 2 completed and pushed: `4619789`; `python3 -m pytest tests/backend/test_open_meteo.py tests/integration/test_data_sources.py -q` passed; web-side boundary grep for direct `src.backend.open_meteo`, `src.backend.pipeline`, and `src.backend.cache` imports returned no matches; targeted ruff check passed.
 - Slice 3 completed and pushed: `f4403ad`; extracted homepage formatter helpers to `assets/js/weather_page_formatters.js`; `python3 -m pytest tests/frontend/test_renderers.py tests/integration/test_web_server.py -q`, `python3 -m pytest tests/integration/test_cli.py::test_copy_static_assets_copies_css_and_js -q`, `python3 scripts/lint_assets.py --html`, and targeted ruff passed; `python3 scripts/lint_assets.py --js` is blocked locally by missing Node; browser preview loaded formatter and main scripts with no console errors.
 - Slice 4 completed and pushed: `bae0547`; centralized Python hourly metric keys and trimming in `src/contract/hourly_payload.py`; extracted browser hourly metric defs and static trim to `assets/js/resort_hourly_metrics.js`; `python3 -m pytest tests/integration/test_hourly_payload_contract.py tests/backend/test_weather_data_server_hourly.py tests/integration/test_data_sources.py tests/integration/test_web_server.py tests/frontend/test_static_site_pipeline.py tests/backend/test_open_meteo.py -q`, `python3 scripts/lint_assets.py --html`, and targeted ruff passed; `python3 scripts/lint_assets.py --js` is blocked locally by missing Node; browser preview loaded static resort hourly page with 72 rows, 7 charts, and no console errors.
+- Slice 5 completed: replaced broad report and hourly payload contract annotations with explicit typed dicts; updated builder, pipeline, data source, render, and cache annotations; validators now share field lists from contract definitions; `python3 -m pytest -q`, `python3 scripts/lint_assets.py --html`, and targeted ruff passed.

--- a/src/backend/compute/coordinator.py
+++ b/src/backend/compute/coordinator.py
@@ -2,14 +2,26 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, TypedDict
 
 from src.backend.cache import JsonCache, ResortCoordinateCache
 from src.backend.constants import API_RETRY_TIMES
 from src.backend.open_meteo import fetch_forecast_async, fetch_history_async, geocode_async
 from src.backend.report_builder import build_report
+from src.contract import FailedItem, WeatherReport
 
 logger = logging.getLogger(__name__)
+
+
+class ResortReportResult(TypedDict):
+    index: int
+    report: Optional[WeatherReport]
+    failed: Optional[FailedItem]
+
+
+class PipelineResult(TypedDict):
+    reports: List[WeatherReport]
+    failed: List[FailedItem]
 
 
 async def build_resort_report(
@@ -22,7 +34,7 @@ async def build_resort_report(
     forecast_ttl: int,
     api_retries: int,
     semaphore: asyncio.Semaphore,
-) -> Dict[str, Any]:
+) -> ResortReportResult:
     async with semaphore:
         logger.info("Resort %d/%d: start %s", idx, total, resort)
         try:
@@ -81,7 +93,7 @@ async def run_pipeline_async(
     forecast_ttl: int,
     max_workers: int,
     api_retries: int = API_RETRY_TIMES,
-) -> Dict[str, Any]:
+) -> PipelineResult:
     semaphore = asyncio.Semaphore(max(1, max_workers))
     tasks = [
         asyncio.create_task(
@@ -101,8 +113,8 @@ async def run_pipeline_async(
     ]
     results = await asyncio.gather(*tasks)
 
-    reports_ordered: List[Optional[Dict[str, Any]]] = [None] * len(selected)
-    failed: List[Dict[str, str]] = []
+    reports_ordered: List[Optional[WeatherReport]] = [None] * len(selected)
+    failed: List[FailedItem] = []
     for result in results:
         reports_ordered[result["index"]] = result["report"]
         if result["failed"] is not None:

--- a/src/backend/compute/payload_metadata.py
+++ b/src/backend/compute/payload_metadata.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Any, Dict, List
+from typing import List
 
 from src.backend.constants import ECMWF_MODEL, FORECAST_DAYS
-from src.contract import SCHEMA_VERSION
+from src.contract import SCHEMA_VERSION, FailedItem, WeatherPayloadV1, WeatherReport
 
 
 def build_payload_metadata(
@@ -14,9 +14,9 @@ def build_payload_metadata(
     geocode_cache_hours: int,
     forecast_cache_hours: int,
     api_retries: int,
-    reports: List[Dict[str, Any]],
-    failed: List[Dict[str, str]],
-) -> Dict[str, Any]:
+    reports: List[WeatherReport],
+    failed: List[FailedItem],
+) -> WeatherPayloadV1:
     return {
         "schema_version": SCHEMA_VERSION,
         "generated_at_utc": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),

--- a/src/backend/pipeline.py
+++ b/src/backend/pipeline.py
@@ -28,7 +28,7 @@ from src.backend.io import (
     seed_coordinate_cache_from_unified,
 )
 from src.backend.resort_catalog import load_resort_catalog, read_resort_queries
-from src.contract import SCHEMA_VERSION, validate_weather_payload_v1
+from src.contract import SCHEMA_VERSION, FailedItem, WeatherPayloadV1, WeatherReport, validate_weather_payload_v1
 from src.shared.config import DEFAULT_RESORTS_FILE
 
 logger = logging.getLogger(__name__)
@@ -62,7 +62,7 @@ def _catalog_metadata_by_query(paths: List[str]) -> Dict[str, Dict[str, Any]]:
 
 
 def _enrich_reports_with_catalog_metadata(
-    reports: List[Dict[str, Any]], metadata_by_query: Dict[str, Dict[str, Any]]
+    reports: List[WeatherReport], metadata_by_query: Dict[str, Dict[str, Any]]
 ) -> None:
     for report in reports:
         query = str(report.get("query", "")).strip()
@@ -100,7 +100,7 @@ def _to_float(value: Any) -> float | None:
         return None
 
 
-def _enrich_reports_with_nearby_airports(reports: List[Dict[str, Any]], airports: List[Dict[str, Any]]) -> None:
+def _enrich_reports_with_nearby_airports(reports: List[WeatherReport], airports: List[Dict[str, Any]]) -> None:
     for report in reports:
         lat = _to_float(report.get("input_latitude"))
         lon = _to_float(report.get("input_longitude"))
@@ -126,7 +126,7 @@ def compute_pipeline_payload(
     forecast_cache_hours: int = DEFAULT_FORECAST_CACHE_HOURS,
     max_workers: int = DEFAULT_MAX_WORKERS,
     api_retries: int = API_RETRY_TIMES,
-) -> Dict[str, Any]:
+) -> WeatherPayloadV1:
     selected = select_resorts(
         resorts=list(resorts or []),
         resorts_file=resorts_file,
@@ -160,8 +160,8 @@ def compute_pipeline_payload(
             api_retries=api_retries,
         )
     )
-    reports: List[Dict[str, Any]] = async_result["reports"]
-    failed: List[Dict[str, str]] = async_result["failed"]
+    reports: List[WeatherReport] = async_result["reports"]
+    failed: List[FailedItem] = async_result["failed"]
     catalog_index = _catalog_metadata_by_query([resorts_file, DEFAULT_RESORTS_FILE])
     _enrich_reports_with_catalog_metadata(reports, catalog_index)
     try:
@@ -210,7 +210,7 @@ def run_pipeline(
     write_outputs: bool = True,
     max_workers: int = DEFAULT_MAX_WORKERS,
     api_retries: int = API_RETRY_TIMES,
-) -> Dict[str, Any]:
+) -> WeatherPayloadV1:
     payload = compute_pipeline_payload(
         resorts=resorts,
         resorts_file=resorts_file,

--- a/src/backend/pipelines/live_pipeline.py
+++ b/src/backend/pipelines/live_pipeline.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from typing import List, Optional
 
 from src.backend.constants import (
     API_RETRY_TIMES,
@@ -10,6 +10,7 @@ from src.backend.constants import (
     DEFAULT_OPEN_METEO_CACHE_FILE,
 )
 from src.backend.services.weather_service import build_weather_payload
+from src.contract import WeatherPayloadV1
 
 
 def run_live_payload(
@@ -21,7 +22,7 @@ def run_live_payload(
     forecast_cache_hours: int = DEFAULT_FORECAST_CACHE_HOURS,
     max_workers: int = DEFAULT_MAX_WORKERS,
     api_retries: int = API_RETRY_TIMES,
-) -> Dict[str, Any]:
+) -> WeatherPayloadV1:
     return build_weather_payload(
         resorts=resorts,
         resorts_file=resorts_file,

--- a/src/backend/report_builder.py
+++ b/src/backend/report_builder.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional
 
 from src.backend.constants import DAYS_PER_WEEK, ECMWF_MODEL, FORECAST_DAYS, HISTORY_DAYS
 from src.backend.models import ResortLocation
+from src.contract.weather_payload_v1 import DailyForecastRow, WeatherReport
 
 
 def as_float_list(values: List[Any]) -> List[Optional[float]]:
@@ -43,7 +44,7 @@ def safe_sum(values: List[Optional[float]]) -> float:
     return float(sum(value for value in values if value is not None))
 
 
-def build_daily_rows(daily: Dict[str, Any]) -> List[Dict[str, Any]]:
+def build_daily_rows(daily: Dict[str, Any]) -> List[DailyForecastRow]:
     dates = daily.get("time", [])
     snowfall = as_float_list(daily.get("snowfall_sum", []))
     rain = as_float_list(daily.get("rain_sum", []))
@@ -54,7 +55,7 @@ def build_daily_rows(daily: Dict[str, Any]) -> List[Dict[str, Any]]:
     sunrise = daily.get("sunrise", [])
     sunset = daily.get("sunset", [])
 
-    rows: List[Dict[str, Any]] = []
+    rows: List[DailyForecastRow] = []
     n = max(
         len(dates),
         len(snowfall),
@@ -91,7 +92,7 @@ def build_daily_rows(daily: Dict[str, Any]) -> List[Dict[str, Any]]:
 
 def build_report(
     location: ResortLocation, forecast: Dict[str, Any], history: Optional[Dict[str, Any]] = None
-) -> Dict[str, Any]:
+) -> WeatherReport:
     daily = forecast.get("daily", {})
     rows = build_daily_rows(daily)
 

--- a/src/backend/services/hourly_payload_service.py
+++ b/src/backend/services/hourly_payload_service.py
@@ -17,7 +17,7 @@ from src.backend.io import seed_coordinate_cache_from_coordinate_cache_file, see
 from src.backend.models import ResortLocation
 from src.backend.open_meteo import fetch_hourly_forecast, fetch_hourly_forecast_async, geocode, geocode_async
 from src.backend.services.resort_selection_service import load_supported_resort_catalog
-from src.contract.hourly_payload import trim_hourly_payload
+from src.contract.hourly_payload import HourlyPayload, trim_hourly_payload
 
 
 def _catalog_by_resort_id(catalog: Iterable[Dict[str, object]]) -> Dict[str, Dict[str, object]]:
@@ -43,7 +43,7 @@ def _build_hourly_payload_from_forecast(
     forecast: Mapping[str, Any],
     airports: List[Dict[str, Any]],
     hours: int,
-) -> Dict[str, object]:
+) -> HourlyPayload:
     query = str(item.get("query", "")).strip()
     nearby_airports = find_nearby_airports(
         resort_latitude=location.latitude,
@@ -84,7 +84,7 @@ def _build_hourly_payload_for_item(
     geocode_cache_hours: int,
     forecast_cache_hours: int,
     api_retries: int,
-) -> Dict[str, object]:
+) -> HourlyPayload:
     query = str(item.get("query", "")).strip()
     location = geocode(
         query,
@@ -126,7 +126,7 @@ async def _build_hourly_payload_for_item_async(
     geocode_cache_hours: int,
     forecast_cache_hours: int,
     api_retries: int,
-) -> Dict[str, object]:
+) -> HourlyPayload:
     query = str(item.get("query", "")).strip()
     location = await geocode_async(
         query,
@@ -167,13 +167,13 @@ async def build_hourly_payloads_for_resorts_async(
     forecast_cache_hours: int,
     max_workers: int = DEFAULT_MAX_WORKERS,
     api_retries: int = API_RETRY_TIMES,
-) -> Dict[str, Dict[str, object] | None]:
+) -> Dict[str, HourlyPayload | None]:
     normalized_ids = [resort_id.strip() for resort_id in resort_ids if resort_id and resort_id.strip()]
     if not normalized_ids:
         return {}
     catalog_by_id = _catalog_by_resort_id(load_supported_resort_catalog())
     items = [catalog_by_id[resort_id] for resort_id in normalized_ids if resort_id in catalog_by_id]
-    out: Dict[str, Dict[str, object] | None] = {resort_id: None for resort_id in normalized_ids}
+    out: Dict[str, HourlyPayload | None] = {resort_id: None for resort_id in normalized_ids}
     if not items:
         return out
 
@@ -188,7 +188,7 @@ async def build_hourly_payloads_for_resorts_async(
         worker_count = min(max(1, int(max_workers)), len(items))
         semaphore = asyncio.Semaphore(worker_count)
 
-        async def run_one(resort_id: str, item: Dict[str, object]) -> tuple[str, Dict[str, object]]:
+        async def run_one(resort_id: str, item: Dict[str, object]) -> tuple[str, HourlyPayload]:
             async with semaphore:
                 try:
                     payload = await _build_hourly_payload_for_item_async(
@@ -232,7 +232,7 @@ def build_hourly_payloads_for_resorts(
     forecast_cache_hours: int,
     max_workers: int = DEFAULT_MAX_WORKERS,
     api_retries: int = API_RETRY_TIMES,
-) -> Dict[str, Dict[str, object] | None]:
+) -> Dict[str, HourlyPayload | None]:
     try:
         asyncio.get_running_loop()
     except RuntimeError:
@@ -258,7 +258,7 @@ def build_hourly_payload_for_resort(
     geocode_cache_hours: int,
     forecast_cache_hours: int,
     api_retries: int = API_RETRY_TIMES,
-) -> Dict[str, object] | None:
+) -> HourlyPayload | None:
     catalog = load_supported_resort_catalog()
     item = next((r for r in catalog if str(r.get("resort_id", "")) == resort_id), None)
     if item is None:

--- a/src/backend/services/payload_memory_cache.py
+++ b/src/backend/services/payload_memory_cache.py
@@ -4,13 +4,15 @@ import copy
 import threading
 import time
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, Hashable, List, Tuple
+from typing import Callable, Dict, Hashable, List, Tuple
+
+from src.contract import WeatherPayloadV1
 
 
 @dataclass
 class _PayloadCacheEntry:
     expires_at: float
-    payload: Dict[str, Any]
+    payload: WeatherPayloadV1
 
 
 class PayloadMemoryCache:
@@ -19,7 +21,7 @@ class PayloadMemoryCache:
         self._entries: Dict[Hashable, _PayloadCacheEntry] = {}
         self._lock = threading.RLock()
 
-    def get_or_load(self, key: Hashable, loader: Callable[[], Dict[str, Any]]) -> Dict[str, Any]:
+    def get_or_load(self, key: Hashable, loader: Callable[[], WeatherPayloadV1]) -> WeatherPayloadV1:
         if self.ttl_seconds <= 0:
             return copy.deepcopy(loader())
 

--- a/src/backend/services/weather_service.py
+++ b/src/backend/services/weather_service.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from typing import List, Optional
 
 from src.backend.constants import (
     API_RETRY_TIMES,
@@ -10,6 +10,7 @@ from src.backend.constants import (
     DEFAULT_OPEN_METEO_CACHE_FILE,
 )
 from src.backend.pipeline import compute_pipeline_payload
+from src.contract import WeatherPayloadV1
 
 
 def _normalize_resorts(resorts: Optional[List[str]]) -> List[str]:
@@ -25,7 +26,7 @@ def build_weather_payload(
     forecast_cache_hours: int = DEFAULT_FORECAST_CACHE_HOURS,
     max_workers: int = DEFAULT_MAX_WORKERS,
     api_retries: int = API_RETRY_TIMES,
-) -> Dict[str, Any]:
+) -> WeatherPayloadV1:
     return compute_pipeline_payload(
         resorts=_normalize_resorts(resorts),
         resorts_file=resorts_file,

--- a/src/contract/__init__.py
+++ b/src/contract/__init__.py
@@ -1,11 +1,24 @@
-from src.contract.hourly_payload import HOURLY_METRIC_KEYS, trim_hourly_payload
+from src.contract.hourly_payload import HOURLY_METRIC_KEYS, HourlyPayload, HourlySeries, trim_hourly_payload
 from src.contract.validators import validate_weather_payload_v1
-from src.contract.weather_payload_v1 import SCHEMA_VERSION, WeatherPayloadV1
+from src.contract.weather_payload_v1 import (
+    SCHEMA_VERSION,
+    DailyForecastRow,
+    FailedItem,
+    NearbyAirport,
+    WeatherPayloadV1,
+    WeatherReport,
+)
 
 __all__ = [
+    "DailyForecastRow",
+    "FailedItem",
     "HOURLY_METRIC_KEYS",
+    "HourlyPayload",
+    "HourlySeries",
+    "NearbyAirport",
     "SCHEMA_VERSION",
     "WeatherPayloadV1",
+    "WeatherReport",
     "trim_hourly_payload",
     "validate_weather_payload_v1",
 ]

--- a/src/contract/hourly_payload.py
+++ b/src/contract/hourly_payload.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Mapping, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Tuple, TypedDict
+
+from src.contract.weather_payload_v1 import JsonNumber, NearbyAirport
 
 HOURLY_METRIC_KEYS: tuple[str, ...] = (
     "snowfall",
@@ -11,6 +13,39 @@ HOURLY_METRIC_KEYS: tuple[str, ...] = (
     "wind_direction_10m",
     "visibility",
 )
+
+
+class HourlySeries(TypedDict, total=False):
+    time: List[str]
+    snowfall: List[Optional[JsonNumber]]
+    rain: List[Optional[JsonNumber]]
+    precipitation_probability: List[Optional[JsonNumber]]
+    snow_depth: List[Optional[JsonNumber]]
+    wind_speed_10m: List[Optional[JsonNumber]]
+    wind_direction_10m: List[Optional[JsonNumber]]
+    visibility: List[Optional[JsonNumber]]
+
+
+class HourlyPayload(TypedDict, total=False):
+    error: str
+    resort_id: str
+    query: str
+    display_name: str
+    website: str
+    matched_name: str
+    country: object
+    region: object
+    subregion: object
+    pass_types: object
+    timezone: object
+    model: str
+    input_latitude: JsonNumber
+    input_longitude: JsonNumber
+    resolved_latitude: object
+    resolved_longitude: object
+    nearby_airports: List[NearbyAirport]
+    hours: int
+    hourly: HourlySeries
 
 
 def trim_hourly_payload(payload: Mapping[str, Any], hours: int) -> Tuple[int, Dict[str, object]]:

--- a/src/contract/validators.py
+++ b/src/contract/validators.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 from typing import Any, Mapping
 
-from src.contract.weather_payload_v1 import SCHEMA_VERSION
+from src.contract.weather_payload_v1 import (
+    DAILY_NUMBER_FIELDS,
+    DAILY_TIME_FIELDS,
+    REPORT_NUMBER_FIELDS,
+    REPORT_STRING_FIELDS,
+    SCHEMA_VERSION,
+)
 
 
 class ContractValidationError(ValueError):
@@ -31,16 +37,10 @@ def _validate_daily_row(row: Any, path: str) -> None:
     if not isinstance(row, Mapping):
         raise ContractValidationError(f"Invalid {path}: expected object")
     _require_optional_type(row, "date", (str,), path)
-    for key in (
-        "snowfall_cm",
-        "rain_mm",
-        "precipitation_mm",
-        "temperature_max_c",
-        "temperature_min_c",
-    ):
+    for key in DAILY_NUMBER_FIELDS:
         _require_optional_number(row, key, path)
     _require_optional_type(row, "weather_code", (int,), path)
-    for key in ("sunrise_iso", "sunset_iso", "sunrise_local_hhmm", "sunset_local_hhmm"):
+    for key in DAILY_TIME_FIELDS:
         _require_optional_type(row, key, (str,), path)
     _require_optional_type(row, "above_0", (int,), path)
 
@@ -90,18 +90,9 @@ def validate_weather_payload_v1(payload: Mapping[str, Any]) -> None:
         if not isinstance(report.get("daily"), list):
             raise ContractValidationError(f"Invalid reports[{idx}].daily: expected list")
         path = f"reports[{idx}]"
-        for key in ("resort_id", "display_name", "matched_name", "country", "admin1", "model", "forecast_timezone"):
+        for key in REPORT_STRING_FIELDS:
             _require_optional_type(report, key, (str,), path)
-        for key in (
-            "input_latitude",
-            "input_longitude",
-            "resolved_latitude",
-            "resolved_longitude",
-            "week1_total_snowfall_cm",
-            "week2_total_snowfall_cm",
-            "week1_total_rain_mm",
-            "week2_total_rain_mm",
-        ):
+        for key in REPORT_NUMBER_FIELDS:
             _require_optional_number(report, key, path)
         if "pass_types" in report and not isinstance(report.get("pass_types"), list):
             raise ContractValidationError(f"Invalid {path}.pass_types: expected list")

--- a/src/contract/weather_payload_v1.py
+++ b/src/contract/weather_payload_v1.py
@@ -1,8 +1,45 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Literal, TypedDict
+from typing import List, Literal, Optional, Tuple, TypedDict, Union
 
 SCHEMA_VERSION = "weather_payload_v1"
+JsonNumber = Union[int, float]
+
+DAILY_NUMBER_FIELDS: Tuple[str, ...] = (
+    "snowfall_cm",
+    "rain_mm",
+    "precipitation_mm",
+    "temperature_max_c",
+    "temperature_min_c",
+)
+DAILY_TIME_FIELDS: Tuple[str, ...] = ("sunrise_iso", "sunset_iso", "sunrise_local_hhmm", "sunset_local_hhmm")
+REPORT_STRING_FIELDS: Tuple[str, ...] = (
+    "resort_id",
+    "display_name",
+    "matched_name",
+    "country",
+    "country_code",
+    "admin1",
+    "region",
+    "subregion",
+    "model",
+    "forecast_timezone",
+    "website",
+    "state_name",
+    "country_name",
+    "city",
+    "address",
+)
+REPORT_NUMBER_FIELDS: Tuple[str, ...] = (
+    "input_latitude",
+    "input_longitude",
+    "resolved_latitude",
+    "resolved_longitude",
+    "week1_total_snowfall_cm",
+    "week2_total_snowfall_cm",
+    "week1_total_rain_mm",
+    "week2_total_rain_mm",
+)
 
 
 class CacheInfo(TypedDict):
@@ -27,6 +64,68 @@ class FailedItem(TypedDict):
     reason: str
 
 
+class DailyForecastRow(TypedDict, total=False):
+    date: Optional[str]
+    snowfall_cm: Optional[JsonNumber]
+    rain_mm: Optional[JsonNumber]
+    precipitation_mm: Optional[JsonNumber]
+    temperature_max_c: Optional[JsonNumber]
+    temperature_min_c: Optional[JsonNumber]
+    weather_code: Optional[int]
+    sunrise_iso: Optional[str]
+    sunset_iso: Optional[str]
+    sunrise_local_hhmm: Optional[str]
+    sunset_local_hhmm: Optional[str]
+    above_0: Optional[int]
+
+
+class NearbyAirport(TypedDict, total=False):
+    airport_id: str
+    iata_code: str
+    display_name: str
+    location_label: str
+    latitude: JsonNumber
+    longitude: JsonNumber
+    distance_miles: JsonNumber
+
+
+class WeatherReportRequired(TypedDict):
+    query: str
+    daily: List[DailyForecastRow]
+
+
+class WeatherReport(WeatherReportRequired, total=False):
+    resort_id: str
+    display_name: str
+    matched_name: str
+    country: str
+    country_code: str
+    admin1: str
+    region: str
+    subregion: str
+    pass_types: List[str]
+    model: str
+    forecast_timezone: str
+    input_latitude: JsonNumber
+    input_longitude: JsonNumber
+    resolved_latitude: JsonNumber
+    resolved_longitude: JsonNumber
+    week1_total_snowfall_cm: JsonNumber
+    week2_total_snowfall_cm: JsonNumber
+    week1_total_rain_mm: JsonNumber
+    week2_total_rain_mm: JsonNumber
+    past_14d_daily: List[DailyForecastRow]
+    default_resort: bool
+    ljcc_favorite: bool
+    website: str
+    state_name: str
+    country_name: str
+    city: str
+    address: str
+    search_terms: List[str]
+    nearby_airports: List[NearbyAirport]
+
+
 class WeatherPayloadV1(TypedDict):
     schema_version: Literal["weather_payload_v1"]
     generated_at_utc: str
@@ -38,4 +137,4 @@ class WeatherPayloadV1(TypedDict):
     resorts_count: int
     failed_count: int
     failed: List[FailedItem]
-    reports: List[Dict[str, Any]]
+    reports: List[WeatherReport]

--- a/src/web/data_sources/api_source.py
+++ b/src/web/data_sources/api_source.py
@@ -2,14 +2,13 @@ from __future__ import annotations
 
 import json
 import urllib.request
-from typing import Any, Dict
 
 from src.backend.constants import API_RETRY_TIMES
-from src.contract import validate_weather_payload_v1
+from src.contract import WeatherPayloadV1, validate_weather_payload_v1
 from src.shared.retry import with_retry
 
 
-def load_api_payload(url: str, timeout: int = 20, api_retries: int = API_RETRY_TIMES) -> Dict[str, Any]:
+def load_api_payload(url: str, timeout: int = 20, api_retries: int = API_RETRY_TIMES) -> WeatherPayloadV1:
     req = urllib.request.Request(
         url,
         headers={
@@ -18,7 +17,7 @@ def load_api_payload(url: str, timeout: int = 20, api_retries: int = API_RETRY_T
         },
     )
 
-    def do_request() -> Dict[str, Any]:
+    def do_request() -> WeatherPayloadV1:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             return json.loads(resp.read().decode("utf-8"))
 

--- a/src/web/data_sources/clients.py
+++ b/src/web/data_sources/clients.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, Protocol
+from typing import Protocol
 
 from src.backend.constants import (
     API_RETRY_TIMES,
@@ -10,20 +10,21 @@ from src.backend.constants import (
     DEFAULT_MAX_WORKERS,
     DEFAULT_OPEN_METEO_CACHE_FILE,
 )
+from src.contract import WeatherPayloadV1
 from src.web.data_sources.api_source import load_api_payload
 from src.web.data_sources.local_source import load_local_payload
 from src.web.data_sources.static_json_source import load_static_payload
 
 
 class PayloadClient(Protocol):
-    def load(self) -> Dict[str, Any]: ...
+    def load(self) -> WeatherPayloadV1: ...
 
 
 @dataclass(frozen=True)
 class FilePayloadClient:
     path: str
 
-    def load(self) -> Dict[str, Any]:
+    def load(self) -> WeatherPayloadV1:
         return load_static_payload(self.path)
 
 
@@ -33,7 +34,7 @@ class HttpPayloadClient:
     timeout: int = 20
     api_retries: int = API_RETRY_TIMES
 
-    def load(self) -> Dict[str, Any]:
+    def load(self) -> WeatherPayloadV1:
         return load_api_payload(self.url, timeout=self.timeout, api_retries=self.api_retries)
 
 
@@ -46,7 +47,7 @@ class LocalPayloadClient:
     max_workers: int = DEFAULT_MAX_WORKERS
     api_retries: int = API_RETRY_TIMES
 
-    def load(self) -> Dict[str, Any]:
+    def load(self) -> WeatherPayloadV1:
         return load_local_payload(
             resorts=list(self.resorts),
             cache_file=self.cache_file,

--- a/src/web/data_sources/gateway.py
+++ b/src/web/data_sources/gateway.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from typing import List, Optional
 
 from src.backend.constants import (
     API_RETRY_TIMES,
@@ -9,6 +9,7 @@ from src.backend.constants import (
     DEFAULT_MAX_WORKERS,
     DEFAULT_OPEN_METEO_CACHE_FILE,
 )
+from src.contract import WeatherPayloadV1
 from src.web.data_sources.clients import FilePayloadClient, HttpPayloadClient, LocalPayloadClient, PayloadClient
 
 
@@ -51,7 +52,7 @@ def load_payload(
     forecast_cache_hours: int = DEFAULT_FORECAST_CACHE_HOURS,
     max_workers: int = DEFAULT_MAX_WORKERS,
     api_retries: int = API_RETRY_TIMES,
-) -> Dict[str, Any]:
+) -> WeatherPayloadV1:
     return build_payload_client(
         mode=mode,
         source=source,

--- a/src/web/data_sources/hourly_source.py
+++ b/src/web/data_sources/hourly_source.py
@@ -4,7 +4,7 @@ import json
 import urllib.error
 import urllib.request
 from pathlib import Path
-from typing import Any, Dict, Tuple
+from typing import Tuple
 from urllib.parse import quote, urlencode, urlsplit, urlunsplit
 
 from src.backend.constants import (
@@ -14,7 +14,7 @@ from src.backend.constants import (
     DEFAULT_OPEN_METEO_CACHE_FILE,
 )
 from src.backend.services.hourly_payload_service import build_hourly_payload_for_resort
-from src.contract.hourly_payload import trim_hourly_payload
+from src.contract.hourly_payload import HourlyPayload, trim_hourly_payload
 from src.shared.retry import with_retry
 
 
@@ -31,7 +31,7 @@ def _load_local_hourly_payload(
     geocode_cache_hours: int,
     forecast_cache_hours: int,
     api_retries: int,
-) -> Tuple[int, Dict[str, Any]]:
+) -> Tuple[int, HourlyPayload]:
     try:
         payload = build_hourly_payload_for_resort(
             resort_id=resort_id,
@@ -57,11 +57,11 @@ def _load_api_hourly_payload(
     hours: int,
     timeout: int,
     api_retries: int,
-) -> Tuple[int, Dict[str, Any]]:
+) -> Tuple[int, HourlyPayload]:
     hourly_base = _hourly_endpoint_from_data_source(source)
     hourly_url = f"{hourly_base}?{urlencode({'resort_id': resort_id, 'hours': str(hours)})}"
 
-    def do_request() -> Tuple[int, Dict[str, Any]]:
+    def do_request() -> Tuple[int, HourlyPayload]:
         with urllib.request.urlopen(hourly_url, timeout=timeout) as resp:
             body = resp.read().decode("utf-8")
             return 200, json.loads(body)
@@ -86,7 +86,7 @@ def _load_file_hourly_payload(
     source: str,
     resort_id: str,
     hours: int,
-) -> Tuple[int, Dict[str, Any]]:
+) -> Tuple[int, HourlyPayload]:
     source_path = Path(source)
     site_root = source_path if source_path.is_dir() else source_path.parent
     hourly_path = site_root / "resort" / quote(resort_id, safe="") / "hourly.json"
@@ -118,7 +118,7 @@ def load_hourly_payload(
     geocode_cache_hours: int = DEFAULT_GEOCODE_CACHE_HOURS,
     forecast_cache_hours: int = DEFAULT_FORECAST_CACHE_HOURS,
     api_retries: int = API_RETRY_TIMES,
-) -> Tuple[int, Dict[str, Any]]:
+) -> Tuple[int, HourlyPayload]:
     if mode == "local":
         return _load_local_hourly_payload(
             resort_id=resort_id,

--- a/src/web/data_sources/local_source.py
+++ b/src/web/data_sources/local_source.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import List
 
 from src.backend.constants import API_RETRY_TIMES
+from src.contract import WeatherPayloadV1
 from src.shared.config import DEFAULT_RESORTS_FILE
 
 
@@ -13,7 +14,7 @@ def load_local_payload(
     forecast_cache_hours: int,
     max_workers: int,
     api_retries: int = API_RETRY_TIMES,
-) -> Dict[str, Any]:
+) -> WeatherPayloadV1:
     # Lazy import keeps frontend startup independent in api/file mode.
     from src.backend.pipelines.live_pipeline import run_live_payload
 

--- a/src/web/data_sources/request_source.py
+++ b/src/web/data_sources/request_source.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import Dict, List
 from urllib.parse import parse_qs, urlencode, urlsplit, urlunsplit
 
 from src.backend.constants import (
@@ -17,6 +17,7 @@ from src.backend.services.resort_selection_service import (
     load_supported_resort_catalog,
     select_resorts_from_query,
 )
+from src.contract import WeatherPayloadV1
 from src.web.data_sources.gateway import load_payload
 from src.web.data_sources.local_source import load_local_payload
 
@@ -47,7 +48,7 @@ def strip_server_filter_query(qs: Dict[str, List[str]]) -> Dict[str, List[str]]:
     return {key: list(values) for key, values in qs.items() if key not in SERVER_FILTER_QUERY_KEYS}
 
 
-def _ensure_filter_metadata(payload: Dict[str, Any]) -> Dict[str, Any]:
+def _ensure_filter_metadata(payload: WeatherPayloadV1) -> WeatherPayloadV1:
     if "available_filters" not in payload:
         try:
             catalog = load_supported_resort_catalog()
@@ -71,7 +72,7 @@ def load_request_payload(
     forecast_cache_hours: int = DEFAULT_FORECAST_CACHE_HOURS,
     max_workers: int = DEFAULT_MAX_WORKERS,
     api_retries: int = API_RETRY_TIMES,
-) -> Dict[str, Any]:
+) -> WeatherPayloadV1:
     qs = {key: list(values) for key, values in (query_params or {}).items()}
     resorts = [x.strip() for x in qs.get("resort", []) if x.strip()]
 

--- a/src/web/data_sources/static_json_source.py
+++ b/src/web/data_sources/static_json_source.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, Dict
 
-from src.contract import validate_weather_payload_v1
+from src.contract import WeatherPayloadV1, validate_weather_payload_v1
 
 
-def load_static_payload(path: str) -> Dict[str, Any]:
+def load_static_payload(path: str) -> WeatherPayloadV1:
     payload = json.loads(Path(path).read_text(encoding="utf-8"))
     validate_weather_payload_v1(payload)
     return payload

--- a/src/web/pipelines/static_site.py
+++ b/src/web/pipelines/static_site.py
@@ -13,6 +13,8 @@ from src.backend.constants import (
     DEFAULT_OPEN_METEO_CACHE_FILE,
     DEFAULT_STATIC_HOURLY_HOURS,
 )
+from src.contract import WeatherPayloadV1
+from src.contract.hourly_payload import HourlyPayload
 from src.web.resort_hourly_context import build_resort_daily_summary_contexts
 from src.web.weather_page_render_core import render_payload_html
 
@@ -28,14 +30,14 @@ def write_payload_json(path: str, payload: Dict[str, Any]) -> Path:
     return out
 
 
-def render_html(path: str, payload: Dict[str, Any], *, data_url: str = "./data.json") -> Path:
+def render_html(path: str, payload: WeatherPayloadV1, *, data_url: str = "./data.json") -> Path:
     out = Path(path)
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(render_payload_html(payload, data_url=data_url), encoding="utf-8")
     return out
 
 
-def _iter_resort_ids(payload: Dict[str, Any]) -> List[str]:
+def _iter_resort_ids(payload: WeatherPayloadV1) -> List[str]:
     reports = payload.get("reports")
     if not isinstance(reports, list):
         return []
@@ -63,7 +65,7 @@ def _build_hourly_payload(
     geocode_cache_hours: int,
     forecast_cache_hours: int,
     api_retries: int,
-) -> Optional[Dict[str, Any]]:
+) -> Optional[HourlyPayload]:
     from src.web.data_sources import load_hourly_payload
 
     code, payload = load_hourly_payload(
@@ -91,7 +93,7 @@ def _build_local_hourly_payloads(
     forecast_cache_hours: int,
     max_workers: int,
     api_retries: int,
-) -> Dict[str, Dict[str, Any] | None]:
+) -> Dict[str, HourlyPayload | None]:
     from src.backend.services.hourly_payload_service import build_hourly_payloads_for_resorts
 
     return build_hourly_payloads_for_resorts(
@@ -107,7 +109,7 @@ def _build_local_hourly_payloads(
 
 def render_hourly_pages(
     index_html_path: str,
-    payload: Dict[str, Any],
+    payload: WeatherPayloadV1,
     *,
     include_hourly_data: bool = True,
     hourly_mode: str = "local",
@@ -124,7 +126,7 @@ def render_hourly_pages(
     outputs: List[Path] = []
     resort_ids = _iter_resort_ids(payload)
     daily_summary_by_resort = build_resort_daily_summary_contexts(payload)
-    local_hourly_payloads: Dict[str, Dict[str, Any] | None] | None = None
+    local_hourly_payloads: Dict[str, HourlyPayload | None] | None = None
     if include_hourly_data and hourly_mode == "local":
         local_hourly_payloads = _build_local_hourly_payloads(
             resort_ids=resort_ids,

--- a/src/web/weather_page_render_core.py
+++ b/src/web/weather_page_render_core.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
-from typing import Any, Dict
-
+from src.contract import WeatherPayloadV1
 from src.web.weather_html_renderer import build_html
 
 
-def render_payload_html(payload: Dict[str, Any], *, data_url: str = "./data.json") -> str:
+def render_payload_html(payload: WeatherPayloadV1, *, data_url: str = "./data.json") -> str:
     return build_html(
         [],
         [],

--- a/src/web/weather_page_server.py
+++ b/src/web/weather_page_server.py
@@ -31,6 +31,7 @@ from src.backend.constants import (
 )
 from src.backend.services.hourly_options import parse_hour_count
 from src.backend.services.payload_memory_cache import PayloadMemoryCache, frozen_query_params
+from src.contract import WeatherPayloadV1
 from src.web.data_sources import load_hourly_payload, load_request_payload, strip_server_filter_query
 from src.web.resort_hourly_context import build_resort_daily_summary_context
 from src.web.weather_page_assets import ASSET_MIME_TYPES, read_asset_bytes
@@ -101,8 +102,8 @@ def make_handler(
 
         def _load_request_payload(
             self, qs: Dict[str, List[str]], *, apply_server_filters: bool = True
-        ) -> Dict[str, Any]:
-            def load() -> Dict[str, Any]:
+        ) -> WeatherPayloadV1:
+            def load() -> WeatherPayloadV1:
                 return load_request_payload(
                     mode=data_mode,
                     source=data_source,

--- a/tests/integration/test_contract_types.py
+++ b/tests/integration/test_contract_types.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import get_args, get_origin, get_type_hints
+
+from src.contract.hourly_payload import HOURLY_METRIC_KEYS, HourlyPayload, HourlySeries
+from src.contract.weather_payload_v1 import DailyForecastRow, NearbyAirport, WeatherPayloadV1, WeatherReport
+
+
+def _list_item_type(annotation):
+    assert get_origin(annotation) is list
+    return get_args(annotation)[0]
+
+
+def test_weather_payload_reports_use_explicit_typed_dicts():
+    payload_hints = get_type_hints(WeatherPayloadV1)
+    report_hints = get_type_hints(WeatherReport)
+
+    assert _list_item_type(payload_hints["reports"]) is WeatherReport
+    assert _list_item_type(report_hints["daily"]) is DailyForecastRow
+    assert _list_item_type(report_hints["past_14d_daily"]) is DailyForecastRow
+    assert _list_item_type(report_hints["nearby_airports"]) is NearbyAirport
+
+
+def test_hourly_payload_uses_explicit_series_schema():
+    payload_hints = get_type_hints(HourlyPayload)
+    series_hints = get_type_hints(HourlySeries)
+
+    assert payload_hints["hourly"] is HourlySeries
+    assert _list_item_type(series_hints["time"]) is str
+    for key in HOURLY_METRIC_KEYS:
+        assert key in series_hints

--- a/tests/integration/test_contract_validators.py
+++ b/tests/integration/test_contract_validators.py
@@ -77,3 +77,10 @@ def test_validate_weather_payload_v1_rejects_bad_report_field_type(valid_payload
     payload["reports"][0]["week1_total_snowfall_cm"] = "lots"
     with pytest.raises(ContractValidationError, match=r"reports\[0\]\.week1_total_snowfall_cm"):
         validate_weather_payload_v1(payload)
+
+
+def test_validate_weather_payload_v1_rejects_bad_catalog_report_field_type(valid_payload):
+    payload = deepcopy(valid_payload)
+    payload["reports"][0]["country_code"] = 123
+    with pytest.raises(ContractValidationError, match=r"reports\[0\]\.country_code"):
+        validate_weather_payload_v1(payload)


### PR DESCRIPTION
Refactor slice 5/7.\n\n- Replaces broad report/hourly payload contract annotations with explicit TypedDicts.\n- Updates builder, pipeline, data source, render, and cache annotations to use the contract types.\n- Shares validator field lists from the contract definitions.\n\nValidation run locally:\n- python3 -m pytest -q\n- python3 scripts/lint_assets.py --html\n- targeted ruff check over touched modules