### PR TITLE
Establish one executable web asset manifest

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -37,15 +37,7 @@ jobs:
 
       - name: Validate generated Pages artifact
         run: |
-          test -f site/index.html
-          test -f site/data.json
-          test -f site/.nojekyll
-          test -f site/assets/css/weather_page.css
-          test -f site/assets/js/weather_page.js
-          test -f site/assets/css/resort_hourly.css
-          test -f site/assets/js/resort_hourly.js
-          find site/resort -mindepth 2 -maxdepth 2 -path '*/index.html' | grep -q .
-          find site/resort -mindepth 2 -maxdepth 2 -path '*/hourly.json' | grep -q .
+          python -m src.web.static_site_validator --site-dir site --require-pages-artifacts
 
       - name: Configure Pages
         uses: actions/configure-pages@v5

--- a/src/web/asset_manifest.py
+++ b/src/web/asset_manifest.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from types import MappingProxyType
+from typing import Final, Mapping, Optional
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[2]
+
+
+@dataclass(frozen=True)
+class WebAsset:
+    repository_path: str
+    mime_type: str
+
+    def __post_init__(self) -> None:
+        parsed = PurePosixPath(self.repository_path)
+        if (
+            parsed.is_absolute()
+            or not parsed.parts
+            or parsed.parts[0] != "assets"
+            or ".." in parsed.parts
+            or str(parsed) != self.repository_path
+        ):
+            raise ValueError(
+                f"Web asset path must be a normalized repository-relative assets path: {self.repository_path}"
+            )
+
+    @property
+    def public_url(self) -> str:
+        return f"/{self.repository_path}"
+
+    def source_path(self, repository_root: Path = REPO_ROOT) -> Path:
+        return repository_root.joinpath(*PurePosixPath(self.repository_path).parts)
+
+
+WEB_ASSET_MANIFEST: Final[tuple[WebAsset, ...]] = (
+    WebAsset("assets/css/weather_page.css", "text/css; charset=utf-8"),
+    WebAsset("assets/js/compact_daily_summary.js", "application/javascript; charset=utf-8"),
+    WebAsset("assets/js/weather_code_emoji.js", "application/javascript; charset=utf-8"),
+    WebAsset("assets/js/weather_filter_state.js", "application/javascript; charset=utf-8"),
+    WebAsset("assets/js/sticky_single_table_layout.js", "application/javascript; charset=utf-8"),
+    WebAsset("assets/js/weather_page_formatters.js", "application/javascript; charset=utf-8"),
+    WebAsset("assets/js/weather_page.js", "application/javascript; charset=utf-8"),
+    WebAsset("assets/css/resort_hourly.css", "text/css; charset=utf-8"),
+    WebAsset("assets/js/resort_hourly_metrics.js", "application/javascript; charset=utf-8"),
+    WebAsset("assets/js/resort_hourly.js", "application/javascript; charset=utf-8"),
+)
+
+
+def _build_asset_index(manifest: tuple[WebAsset, ...]) -> Mapping[str, WebAsset]:
+    index: dict[str, WebAsset] = {}
+    for asset in manifest:
+        if asset.repository_path in index:
+            raise ValueError(f"Duplicate web asset path: {asset.repository_path}")
+        index[asset.repository_path] = asset
+    return MappingProxyType(index)
+
+
+WEB_ASSETS_BY_PATH: Final[Mapping[str, WebAsset]] = _build_asset_index(WEB_ASSET_MANIFEST)
+ASSET_MIME_TYPES: Final[Mapping[str, str]] = MappingProxyType(
+    {path: asset.mime_type for path, asset in WEB_ASSETS_BY_PATH.items()}
+)
+
+
+def asset_for_path(name: str) -> Optional[WebAsset]:
+    return WEB_ASSETS_BY_PATH.get(name)
+
+
+def asset_path(name: str) -> Path:
+    asset = asset_for_path(name)
+    if asset is None:
+        raise KeyError(f"Unknown web asset: {name}")
+    return asset.source_path()
+
+
+def read_asset_bytes(name: str) -> bytes:
+    return asset_path(name).read_bytes()
+
+
+__all__ = [
+    "ASSET_MIME_TYPES",
+    "REPO_ROOT",
+    "WEB_ASSET_MANIFEST",
+    "WEB_ASSETS_BY_PATH",
+    "WebAsset",
+    "asset_for_path",
+    "asset_path",
+    "read_asset_bytes",
+]

