### PR TITLE
Deduplicate CLI option wiring

### DIFF
--- a/agent_docs/graphs/refactor-stabilization-2026-06.md
+++ b/agent_docs/graphs/refactor-stabilization-2026-06.md
@@ -59,16 +59,16 @@
 - Validation: contract validator tests and pipeline/report builder tests.
 - Commit: `6bfcfb4` (`Strengthen payload contract types`)
 - Push: done (`origin/ljcc/refactor-contract-types`)
-- PR/Merge: [#68](https://github.com/ljcc0930/CloseSnow/pull/68); merge must be verified before slice 6 starts.
+- PR/Merge: [#68](https://github.com/ljcc0930/CloseSnow/pull/68); merged and verified before slice 6 started.
 
 ### 6. Deduplicate CLI And Server Option Wiring
-- Status: pending
+- Status: done; PR pending merge verification
 - Goal: reduce repeated argparse option declarations and server startup wiring while keeping CLI behavior stable.
 - Primary files: `src/cli.py`, server entrypoints if needed, integration CLI tests.
 - Validation: CLI/entrypoint/static-server tests.
-- Commit: pending
-- Push: pending
-- PR/Merge: pending
+- Commit: `7d931e5` (`Deduplicate CLI option wiring`)
+- Push: done (`origin/ljcc/refactor-cli-option-wiring`)
+- PR/Merge: [#69](https://github.com/ljcc0930/CloseSnow/pull/69); merge must be verified before slice 7 starts.
 
 ### 7. Clean Stale Docs And Legacy Renderer Decision
 - Status: pending
@@ -85,3 +85,4 @@
 - Slice 3 completed and pushed: `f4403ad`; extracted homepage formatter helpers to `assets/js/weather_page_formatters.js`; `python3 -m pytest tests/frontend/test_renderers.py tests/integration/test_web_server.py -q`, `python3 -m pytest tests/integration/test_cli.py::test_copy_static_assets_copies_css_and_js -q`, `python3 scripts/lint_assets.py --html`, and targeted ruff passed; `python3 scripts/lint_assets.py --js` is blocked locally by missing Node; browser preview loaded formatter and main scripts with no console errors.
 - Slice 4 completed and pushed: `bae0547`; centralized Python hourly metric keys and trimming in `src/contract/hourly_payload.py`; extracted browser hourly metric defs and static trim to `assets/js/resort_hourly_metrics.js`; `python3 -m pytest tests/integration/test_hourly_payload_contract.py tests/backend/test_weather_data_server_hourly.py tests/integration/test_data_sources.py tests/integration/test_web_server.py tests/frontend/test_static_site_pipeline.py tests/backend/test_open_meteo.py -q`, `python3 scripts/lint_assets.py --html`, and targeted ruff passed; `python3 scripts/lint_assets.py --js` is blocked locally by missing Node; browser preview loaded static resort hourly page with 72 rows, 7 charts, and no console errors.
 - Slice 5 completed on branch `ljcc/refactor-contract-types` and PR [#68](https://github.com/ljcc0930/CloseSnow/pull/68): `6bfcfb4`; replaced broad report and hourly payload contract annotations with explicit typed dicts; updated builder, pipeline, data source, render, and cache annotations; validators now share field lists from contract definitions; `python3 -m pytest -q`, `python3 scripts/lint_assets.py --html`, and targeted ruff passed.
+- Slice 6 completed on branch `ljcc/refactor-cli-option-wiring` and PR [#69](https://github.com/ljcc0930/CloseSnow/pull/69): `7d931e5`; added shared argparse helpers for resort, cache/runtime, and server bind options; reused them across the unified CLI, standalone backend data server, dynamic web server, static renderer, and legacy backend entrypoint; added parser default/override coverage; `python3 -m ruff check src/shared/cli_options.py src/cli.py src/backend/weather_data_server.py src/web/weather_page_server.py src/backend/ecmwf_unified_backend.py src/web/weather_page_static_render.py tests/integration/test_cli.py`, `python3 -m pytest tests/integration/test_cli.py tests/integration/test_entrypoints.py tests/integration/test_web_server.py tests/integration/test_backend_data_server.py -q`, `python3 -m pytest -q`, and standalone `--help` smoke tests passed.

--- a/src/backend/ecmwf_unified_backend.py
+++ b/src/backend/ecmwf_unified_backend.py
@@ -5,38 +5,30 @@ from __future__ import annotations
 
 import argparse
 import sys
+from pathlib import Path
 
-from src.backend.constants import (
-    API_RETRY_TIMES,
-    DEFAULT_FORECAST_CACHE_HOURS,
-    DEFAULT_GEOCODE_CACHE_HOURS,
-    DEFAULT_MAX_WORKERS,
-    DEFAULT_OPEN_METEO_CACHE_FILE,
-    DEFAULT_RESORTS,
-    DEFAULT_UNIFIED_PAYLOAD_FILE,
-)
+if str(Path(__file__).resolve().parents[2]) not in sys.path:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from src.backend.constants import DEFAULT_RESORTS, DEFAULT_UNIFIED_PAYLOAD_FILE
 from src.backend.pipeline import read_resorts, run_pipeline
+from src.shared.cli_options import add_cache_runtime_options, add_resort_options
 from src.shared.config import DEFAULT_RESORTS_FILE
 
 
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Unified ECMWF backend pipeline for ski weather.")
-    p.add_argument("--resort", action="append", default=[], help="Resort name (repeatable).")
-    p.add_argument(
-        "--resorts-file",
-        default=DEFAULT_RESORTS_FILE,
-        help="Resort catalog file (.yml/.json) or plain text file with one resort query per line.",
+    add_resort_options(
+        p,
+        resort_help="Resort name (repeatable).",
+        resorts_file_help="Resort catalog file (.yml/.json) or plain text file with one resort query per line.",
+        use_default_resorts=True,
     )
-    p.add_argument("--use-default-resorts", action="store_true", help="Use built-in resort list.")
     p.add_argument("--output-json", default=DEFAULT_UNIFIED_PAYLOAD_FILE)
     p.add_argument("--snow-csv", default=".cache/resorts_snowfall_daily.csv")
     p.add_argument("--rain-csv", default=".cache/resorts_rainfall_daily.csv")
     p.add_argument("--temp-csv", default=".cache/resorts_temperature_daily.csv")
-    p.add_argument("--cache-file", default=DEFAULT_OPEN_METEO_CACHE_FILE)
-    p.add_argument("--geocode-cache-hours", type=int, default=DEFAULT_GEOCODE_CACHE_HOURS)
-    p.add_argument("--forecast-cache-hours", type=int, default=DEFAULT_FORECAST_CACHE_HOURS)
-    p.add_argument("--max-workers", type=int, default=DEFAULT_MAX_WORKERS)
-    p.add_argument("--api-retries", type=int, default=API_RETRY_TIMES)
+    add_cache_runtime_options(p)
     return p.parse_args()
 
 

--- a/src/backend/weather_data_server.py
+++ b/src/backend/weather_data_server.py
@@ -13,14 +13,7 @@ from urllib.parse import parse_qs, urlparse
 if str(Path(__file__).resolve().parents[2]) not in sys.path:
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from src.backend.constants import (
-    API_RETRY_TIMES,
-    DEFAULT_FORECAST_CACHE_HOURS,
-    DEFAULT_GEOCODE_CACHE_HOURS,
-    DEFAULT_MAX_WORKERS,
-    DEFAULT_OPEN_METEO_CACHE_FILE,
-    DEFAULT_PAYLOAD_CACHE_TTL_SECONDS,
-)
+from src.backend.constants import API_RETRY_TIMES, DEFAULT_PAYLOAD_CACHE_TTL_SECONDS
 from src.backend.pipelines.live_pipeline import run_live_payload
 from src.backend.services.hourly_options import parse_hour_count
 from src.backend.services.hourly_payload_service import build_hourly_payload_for_resort
@@ -36,6 +29,7 @@ from src.backend.services.resort_selection_service import (
     split_query_values,
     supported_catalog,
 )
+from src.shared.cli_options import add_cache_runtime_options, add_server_bind_options
 from src.shared.config import DEFAULT_RESORTS_FILE
 
 
@@ -271,13 +265,8 @@ def make_handler(
 
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Serve backend weather payload API.")
-    p.add_argument("--host", default="127.0.0.1")
-    p.add_argument("--port", type=int, default=8020)
-    p.add_argument("--cache-file", default=DEFAULT_OPEN_METEO_CACHE_FILE)
-    p.add_argument("--geocode-cache-hours", type=int, default=DEFAULT_GEOCODE_CACHE_HOURS)
-    p.add_argument("--forecast-cache-hours", type=int, default=DEFAULT_FORECAST_CACHE_HOURS)
-    p.add_argument("--max-workers", type=int, default=DEFAULT_MAX_WORKERS)
-    p.add_argument("--api-retries", type=int, default=API_RETRY_TIMES)
+    add_server_bind_options(p, default_port=8020)
+    add_cache_runtime_options(p)
     p.add_argument("--allow-origin", default="*")
     return p.parse_args()
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -12,16 +12,10 @@ from typing import Any, Dict, List, Tuple
 if str(Path(__file__).resolve().parents[1]) not in sys.path:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from src.backend.constants import (
-    API_RETRY_TIMES,
-    DEFAULT_FORECAST_CACHE_HOURS,
-    DEFAULT_GEOCODE_CACHE_HOURS,
-    DEFAULT_MAX_WORKERS,
-    DEFAULT_OPEN_METEO_CACHE_FILE,
-)
 from src.backend.pipelines.static_pipeline import fetch_static_payload
 from src.backend.weather_data_server import make_handler as make_data_handler
-from src.shared.config import DATA_API_URL_ENV, DEFAULT_DATA_API_URL, DEFAULT_RESORTS_FILE
+from src.shared.cli_options import add_cache_runtime_options, add_resort_options, add_server_bind_options
+from src.shared.config import DATA_API_URL_ENV, DEFAULT_DATA_API_URL
 from src.web.data_sources import load_payload
 from src.web.pipelines import render_hourly_pages, render_html, write_payload_json
 from src.web.static_assets import copy_static_assets
@@ -29,27 +23,8 @@ from src.web.weather_page_server import make_handler
 
 
 def _add_fetch_options(p: argparse.ArgumentParser) -> None:
-    p.add_argument(
-        "--resort",
-        action="append",
-        default=[],
-        help="Resort query (repeatable). If set, resorts file is ignored.",
-    )
-    p.add_argument(
-        "--resorts-file",
-        default=DEFAULT_RESORTS_FILE,
-        help="Input resorts file when --resort is not provided.",
-    )
-    p.add_argument(
-        "--include-all-resorts",
-        action="store_true",
-        help="Include all resorts from --resorts-file, including default_enabled=false entries.",
-    )
-    p.add_argument("--cache-file", default=DEFAULT_OPEN_METEO_CACHE_FILE)
-    p.add_argument("--geocode-cache-hours", type=int, default=DEFAULT_GEOCODE_CACHE_HOURS)
-    p.add_argument("--forecast-cache-hours", type=int, default=DEFAULT_FORECAST_CACHE_HOURS)
-    p.add_argument("--max-workers", type=int, default=DEFAULT_MAX_WORKERS)
-    p.add_argument("--api-retries", type=int, default=API_RETRY_TIMES)
+    add_resort_options(p, include_all_resorts=True)
+    add_cache_runtime_options(p)
 
 
 def _resolve_resorts(args: argparse.Namespace) -> Tuple[List[str], str, bool]:
@@ -84,42 +59,26 @@ def build_parser() -> argparse.ArgumentParser:
         "serve-static", help="Build and serve generated static site files from a directory."
     )
     _add_fetch_options(p_serve_static)
-    p_serve_static.add_argument("--host", default="127.0.0.1")
-    p_serve_static.add_argument("--port", type=int, default=8011)
+    add_server_bind_options(p_serve_static, default_port=8011)
     p_serve_static.add_argument("--directory", default="site")
     p_serve_static.add_argument("--skip-fetch", action="store_true")
     p_serve_static.add_argument("--skip-render", action="store_true")
 
     p_serve = sub.add_parser("serve", help="Run dynamic weather HTTP server.")
-    p_serve.add_argument("--host", default="127.0.0.1")
-    p_serve.add_argument("--port", type=int, default=8010)
-    p_serve.add_argument("--cache-file", default=DEFAULT_OPEN_METEO_CACHE_FILE)
-    p_serve.add_argument("--geocode-cache-hours", type=int, default=DEFAULT_GEOCODE_CACHE_HOURS)
-    p_serve.add_argument("--forecast-cache-hours", type=int, default=DEFAULT_FORECAST_CACHE_HOURS)
-    p_serve.add_argument("--max-workers", type=int, default=DEFAULT_MAX_WORKERS)
-    p_serve.add_argument("--api-retries", type=int, default=API_RETRY_TIMES)
+    add_server_bind_options(p_serve, default_port=8010)
+    add_cache_runtime_options(p_serve)
 
     p_serve_data = sub.add_parser("serve-data", help="Run backend data API server only.")
-    p_serve_data.add_argument("--host", default="127.0.0.1")
-    p_serve_data.add_argument("--port", type=int, default=8020)
-    p_serve_data.add_argument("--cache-file", default=DEFAULT_OPEN_METEO_CACHE_FILE)
-    p_serve_data.add_argument("--geocode-cache-hours", type=int, default=DEFAULT_GEOCODE_CACHE_HOURS)
-    p_serve_data.add_argument("--forecast-cache-hours", type=int, default=DEFAULT_FORECAST_CACHE_HOURS)
-    p_serve_data.add_argument("--max-workers", type=int, default=DEFAULT_MAX_WORKERS)
-    p_serve_data.add_argument("--api-retries", type=int, default=API_RETRY_TIMES)
+    add_server_bind_options(p_serve_data, default_port=8020)
+    add_cache_runtime_options(p_serve_data)
     p_serve_data.add_argument("--allow-origin", default="*")
 
     p_serve_web = sub.add_parser("serve-web", help="Run frontend web server with configurable data source.")
-    p_serve_web.add_argument("--host", default="127.0.0.1")
-    p_serve_web.add_argument("--port", type=int, default=8010)
+    add_server_bind_options(p_serve_web, default_port=8010)
     p_serve_web.add_argument("--data-mode", choices=["local", "api", "file"], default="api")
     p_serve_web.add_argument("--data-source", default=os.getenv(DATA_API_URL_ENV, DEFAULT_DATA_API_URL))
     p_serve_web.add_argument("--data-timeout", type=int, default=20)
-    p_serve_web.add_argument("--cache-file", default=DEFAULT_OPEN_METEO_CACHE_FILE)
-    p_serve_web.add_argument("--geocode-cache-hours", type=int, default=DEFAULT_GEOCODE_CACHE_HOURS)
-    p_serve_web.add_argument("--forecast-cache-hours", type=int, default=DEFAULT_FORECAST_CACHE_HOURS)
-    p_serve_web.add_argument("--max-workers", type=int, default=DEFAULT_MAX_WORKERS)
-    p_serve_web.add_argument("--api-retries", type=int, default=API_RETRY_TIMES)
+    add_cache_runtime_options(p_serve_web)
 
     return p
 

--- a/src/shared/cli_options.py
+++ b/src/shared/cli_options.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import argparse
+
+from src.backend.constants import (
+    API_RETRY_TIMES,
+    DEFAULT_FORECAST_CACHE_HOURS,
+    DEFAULT_GEOCODE_CACHE_HOURS,
+    DEFAULT_MAX_WORKERS,
+    DEFAULT_OPEN_METEO_CACHE_FILE,
+)
+from src.shared.config import DEFAULT_RESORTS_FILE
+
+
+def add_resort_options(
+    parser: argparse.ArgumentParser,
+    *,
+    resort_help: str = "Resort query (repeatable). If set, resorts file is ignored.",
+    resorts_file_help: str = "Input resorts file when --resort is not provided.",
+    include_all_resorts: bool = False,
+    use_default_resorts: bool = False,
+) -> None:
+    parser.add_argument("--resort", action="append", default=[], help=resort_help)
+    parser.add_argument("--resorts-file", default=DEFAULT_RESORTS_FILE, help=resorts_file_help)
+    if include_all_resorts:
+        parser.add_argument(
+            "--include-all-resorts",
+            action="store_true",
+            help="Include all resorts from --resorts-file, including default_enabled=false entries.",
+        )
+    if use_default_resorts:
+        parser.add_argument("--use-default-resorts", action="store_true", help="Use built-in resort list.")
+
+
+def add_cache_runtime_options(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--cache-file", default=DEFAULT_OPEN_METEO_CACHE_FILE)
+    parser.add_argument("--geocode-cache-hours", type=int, default=DEFAULT_GEOCODE_CACHE_HOURS)
+    parser.add_argument("--forecast-cache-hours", type=int, default=DEFAULT_FORECAST_CACHE_HOURS)
+    parser.add_argument("--max-workers", type=int, default=DEFAULT_MAX_WORKERS)
+    parser.add_argument("--api-retries", type=int, default=API_RETRY_TIMES)
+
+
+def add_server_bind_options(parser: argparse.ArgumentParser, *, default_port: int) -> None:
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=default_port)

--- a/src/web/weather_page_server.py
+++ b/src/web/weather_page_server.py
@@ -21,17 +21,11 @@ from urllib.parse import parse_qs, urlparse
 if str(Path(__file__).resolve().parents[2]) not in sys.path:
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from src.backend.constants import (
-    API_RETRY_TIMES,
-    DEFAULT_FORECAST_CACHE_HOURS,
-    DEFAULT_GEOCODE_CACHE_HOURS,
-    DEFAULT_MAX_WORKERS,
-    DEFAULT_OPEN_METEO_CACHE_FILE,
-    DEFAULT_PAYLOAD_CACHE_TTL_SECONDS,
-)
+from src.backend.constants import API_RETRY_TIMES, DEFAULT_PAYLOAD_CACHE_TTL_SECONDS
 from src.backend.services.hourly_options import parse_hour_count
 from src.backend.services.payload_memory_cache import PayloadMemoryCache, frozen_query_params
 from src.contract import WeatherPayloadV1
+from src.shared.cli_options import add_cache_runtime_options, add_server_bind_options
 from src.web.data_sources import load_hourly_payload, load_request_payload, strip_server_filter_query
 from src.web.resort_hourly_context import build_resort_daily_summary_context
 from src.web.weather_page_assets import ASSET_MIME_TYPES, read_asset_bytes
@@ -208,16 +202,11 @@ def make_handler(
 
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Serve dynamic ski weather page.")
-    p.add_argument("--host", default="127.0.0.1")
-    p.add_argument("--port", type=int, default=8010)
+    add_server_bind_options(p, default_port=8010)
     p.add_argument("--data-mode", choices=["local", "api", "file"], default="local")
     p.add_argument("--data-source", default="")
     p.add_argument("--data-timeout", type=int, default=20)
-    p.add_argument("--cache-file", default=DEFAULT_OPEN_METEO_CACHE_FILE)
-    p.add_argument("--geocode-cache-hours", type=int, default=DEFAULT_GEOCODE_CACHE_HOURS)
-    p.add_argument("--forecast-cache-hours", type=int, default=DEFAULT_FORECAST_CACHE_HOURS)
-    p.add_argument("--max-workers", type=int, default=DEFAULT_MAX_WORKERS)
-    p.add_argument("--api-retries", type=int, default=API_RETRY_TIMES)
+    add_cache_runtime_options(p)
     return p.parse_args()
 
 

--- a/src/web/weather_page_static_render.py
+++ b/src/web/weather_page_static_render.py
@@ -14,37 +14,19 @@ from typing import List
 if str(Path(__file__).resolve().parents[2]) not in sys.path:
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from src.backend.constants import (
-    API_RETRY_TIMES,
-    DEFAULT_FORECAST_CACHE_HOURS,
-    DEFAULT_GEOCODE_CACHE_HOURS,
-    DEFAULT_MAX_WORKERS,
-    DEFAULT_OPEN_METEO_CACHE_FILE,
-)
 from src.backend.pipelines.static_pipeline import fetch_static_payload
-from src.shared.config import DEFAULT_RESORTS_FILE
+from src.shared.cli_options import add_cache_runtime_options, add_resort_options
 from src.web.pipelines import render_hourly_pages, render_html
 from src.web.static_assets import copy_static_assets
 
 
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Render static ski weather HTML using unified backend payload.")
-    p.add_argument(
-        "--resort",
-        action="append",
-        default=[],
-        help="Resort query (repeatable). If set, --resorts-file is ignored.",
+    add_resort_options(
+        p,
+        resort_help="Resort query (repeatable). If set, --resorts-file is ignored.",
     )
-    p.add_argument(
-        "--resorts-file",
-        default=DEFAULT_RESORTS_FILE,
-        help="Input resorts file when --resort is not provided.",
-    )
-    p.add_argument("--cache-file", default=DEFAULT_OPEN_METEO_CACHE_FILE)
-    p.add_argument("--geocode-cache-hours", type=int, default=DEFAULT_GEOCODE_CACHE_HOURS)
-    p.add_argument("--forecast-cache-hours", type=int, default=DEFAULT_FORECAST_CACHE_HOURS)
-    p.add_argument("--max-workers", type=int, default=DEFAULT_MAX_WORKERS)
-    p.add_argument("--api-retries", type=int, default=API_RETRY_TIMES)
+    add_cache_runtime_options(p)
     p.add_argument("--output-dir", default="site")
     return p.parse_args()
 

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -6,6 +6,14 @@ from pathlib import Path
 
 import pytest
 from src import cli
+from src.backend.constants import (
+    API_RETRY_TIMES,
+    DEFAULT_FORECAST_CACHE_HOURS,
+    DEFAULT_GEOCODE_CACHE_HOURS,
+    DEFAULT_MAX_WORKERS,
+    DEFAULT_OPEN_METEO_CACHE_FILE,
+)
+from src.shared.config import DEFAULT_RESORTS_FILE
 
 
 def test_build_parser_has_all_commands():
@@ -27,6 +35,55 @@ def test_build_parser_has_all_commands():
     assert args.command == "serve-data"
     args = parser.parse_args(["serve-web"])
     assert args.command == "serve-web"
+
+
+def test_build_parser_shared_option_defaults_and_overrides():
+    parser = cli.build_parser()
+
+    fetch_args = parser.parse_args(["fetch"])
+    assert fetch_args.resort == []
+    assert fetch_args.resorts_file == DEFAULT_RESORTS_FILE
+    assert fetch_args.include_all_resorts is False
+    assert fetch_args.cache_file == DEFAULT_OPEN_METEO_CACHE_FILE
+    assert fetch_args.geocode_cache_hours == DEFAULT_GEOCODE_CACHE_HOURS
+    assert fetch_args.forecast_cache_hours == DEFAULT_FORECAST_CACHE_HOURS
+    assert fetch_args.max_workers == DEFAULT_MAX_WORKERS
+    assert fetch_args.api_retries == API_RETRY_TIMES
+
+    serve_static_args = parser.parse_args(["serve-static"])
+    assert serve_static_args.host == "127.0.0.1"
+    assert serve_static_args.port == 8011
+    assert serve_static_args.directory == "site"
+    assert serve_static_args.cache_file == DEFAULT_OPEN_METEO_CACHE_FILE
+
+    serve_args = parser.parse_args(["serve"])
+    assert serve_args.host == "127.0.0.1"
+    assert serve_args.port == 8010
+    assert serve_args.api_retries == API_RETRY_TIMES
+
+    serve_data_args = parser.parse_args(["serve-data"])
+    assert serve_data_args.host == "127.0.0.1"
+    assert serve_data_args.port == 8020
+    assert serve_data_args.allow_origin == "*"
+    assert serve_data_args.max_workers == DEFAULT_MAX_WORKERS
+
+    serve_web_args = parser.parse_args(
+        [
+            "serve-web",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            "9000",
+            "--cache-file",
+            ".cache/custom.json",
+            "--api-retries",
+            "5",
+        ]
+    )
+    assert serve_web_args.host == "0.0.0.0"
+    assert serve_web_args.port == 9000
+    assert serve_web_args.cache_file == ".cache/custom.json"
+    assert serve_web_args.api_retries == 5
 
 
 def test_serve_web_parser_uses_env_default(monkeypatch):


### PR DESCRIPTION
## Summary
- Add shared argparse helpers for resort, cache/runtime, and server bind options
- Reuse the helpers across the unified CLI and standalone server/static entrypoints
- Add parser assertions to lock shared defaults and overrides

## Validation
- python3 -m ruff check src/shared/cli_options.py src/cli.py src/backend/weather_data_server.py src/web/weather_page_server.py src/backend/ecmwf_unified_backend.py src/web/weather_page_static_render.py tests/integration/test_cli.py
- python3 -m pytest tests/integration/test_cli.py tests/integration/test_entrypoints.py tests/integration/test_web_server.py tests/integration/test_backend_data_server.py -q
- python3 -m pytest -q
- python3 -m src.cli serve-web --help
- python3 src/backend/ecmwf_unified_backend.py --help
- python3 src/backend/weather_data_server.py --help
- python3 src/web/weather_page_server.py --help
- python3 src/web/weather_page_static_render.py --help