### PR TITLE
Clarify legacy renderer compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ python -m src.cli static --output-dir site --max-workers 8 --include-all-resorts
 touch site/.nojekyll
 ```
 
-## Compatibility Entrypoint
+## Compatibility Surfaces
 
 Legacy-compatible backend entrypoint:
 
@@ -447,12 +447,15 @@ Default artifacts:
 - `.cache/resorts_rainfall_daily.csv`
 - `.cache/resorts_temperature_daily.csv`
 
+Legacy Python table renderers under `src/web/weather_table_renderer.py`, `src/web/split_metric_renderer.py`, and `src/web/desktop`/`src/web/mobile` are retained as compatibility and regression-test surface. The current main page shell bootstraps payload data and renders forecast tables in browser JavaScript.
+
 ## Architecture Docs
 
-- `docs/FRONTEND_BACKEND_FLOW_ARCHITECTURE.md`
-- `docs/FRONTEND_COMM_BACKEND_REFACTOR_GUIDE.md`
 - `docs/CODEBASE_VALIDATION_PLAYBOOK.md`
-- `docs/FEATURE_DESIGN_SKI_WEATHER_FULL_INFO.md`
+- `docs/FEATURE_DESIGN_MAIN_PAGE_FAVORITES_LOCAL_UPDATE.md`
+- `docs/FEATURE_DESIGN_RESORT_COORDINATE_VERIFICATION_LINKS.md`
+- `docs/FEATURE_DESIGN_RESORT_PAGE_DAILY_SUMMARY_REUSE.md`
+- `docs/FEATURE_DESIGN_SERVE_STATIC.md`
 - `docs/REFACTOR_PROGRESS_LEDGER.md`
 
 ## License

--- a/agent_docs/graphs/refactor-stabilization-2026-06.md
+++ b/agent_docs/graphs/refactor-stabilization-2026-06.md
@@ -62,22 +62,22 @@
 - PR/Merge: [#68](https://github.com/ljcc0930/CloseSnow/pull/68); merged and verified before slice 6 started.
 
 ### 6. Deduplicate CLI And Server Option Wiring
-- Status: done; PR pending merge verification
+- Status: done
 - Goal: reduce repeated argparse option declarations and server startup wiring while keeping CLI behavior stable.
 - Primary files: `src/cli.py`, server entrypoints if needed, integration CLI tests.
 - Validation: CLI/entrypoint/static-server tests.
 - Commit: `7d931e5` (`Deduplicate CLI option wiring`)
 - Push: done (`origin/ljcc/refactor-cli-option-wiring`)
-- PR/Merge: [#69](https://github.com/ljcc0930/CloseSnow/pull/69); merge must be verified before slice 7 starts.
+- PR/Merge: [#69](https://github.com/ljcc0930/CloseSnow/pull/69); merged and verified before slice 7 started.
 
 ### 7. Clean Stale Docs And Legacy Renderer Decision
-- Status: pending
+- Status: done; PR pending merge verification
 - Goal: remove or clearly mark stale documentation references and decide whether old Python table renderers are compatibility surface or dead code.
 - Primary files: `README.md`, docs, legacy renderer modules/tests if changed.
 - Validation: documentation grep for stale paths; targeted renderer/docs-adjacent tests.
-- Commit: pending
-- Push: pending
-- PR/Merge: pending
+- Commit: `1786a65` (`Clarify legacy renderer compatibility`)
+- Push: done (`origin/ljcc/refactor-docs-legacy-renderers`)
+- PR/Merge: [#70](https://github.com/ljcc0930/CloseSnow/pull/70); merge must be verified before declaring all seven slices complete.
 
 ## Completion Ledger
 - Slice 1 completed and pushed: `f7961fa`; `python3 -m pytest tests/test_lint_assets.py -q` passed; `./scripts/lint.sh` now reports `assets/js: node is required for JavaScript syntax checks` cleanly on this machine instead of raising `ValueError`.
@@ -86,3 +86,4 @@
 - Slice 4 completed and pushed: `bae0547`; centralized Python hourly metric keys and trimming in `src/contract/hourly_payload.py`; extracted browser hourly metric defs and static trim to `assets/js/resort_hourly_metrics.js`; `python3 -m pytest tests/integration/test_hourly_payload_contract.py tests/backend/test_weather_data_server_hourly.py tests/integration/test_data_sources.py tests/integration/test_web_server.py tests/frontend/test_static_site_pipeline.py tests/backend/test_open_meteo.py -q`, `python3 scripts/lint_assets.py --html`, and targeted ruff passed; `python3 scripts/lint_assets.py --js` is blocked locally by missing Node; browser preview loaded static resort hourly page with 72 rows, 7 charts, and no console errors.
 - Slice 5 completed on branch `ljcc/refactor-contract-types` and PR [#68](https://github.com/ljcc0930/CloseSnow/pull/68): `6bfcfb4`; replaced broad report and hourly payload contract annotations with explicit typed dicts; updated builder, pipeline, data source, render, and cache annotations; validators now share field lists from contract definitions; `python3 -m pytest -q`, `python3 scripts/lint_assets.py --html`, and targeted ruff passed.
 - Slice 6 completed on branch `ljcc/refactor-cli-option-wiring` and PR [#69](https://github.com/ljcc0930/CloseSnow/pull/69): `7d931e5`; added shared argparse helpers for resort, cache/runtime, and server bind options; reused them across the unified CLI, standalone backend data server, dynamic web server, static renderer, and legacy backend entrypoint; added parser default/override coverage; `python3 -m ruff check src/shared/cli_options.py src/cli.py src/backend/weather_data_server.py src/web/weather_page_server.py src/backend/ecmwf_unified_backend.py src/web/weather_page_static_render.py tests/integration/test_cli.py`, `python3 -m pytest tests/integration/test_cli.py tests/integration/test_entrypoints.py tests/integration/test_web_server.py tests/integration/test_backend_data_server.py -q`, `python3 -m pytest -q`, and standalone `--help` smoke tests passed.
+- Slice 7 completed on branch `ljcc/refactor-docs-legacy-renderers` and PR [#70](https://github.com/ljcc0930/CloseSnow/pull/70): `1786a65`; removed current README/docs references to missing architecture docs, removed test paths, and old `--output-html` examples; marked old ledger entries as historical evidence rather than current instructions; documented legacy Python table renderers as compatibility/regression-test surface while current page shell rendering is browser-driven; `python3 -m ruff check src/web/weather_html_renderer.py tests/frontend/test_renderers.py`, `python3 -m pytest tests/frontend/test_renderers.py tests/frontend/test_resort_hourly_context.py tests/frontend/test_static_site_pipeline.py tests/integration/test_web_server.py -q`, `python3 -m pytest tests/integration/test_cli.py::test_copy_static_assets_copies_css_and_js -q`, `python3 -m pytest -q`, and documentation/renderer grep checks passed.

--- a/docs/FEATURE_DESIGN_MAIN_PAGE_FAVORITES_LOCAL_UPDATE.md
+++ b/docs/FEATURE_DESIGN_MAIN_PAGE_FAVORITES_LOCAL_UPDATE.md
@@ -105,7 +105,7 @@ This keeps the render strategy explicit:
 Files expected in this slice:
 
 1. [`assets/js/weather_page.js`](/Users/ljcc/workspace/CloseSnow/assets/js/weather_page.js)
-2. [`tests/frontend/test_assets.py`](/Users/ljcc/workspace/CloseSnow/tests/frontend/test_assets.py)
+2. [`tests/frontend/test_static_site_pipeline.py`](/Users/ljcc/workspace/CloseSnow/tests/frontend/test_static_site_pipeline.py)
 3. [`docs/REFACTOR_PROGRESS_LEDGER.md`](/Users/ljcc/workspace/CloseSnow/docs/REFACTOR_PROGRESS_LEDGER.md)
 
 Phase 1:

--- a/docs/FEATURE_DESIGN_RESORT_COORDINATE_VERIFICATION_LINKS.md
+++ b/docs/FEATURE_DESIGN_RESORT_COORDINATE_VERIFICATION_LINKS.md
@@ -65,7 +65,8 @@ Primary files:
 1. `assets/js/resort_hourly.js`
 2. `assets/css/resort_hourly.css`
 3. `.github/ISSUE_TEMPLATE/01-coordinate-correction.yml`
-4. `tests/frontend/test_assets.py`
+4. `tests/frontend/test_static_site_pipeline.py`
+5. `tests/integration/test_web_server.py`
 
 ## 6. Validation
 

--- a/docs/FEATURE_DESIGN_RESORT_PAGE_DAILY_SUMMARY_REUSE.md
+++ b/docs/FEATURE_DESIGN_RESORT_PAGE_DAILY_SUMMARY_REUSE.md
@@ -207,7 +207,7 @@ HTML/template/bootstrap:
 
 Tests:
 
-1. [`tests/frontend/test_assets.py`](/Users/ljcc/workspace/CloseSnow/tests/frontend/test_assets.py)
+1. [`tests/frontend/test_resort_hourly_context.py`](/Users/ljcc/workspace/CloseSnow/tests/frontend/test_resort_hourly_context.py)
 2. [`tests/frontend/test_static_site_pipeline.py`](/Users/ljcc/workspace/CloseSnow/tests/frontend/test_static_site_pipeline.py)
 3. [`tests/integration/test_web_server.py`](/Users/ljcc/workspace/CloseSnow/tests/integration/test_web_server.py)
 
@@ -223,8 +223,8 @@ Automated:
 Commands:
 
 ```bash