--- a/src/web/static_assets.py
+++ b/src/web/static_assets.py
@@ -1,19 +1,24 @@
 from __future__ import annotations
 
 import shutil
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import List
 
-STATIC_ASSET_DIRS = ("css", "js")
+from src.web.asset_manifest import WEB_ASSET_MANIFEST
+
+STATIC_ASSET_DIRS = tuple(dict.fromkeys(PurePosixPath(asset.repository_path).parts[1] for asset in WEB_ASSET_MANIFEST))
 
 
 def copy_static_assets(directory: str) -> List[Path]:
     root = Path(directory).resolve()
-    assets_root = root / "assets"
     copied: List[Path] = []
-    for name in STATIC_ASSET_DIRS:
-        source = Path("assets") / name
-        target = assets_root / name
-        shutil.copytree(source, target, dirs_exist_ok=True)
-        copied.append(target)
+    copied_set: set[Path] = set()
+    for asset in WEB_ASSET_MANIFEST:
+        source = asset.source_path()
+        target = root.joinpath(*PurePosixPath(asset.repository_path).parts)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, target)
+        if target.parent not in copied_set:
+            copied.append(target.parent)
+            copied_set.add(target.parent)
     return copied

--- a/src/web/static_site_validator.py
+++ b/src/web/static_site_validator.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final, Optional, Sequence
+
+from src.web.asset_manifest import WEB_ASSET_MANIFEST
+
+REQUIRED_ENTRY_ARTIFACTS: Final[tuple[str, ...]] = ("index.html", "data.json")
+PAGES_ENTRY_ARTIFACTS: Final[tuple[str, ...]] = (".nojekyll",)
+PAGES_REQUIRED_PATTERNS: Final[tuple[str, ...]] = (
+    "resort/*/index.html",
+    "resort/*/hourly.json",
+)
+
+
+@dataclass(frozen=True)
+class StaticSiteValidationIssue:
+    path: Path
+    message: str
+
+    def render(self) -> str:
+        return f"{self.path}: {self.message}"
+
+
+def validate_static_site(
+    directory: str | Path,
+    *,
+    require_pages_artifacts: bool = False,
+) -> tuple[StaticSiteValidationIssue, ...]:
+    root = Path(directory).resolve()
+    if not root.is_dir():
+        return (StaticSiteValidationIssue(root, "static-site root is missing or is not a directory"),)
+
+    issues: list[StaticSiteValidationIssue] = []
+    required_entries = REQUIRED_ENTRY_ARTIFACTS + (PAGES_ENTRY_ARTIFACTS if require_pages_artifacts else ())
+    for relative_path in required_entries:
+        path = root / relative_path
+        if not path.is_file():
+            issues.append(StaticSiteValidationIssue(path, "missing required static-site entry artifact"))
+
+    for asset in WEB_ASSET_MANIFEST:
+        path = root / asset.repository_path
+        if not path.is_file():
+            issues.append(
+                StaticSiteValidationIssue(
+                    path,
+                    f"missing manifest asset ({asset.mime_type})",
+                )
+            )
+
+    if require_pages_artifacts:
+        for pattern in PAGES_REQUIRED_PATTERNS:
+            if not any(path.is_file() for path in root.glob(pattern)):
+                issues.append(
+                    StaticSiteValidationIssue(
+                        root / pattern,
+                        "no generated artifact matches required Pages pattern",
+                    )
+                )
+
+    return tuple(issues)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Validate a generated CloseSnow static-site artifact.")
+    parser.add_argument("--site-dir", default="site")
+    parser.add_argument(
+        "--require-pages-artifacts",
+        action="store_true",
+        help="Also require .nojekyll and generated resort index/hourly artifacts.",
+    )
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    site_root = Path(args.site_dir).resolve()
+    issues = validate_static_site(site_root, require_pages_artifacts=args.require_pages_artifacts)
+    if issues:
+        for issue in issues:
+            print(issue.render(), file=sys.stderr)
+        return 1
+    print(f"Static site validation passed: {site_root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/web/weather_page_assets.py
+++ b/src/web/weather_page_assets.py
@@ -1,28 +1,10 @@
-#!/usr/bin/env python3
-from __future__ import annotations
+"""Compatibility exports for callers using the historical asset module."""
 
-from pathlib import Path
-from typing import Dict
+from src.web.asset_manifest import ASSET_MIME_TYPES, REPO_ROOT, asset_path, read_asset_bytes
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
-
-ASSET_MIME_TYPES: Dict[str, str] = {
-    "assets/css/weather_page.css": "text/css; charset=utf-8",
-    "assets/js/compact_daily_summary.js": "application/javascript; charset=utf-8",
-    "assets/js/weather_code_emoji.js": "application/javascript; charset=utf-8",
-    "assets/js/weather_filter_state.js": "application/javascript; charset=utf-8",
-    "assets/js/sticky_single_table_layout.js": "application/javascript; charset=utf-8",
-    "assets/js/weather_page_formatters.js": "application/javascript; charset=utf-8",
-    "assets/js/weather_page.js": "application/javascript; charset=utf-8",
-    "assets/css/resort_hourly.css": "text/css; charset=utf-8",
-    "assets/js/resort_hourly_metrics.js": "application/javascript; charset=utf-8",
-    "assets/js/resort_hourly.js": "application/javascript; charset=utf-8",
-}
-
-
-def asset_path(name: str) -> Path:
-    return REPO_ROOT / name
-
-
-def read_asset_bytes(name: str) -> bytes:
-    return asset_path(name).read_bytes()
+__all__ = [
+    "ASSET_MIME_TYPES",
+    "REPO_ROOT",
+    "asset_path",
+    "read_asset_bytes",
+]

--- a/src/web/weather_page_server.py
+++ b/src/web/weather_page_server.py
@@ -26,9 +26,9 @@ from src.backend.services.hourly_options import parse_hour_count
 from src.backend.services.payload_memory_cache import PayloadMemoryCache, frozen_query_params
 from src.contract import WeatherPayloadV1
 from src.shared.cli_options import add_cache_runtime_options, add_server_bind_options
+from src.web.asset_manifest import asset_for_path, read_asset_bytes
 from src.web.data_sources import load_hourly_payload, load_request_payload, strip_server_filter_query
 from src.web.resort_hourly_context import build_resort_daily_summary_context
-from src.web.weather_page_assets import ASSET_MIME_TYPES, read_asset_bytes
 from src.web.weather_page_render_core import render_payload_html
 
 _HOURLY_TEMPLATE = (Path(__file__).resolve().parent / "templates" / "resort_hourly_page.html").read_text(
@@ -146,13 +146,14 @@ def make_handler(
             normalized_path = _normalize_known_path(parsed.path)
 
             asset_name = _asset_name_from_path(parsed.path)
-            if asset_name in ASSET_MIME_TYPES:
+            asset = asset_for_path(asset_name)
+            if asset is not None:
                 try:
-                    body = read_asset_bytes(asset_name)
+                    body = read_asset_bytes(asset.repository_path)
                 except OSError:
                     self._write(404, b"Not Found", "text/plain; charset=utf-8")
                     return
-                self._write(200, body, ASSET_MIME_TYPES[asset_name])
+                self._write(200, body, asset.mime_type)
                 return
 
             if normalized_path == "/api/health":

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import argparse
-import os
 from pathlib import Path
 
 import pytest
@@ -14,6 +13,7 @@ from src.backend.constants import (
     DEFAULT_OPEN_METEO_CACHE_FILE,
 )
 from src.shared.config import DEFAULT_RESORTS_FILE
+from src.web.asset_manifest import WEB_ASSET_MANIFEST
 
 
 def test_build_parser_has_all_commands():
@@ -359,25 +359,24 @@ def test_run_static_server_propagates_missing_directory_when_static_skips_render
         cli.run_static_server(args)
 
 
-def test_copy_static_assets_copies_css_and_js(tmp_path):
-    assets_root = tmp_path / "repo"
-    (assets_root / "assets" / "css").mkdir(parents=True)
-    (assets_root / "assets" / "js").mkdir(parents=True)
-    (assets_root / "assets" / "css" / "weather_page.css").write_text("body{}", encoding="utf-8")
-    (assets_root / "assets" / "js" / "weather_page.js").write_text("console.log('x')", encoding="utf-8")
-    output_dir = assets_root / "site"
-    output_dir.mkdir()
+def test_copy_static_assets_copies_only_manifest_assets_from_non_repo_cwd(tmp_path, monkeypatch):
+    outside_repo = tmp_path / "outside-repo"
+    outside_repo.mkdir()
+    output_dir = tmp_path / "site"
+    monkeypatch.chdir(outside_repo)
 
-    cwd = Path.cwd()
-    try:
-        os.chdir(assets_root)
-        copied = cli.copy_static_assets(str(output_dir))
-    finally:
-        os.chdir(cwd)
+    copied = cli.copy_static_assets(str(output_dir))
 
-    assert copied == [output_dir / "assets" / "css", output_dir / "assets" / "js"]
-    assert (output_dir / "assets" / "css" / "weather_page.css").read_text(encoding="utf-8") == "body{}"
-    assert (output_dir / "assets" / "js" / "weather_page.js").read_text(encoding="utf-8") == "console.log('x')"
+    expected_directories = list(
+        dict.fromkeys((output_dir / Path(asset.repository_path)).parent for asset in WEB_ASSET_MANIFEST)
+    )
+    copied_files = {
+        path.relative_to(output_dir).as_posix() for path in (output_dir / "assets").rglob("*") if path.is_file()
+    }
+    assert copied == expected_directories
+    assert copied_files == {asset.repository_path for asset in WEB_ASSET_MANIFEST}
+    for asset in WEB_ASSET_MANIFEST:
+        assert (output_dir / asset.repository_path).read_bytes() == asset.source_path().read_bytes()
 
 
 def test_run_render_uses_input_parent_when_output_dir_missing(monkeypatch, tmp_path):

--- a/tests/integration/test_static_server.py
+++ b/tests/integration/test_static_server.py
@@ -5,7 +5,12 @@ import threading
 import urllib.request
 from pathlib import Path
 
+import pytest
 from src import cli
+from src.web.asset_manifest import WEB_ASSET_MANIFEST
+from src.web.static_assets import copy_static_assets
+from src.web.static_site_validator import main as validate_static_site_main
+from src.web.static_site_validator import validate_static_site
 
 
 def _start_static_server(site_dir: Path):
@@ -16,6 +21,54 @@ def _start_static_server(site_dir: Path):
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     return server, thread, f"http://{host}:{port}"
+
+
+def _write_valid_pages_site(site_dir: Path) -> None:
+    resort_dir = site_dir / "resort" / "snowbird-ut"
+    resort_dir.mkdir(parents=True)
+    (site_dir / "index.html").write_text("<!doctype html><title>CloseSnow</title>", encoding="utf-8")
+    (site_dir / "data.json").write_text('{"ok":true}', encoding="utf-8")
+    (site_dir / ".nojekyll").touch()
+    (resort_dir / "index.html").write_text("<!doctype html><title>Snowbird</title>", encoding="utf-8")
+    (resort_dir / "hourly.json").write_text('{"hours":0,"hourly":{}}', encoding="utf-8")
+    copy_static_assets(str(site_dir))
+
+
+def test_static_site_validator_accepts_complete_pages_artifact(tmp_path, capsys):
+    site_dir = tmp_path / "site"
+    _write_valid_pages_site(site_dir)
+
+    assert validate_static_site(site_dir, require_pages_artifacts=True) == ()
+    assert validate_static_site_main(["--site-dir", str(site_dir), "--require-pages-artifacts"]) == 0
+    assert "Static site validation passed" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("asset", WEB_ASSET_MANIFEST, ids=lambda asset: asset.repository_path)
+def test_static_site_validator_detects_each_missing_manifest_asset(tmp_path, asset):
+    site_dir = tmp_path / "site"
+    _write_valid_pages_site(site_dir)
+    missing_path = site_dir / asset.repository_path
+    missing_path.unlink()
+
+    issues = validate_static_site(site_dir, require_pages_artifacts=True)
+
+    assert any(issue.path == missing_path and "missing manifest asset" in issue.message for issue in issues)
+
+
+def test_static_site_validator_reports_actionable_required_entry_paths(tmp_path, capsys):
+    site_dir = tmp_path / "site"
+    site_dir.mkdir()
+
+    issues = validate_static_site(site_dir, require_pages_artifacts=True)
+    rendered = {issue.render() for issue in issues}
+
+    assert any(str(site_dir / "index.html") in issue for issue in rendered)
+    assert any(str(site_dir / "data.json") in issue for issue in rendered)
+    assert any(str(site_dir / ".nojekyll") in issue for issue in rendered)
+    assert any(str(site_dir / "resort/*/index.html") in issue for issue in rendered)
+    assert any(str(site_dir / "resort/*/hourly.json") in issue for issue in rendered)
+    assert validate_static_site_main(["--site-dir", str(site_dir), "--require-pages-artifacts"]) == 1
+    assert str(site_dir / "index.html") in capsys.readouterr().err
 
 
 def test_static_server_serves_site_and_resort_routes(tmp_path):

--- a/tests/integration/test_web_server.py
+++ b/tests/integration/test_web_server.py
@@ -8,6 +8,7 @@ import urllib.request
 from http.server import ThreadingHTTPServer
 
 import pytest
+from src.web.asset_manifest import WEB_ASSET_MANIFEST
 from src.web.weather_page_server import make_handler
 
 
@@ -23,6 +24,25 @@ def _hourly_context_from_html(html: str) -> dict:
     match = re.search(r"window\.CLOSESNOW_HOURLY_CONTEXT = (\{.*?\});", html, re.S)
     assert match is not None
     return json.loads(match.group(1))
+
+
+def test_server_serves_every_manifest_asset_with_expected_mime_type():
+    handler = make_handler(
+        cache_file=".cache/x.json",
+        geocode_cache_hours=720,
+        forecast_cache_hours=3,
+        max_workers=2,
+    )
+    server, thread, base = _serve_once(handler)
+    try:
+        for asset in WEB_ASSET_MANIFEST:
+            with urllib.request.urlopen(f"{base}{asset.public_url}", timeout=3) as response:
+                assert response.headers["Content-Type"] == asset.mime_type
+                assert response.read() == asset.source_path().read_bytes()
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=3)
 
 
 def test_server_api_root_and_asset(monkeypatch):

--- a/tests/test_lint_assets.py
+++ b/tests/test_lint_assets.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+from dataclasses import FrozenInstanceError
 from pathlib import Path
 
+import pytest
 from scripts.lint_assets import REPO_ROOT, LintResult
+from src.web.asset_manifest import ASSET_MIME_TYPES, WEB_ASSET_MANIFEST, read_asset_bytes
 
 
 def test_lint_result_renders_relative_path() -> None:
@@ -15,3 +18,34 @@ def test_lint_result_renders_repo_relative_absolute_path() -> None:
     result = LintResult(REPO_ROOT / "assets" / "js" / "weather_page.js", "syntax error")
 
     assert result.render() == "assets/js/weather_page.js: syntax error"
+
+
+def test_web_asset_manifest_covers_repository_browser_assets() -> None:
+    expected_mime_types = {
+        ".css": "text/css; charset=utf-8",
+        ".js": "application/javascript; charset=utf-8",
+    }
+    repository_assets = {
+        path.relative_to(REPO_ROOT).as_posix() for path in (REPO_ROOT / "assets").rglob("*") if path.is_file()
+    }
+    manifest_paths = {asset.repository_path for asset in WEB_ASSET_MANIFEST}
+
+    assert manifest_paths == repository_assets
+    assert len(manifest_paths) == len(WEB_ASSET_MANIFEST)
+    assert set(ASSET_MIME_TYPES) == manifest_paths
+
+    for asset in WEB_ASSET_MANIFEST:
+        source = asset.source_path()
+        assert source.is_file()
+        assert asset.public_url == f"/{asset.repository_path}"
+        assert asset.mime_type == expected_mime_types[source.suffix]
+        assert ASSET_MIME_TYPES[asset.repository_path] == asset.mime_type
+        assert read_asset_bytes(asset.repository_path) == source.read_bytes()
+
+
+def test_web_asset_manifest_and_compatibility_index_are_immutable() -> None:
+    with pytest.raises(FrozenInstanceError):
+        WEB_ASSET_MANIFEST[0].mime_type = "text/plain"  # type: ignore[misc]
+
+    with pytest.raises(TypeError):
+        ASSET_MIME_TYPES["assets/new.js"] = "application/javascript"  # type: ignore[index]


### PR DESCRIPTION
Summary: add an immutable typed asset manifest; drive dynamic serving and static copying from it; add reusable static-site validation; replace partial Pages checks with the validator; preserve compatibility exports. Tests: targeted feature suite 56 passed; full suite 238 passed; ruff and scripts/lint.sh passed.