-python3 -m pytest tests/frontend/test_assets.py tests/frontend/test_static_site_pipeline.py tests/integration/test_web_server.py -q
-python3 -m src.cli static --output-html index.html
+python3 -m pytest tests/frontend/test_resort_hourly_context.py tests/frontend/test_static_site_pipeline.py tests/integration/test_web_server.py -q
+python3 -m src.cli static --output-dir site --max-workers 8
 ```
 
 Manual:

--- a/docs/REFACTOR_PROGRESS_LEDGER.md
+++ b/docs/REFACTOR_PROGRESS_LEDGER.md
@@ -2,11 +2,12 @@
 
 This file is the recovery anchor for long-running refactor work.
 
-Always read in this order before continuing:
+Current continuation order:
 
-1. `docs/FRONTEND_COMM_BACKEND_REFACTOR_GUIDE.md`
-2. `docs/CODEBASE_VALIDATION_PLAYBOOK.md`
-3. `docs/REFACTOR_PROGRESS_LEDGER.md` (this file)
+1. `docs/CODEBASE_VALIDATION_PLAYBOOK.md`
+2. `docs/REFACTOR_PROGRESS_LEDGER.md` (this file)
+
+Historical entries below are preserved as executed. Some older entries mention removed planning docs, removed tests such as `tests/frontend/test_assets.py`, or superseded CLI flags such as `--output-html`; treat those as dated ledger evidence, not current instructions.
 
 ---
 
@@ -28,9 +29,7 @@ Status: v4 classification+merge pass implemented and validated on 2026-03-04 loc
 2. Cache read/write paths are lock-protected for concurrent access.
 3. Frontend has per-table unit toggles (`cm/in`, `mm/in`, `C/F`) with persisted browser preference.
 4. Desktop/mobile renderer split exists with merged precipitation wrappers by platform.
-5. Two planning docs already exist:
-   - `docs/FRONTEND_COMM_BACKEND_REFACTOR_GUIDE.md`
-   - `docs/CODEBASE_VALIDATION_PLAYBOOK.md`
+5. Current validation guidance lives in `docs/CODEBASE_VALIDATION_PLAYBOOK.md`; feature-specific plans live in `docs/FEATURE_DESIGN_*.md` and `agent_docs/graphs/`.
 6. Automated pytest suite exists under `tests/` and is runnable via `python3 -m pytest -q`.
 7. Current Codex convention for local static preview/validation runs is `--max-workers 8`; older ledger entries that used `2` were temporary throttled runs.
 

--- a/src/web/weather_html_renderer.py
+++ b/src/web/weather_html_renderer.py
@@ -30,6 +30,14 @@ def build_html(
     data_url: str = "./data.json",
     initial_payload: Dict[str, Any] | None = None,
 ) -> str:
+    """Build the browser-rendered page shell.
+
+    The table-data arguments are kept for compatibility with older tests and
+    callers; the active page path bootstraps payload JSON and lets JS render
+    forecast tables in the browser.
+    """
+    del snowfall, rain, weather, sun, temp
+
     now_utc = datetime.now(timezone.utc)
     generated_utc_iso = now_utc.replace(microsecond=0).isoformat().replace("+00:00", "Z")
     filter_meta = {

--- a/tests/frontend/test_renderers.py
+++ b/tests/frontend/test_renderers.py
@@ -270,6 +270,25 @@ def test_build_html_contains_meta_sections():
     assert re.search(r"data-generated-utc=\"[0-9T:\-]+Z\"", html)
 
 
+def test_build_html_keeps_legacy_table_args_out_of_page_shell():
+    html = build_html(
+        [{"query": "Legacy Snow"}],
+        [{"query": "Legacy Rain"}],
+        [{"query": "Legacy Weather"}],
+        [{"query": "Legacy Sun"}],
+        [{"query": "Legacy Temp"}],
+        initial_payload={"reports": []},
+    )
+
+    assert "Legacy Snow" not in html
+    assert "Legacy Rain" not in html
+    assert "Legacy Weather" not in html
+    assert "Legacy Sun" not in html
+    assert "Legacy Temp" not in html
+    assert "Loading forecast..." in html
+    assert 'window.CLOSESNOW_INITIAL_PAYLOAD = {"reports": []};' in html
+
+
 def test_render_payload_html_wires_transform_and_builder(monkeypatch):
     captured = {}
 


### PR DESCRIPTION
## Summary
- Remove stale current README/docs references to missing architecture docs, removed test paths, and old static output flags
- Mark historical ledger entries as dated evidence instead of current instructions
- Document that Python table renderers are retained as compatibility/regression-test surface while the page shell renders tables in browser JS

## Validation
- python3 -m ruff check src/web/weather_html_renderer.py tests/frontend/test_renderers.py
- python3 -m pytest tests/frontend/test_renderers.py tests/frontend/test_resort_hourly_context.py tests/frontend/test_static_site_pipeline.py tests/integration/test_web_server.py -q
- python3 -m pytest tests/integration/test_cli.py::test_copy_static_assets_copies_css_and_js -q
- python3 -m pytest -q
- rg -n "FRONTEND_BACKEND_FLOW_ARCHITECTURE|FRONTEND_COMM_BACKEND_REFACTOR_GUIDE|FEATURE_DESIGN_SKI_WEATHER_FULL_INFO|tests/frontend/test_assets.py|--output-html" README.md docs --glob '!docs/REFACTOR_PROGRESS_LEDGER.md'
- rg -n "build_html\(|render_snowfall_table|render_rain_table|render_temperature_table|render_weather_table|render_sun_table" src tests -g '*.py'