### PR TITLE
Refactor static site build orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Notes:
 - Generates per-resort hourly HTML routes (`resort/<resort_id>/index.html`)
 - Copies bundled `resort/<resort_id>/hourly.json` files and points each static hourly page at `./hourly.json`
 - Copies and validates the assets declared by the canonical web asset manifest
+- Writes bundle metadata for the rendered `data.json`, so the output directory can be reused as an offline bundle
 
 ### `static`
 
@@ -328,7 +329,8 @@ If output HTML is `site/index.html`, generated artifacts include:
 - `site/resort/<resort_id>/index.html`
 - `site/resort/<resort_id>/hourly.json` (when hourly fetch succeeds)
 - `site/assets/css/*` and `site/assets/js/*` (copied automatically by `render`, `static`, and `serve-static`)
-- `<bundle-root>/.closesnow-static-bundle.json` and `<output-dir>/.closesnow-static-site.json` (builder ownership metadata; both are under `site/` when bundle and render output share that directory)
+- `<bundle-root>/.closesnow-static-bundle.json` (written by fetch and refreshed in every rendered output)
+- `<output-dir>/.closesnow-static-site.json` (rendered route and asset ownership metadata)
 
 ## Payload Contract (`weather_payload_v1`)
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,10 @@ python3 -m src.cli render --input-json site/data.json --output-dir site
 
 Notes:
 
-- `render` generates per-resort hourly HTML routes and sibling `hourly.json` files by default
+- `fetch` writes a complete bundle: the daily JSON, per-resort hourly JSON, and bundle metadata
+- `render` is offline: it only reads that bundle, generates routes, and copies canonical web assets
+- When `--output-dir` differs from the bundle directory, `render` copies the daily payload to
+  `<output-dir>/data.json` and hourly payloads to `<output-dir>/resort/<resort_id>/hourly.json`
 - If you serve `site/` over localhost, resort pages under `site/resort/<resort_id>/` will load from local `hourly.json` instead of requiring `/api/resort-hourly`
 
 ### 3) Coupled dynamic server
@@ -108,7 +111,7 @@ python3 -m src.cli serve-web \
 
 ### `fetch`
 
-Fetch payload and write JSON artifact.
+Fetch daily and hourly payloads and write a reusable static bundle.
 
 ```bash
 python3 -m src.cli fetch \
@@ -123,6 +126,10 @@ python3 -m src.cli fetch \
   [--output-json site/data.json]
 ```
 
+The bundle root is the parent directory of `--output-json`. It contains the requested daily JSON,
+`resort/<resort_id>/hourly.json`, and `.closesnow-static-bundle.json`. Use a distinct parent directory
+for each concurrent fetch so the bundle roots do not overlap.
+
 ### `render`
 
 Render HTML from payload JSON artifact.
@@ -136,9 +143,11 @@ python3 -m src.cli render \
 Notes:
 
 - Validates payload contract before rendering
-- Writes `index.html` into `--output-dir`
+- Performs no backend or network fetches
+- Writes `index.html` and a canonical `data.json` into `--output-dir`
 - Generates per-resort hourly HTML routes (`resort/<resort_id>/index.html`)
-- Also writes sibling `resort/<resort_id>/hourly.json` files and points the static hourly page at `./hourly.json` by default
+- Copies bundled `resort/<resort_id>/hourly.json` files and points each static hourly page at `./hourly.json`
+- Copies and validates the assets declared by the canonical web asset manifest
 
 ### `static`
 
@@ -165,9 +174,9 @@ Notes:
 - `--resort` is repeatable; when set, `--include-all-resorts` is ignored
 - Default `--output-json` resolves to `--output-dir/data.json`
 - `index.html`, `resort/...`, and `assets/...` are written under `--output-dir`
-- `--skip-fetch`: reuse existing JSON
-- `--skip-render`: refresh payload only
-- Static render writes per-resort `hourly.json` files and copies `assets/css` + `assets/js`
+- `--skip-fetch`: reuse an existing offline bundle
+- `--skip-render`: refresh the daily and hourly bundle without rendering
+- Runtime/cache/worker flags affect fetch only; render always consumes files from the bundle
 
 ### `serve`
 
@@ -188,7 +197,7 @@ python3 -m src.cli serve-static [--host 127.0.0.1] [--port 8011] [--directory si
 Notes:
 
 - By default this reuses the `static` workflow and writes `data.json` + `index.html` into the target directory before serving
-- It inherits the static-fetch worker default, so resort fetch/render uses `8` workers unless `--max-workers` is provided
+- It inherits the static-fetch worker default, so daily/hourly fetch uses `8` workers unless `--max-workers` is provided
 - It also copies repo `assets/css` and `assets/js` into `<directory>/assets/`
 - Use `--skip-fetch` or `--skip-render` to reuse existing build artifacts with the same semantics as `static`
 - Directory indexes work as expected, so generated resort pages under `site/resort/<resort_id>/` are reachable directly
@@ -317,8 +326,9 @@ If output HTML is `site/index.html`, generated artifacts include:
 - `site/index.html`
 - `site/data.json` (when chosen as fetch/static output JSON)
 - `site/resort/<resort_id>/index.html`
-- `site/resort/<resort_id>/hourly.json` (when hourly embedding is enabled, e.g. `src.cli static`)
+- `site/resort/<resort_id>/hourly.json` (when hourly fetch succeeds)
 - `site/assets/css/*` and `site/assets/js/*` (copied automatically by `render`, `static`, and `serve-static`)
+- `<bundle-root>/.closesnow-static-bundle.json` and `<output-dir>/.closesnow-static-site.json` (builder ownership metadata; both are under `site/` when bundle and render output share that directory)
 
 ## Payload Contract (`weather_payload_v1`)
 

--- a/docs/CODEBASE_VALIDATION_PLAYBOOK.md
+++ b/docs/CODEBASE_VALIDATION_PLAYBOOK.md
@@ -290,14 +290,15 @@ Pass criteria:
 
 ## 7) Workflow compatibility check
 
-The GitHub Pages workflow currently builds with split static pipeline commands.
+The GitHub Pages workflow currently uses the one-shot static builder for every catalog resort.
 
 Local equivalent:
 
 ```bash
-python3 -m src.cli fetch --output-json site/data.json --max-workers 8
-python3 -m src.cli render --input-json site/data.json --output-dir site
-ls -la site site/assets/css site/assets/js
+python3 -m src.cli static --output-dir site --max-workers 8 --include-all-resorts
+touch site/.nojekyll
+python3 -m src.web.static_site_validator --site-dir site --require-pages-artifacts
+ls -la site site/resort site/assets/css site/assets/js
 ```
 
 Pass criteria:
@@ -305,7 +306,7 @@ Pass criteria:
 1. `site/data.json` and `site/index.html` exist.
 2. Per-resort `index.html` and `hourly.json` files are present in `site/resort/...`.
 3. CSS and JS files are present in `site/assets/...`.
-4. The `render` step does not contact the backend or external APIs.
+4. Strict Pages validation confirms every resort in `data.json` has both `index.html` and `hourly.json`.
 
 ---
 

--- a/docs/CODEBASE_VALIDATION_PLAYBOOK.md
+++ b/docs/CODEBASE_VALIDATION_PLAYBOOK.md
@@ -139,6 +139,7 @@ Pass criteria:
 
 1. Command prints `Done: site/data.json`.
 2. Exit code is 0.
+3. `site/resort/<resort_id>/hourly.json` files and `site/.closesnow-static-bundle.json` are written.
 
 ### 4.2 Render HTML from fetched payload
 
@@ -150,6 +151,7 @@ Pass criteria:
 
 1. Command prints `Done: site/index.html`.
 2. Exit code is 0.
+3. Rendering succeeds with network access disabled because it only consumes the fetched bundle.
 
 ### 4.3 Validate one-shot wrapper still works
 
@@ -165,7 +167,7 @@ Pass criteria:
 ### 4.4 Verify output files exist and are not empty
 
 ```bash
-ls -lh site/data.json site/index.html site/assets/css site/assets/js
+ls -lh site/data.json site/index.html site/resort/*/index.html site/resort/*/hourly.json site/assets/css site/assets/js
 ```
 
 Pass criteria:
@@ -274,14 +276,15 @@ Pass criteria:
 Because backend now uses async orchestration with worker limits, validate at least two worker settings:
 
 ```bash
-python3 -m src.cli fetch --output-json /tmp/worker1.json --max-workers 1
-python3 -m src.cli fetch --output-json /tmp/worker8.json --max-workers 8
+python3 -m src.cli fetch --output-json /tmp/closesnow-worker1/data.json --max-workers 1
+python3 -m src.cli fetch --output-json /tmp/closesnow-worker8/data.json --max-workers 8
 ```
 
 Pass criteria:
 
 1. Both commands succeed.
 2. No crashes around cache or race conditions.
+3. Distinct bundle roots prevent the two runs from sharing per-resort hourly paths.
 
 ---
 
@@ -300,7 +303,9 @@ ls -la site site/assets/css site/assets/js
 Pass criteria:
 
 1. `site/data.json` and `site/index.html` exist.
-2. CSS and JS files are present in `site/assets/...`.
+2. Per-resort `index.html` and `hourly.json` files are present in `site/resort/...`.
+3. CSS and JS files are present in `site/assets/...`.
+4. The `render` step does not contact the backend or external APIs.
 
 ---
 
@@ -316,7 +321,7 @@ Pass criteria:
 
 ## 9) Optional deeper checks (when touching backend request logic)
 
-1. Run static render twice; second run should show more cache hits.
+1. Run static fetch twice; the second fetch should show more cache hits. Render itself does not use the cache.
 2. Confirm no unhandled exceptions in logs.
 3. If changing retry/caching behavior, test with temporary network interruption.
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -7,18 +7,23 @@ import sys
 from functools import partial
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import List, Tuple
 
 if str(Path(__file__).resolve().parents[1]) not in sys.path:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from src.backend.pipelines.static_pipeline import fetch_static_payload
+from src.backend.runtime import WeatherPayloadBuildRequest
 from src.backend.weather_data_server import make_handler as make_data_handler
 from src.shared.cli_options import add_cache_runtime_options, add_resort_options, add_server_bind_options
 from src.shared.config import DATA_API_URL_ENV, DEFAULT_DATA_API_URL
-from src.web.data_sources import load_payload
-from src.web.pipelines import render_hourly_pages, render_html, write_payload_json
-from src.web.static_assets import copy_static_assets
+from src.web.static_site_builder import (
+    StaticBuildRequest,
+    StaticFetchRequest,
+    StaticRenderRequest,
+    build_static_site,
+    fetch_static_bundle,
+    render_static_bundle,
+)
 from src.web.weather_page_server import make_handler
 
 
@@ -83,27 +88,19 @@ def build_parser() -> argparse.ArgumentParser:
     return p
 
 
-def _fetch_payload(args: argparse.Namespace) -> Dict[str, Any]:
+def _payload_build_request(args: argparse.Namespace, *, output_json: str) -> WeatherPayloadBuildRequest:
     resorts, resorts_file, include_all_resorts = _resolve_resorts(args)
-    return fetch_static_payload(
+    return WeatherPayloadBuildRequest.from_legacy_options(
         resorts=resorts,
         resorts_file=resorts_file,
         include_all_resorts=include_all_resorts,
+        output_json=output_json,
         cache_file=args.cache_file,
         geocode_cache_hours=args.geocode_cache_hours,
         forecast_cache_hours=args.forecast_cache_hours,
         max_workers=args.max_workers,
         api_retries=args.api_retries,
     )
-
-
-def _relative_url(from_html_path: str, target_path: str) -> str:
-    from_dir = Path(from_html_path).resolve().parent
-    target = Path(target_path).resolve()
-    rel = os.path.relpath(target, start=from_dir).replace(os.sep, "/")
-    if not rel.startswith("."):
-        return f"./{rel}"
-    return rel
 
 
 def _index_html_for_output_dir(output_dir: str | None, *, input_json: str | None = None) -> str:
@@ -120,7 +117,7 @@ def _static_output_json(args: argparse.Namespace) -> str:
     return str(Path(args.output_dir) / "data.json")
 
 
-def _load_existing_static_payload(output_json: str) -> Dict[str, Any]:
+def _require_existing_static_bundle(output_json: str) -> None:
     path = Path(output_json)
     if not path.exists():
         raise FileNotFoundError(
@@ -128,7 +125,6 @@ def _load_existing_static_payload(output_json: str) -> Dict[str, Any]:
             "The static --skip-fetch command can only render an existing payload. "
             "Run without --skip-fetch to create it, or pass --output-json to an existing JSON file."
         )
-    return load_payload(mode="file", source=output_json)
 
 
 def _serve_http_server(
@@ -150,59 +146,39 @@ def _serve_http_server(
 
 
 def run_fetch(args: argparse.Namespace) -> int:
-    payload = _fetch_payload(args)
-    out = write_payload_json(args.output_json, payload)
-    print(f"Done: {out}")
+    request = StaticFetchRequest(_payload_build_request(args, output_json=args.output_json))
+    result = fetch_static_bundle(request)
+    print(f"Done: {args.output_json}")
+    print(f"Done: {len(result.hourly_json_paths)} resort hourly artifact(s)")
     return 0
 
 
 def run_render(args: argparse.Namespace) -> int:
-    payload = load_payload(mode="file", source=args.input_json)
-    output_html = _index_html_for_output_dir(args.output_dir, input_json=args.input_json)
-    out = render_html(output_html, payload, data_url=_relative_url(output_html, args.input_json))
-    hourly_pages = render_hourly_pages(
-        output_html,
-        payload,
-        hourly_mode="file",
-        hourly_source=args.input_json,
-    )
-    output_dir = str(Path(output_html).parent)
-    copied_assets = copy_static_assets(output_dir)
-    print(f"Done: {out}")
-    print(f"Done: {len(hourly_pages)} resort hourly page(s)")
-    print(f"Done: copied assets -> {', '.join(str(path) for path in copied_assets)}")
+    result = render_static_bundle(StaticRenderRequest(input_json=args.input_json, output_dir=args.output_dir))
+    print(f"Done: {_index_html_for_output_dir(args.output_dir, input_json=args.input_json)}")
+    print(f"Done: {len(result.hourly_page_paths)} resort hourly page(s)")
+    print(f"Done: copied assets -> {', '.join(str(path) for path in result.asset_directories)}")
     return 0
 
 
 def run_static(args: argparse.Namespace) -> int:
     output_json = _static_output_json(args)
-    output_html = _index_html_for_output_dir(args.output_dir)
-    payload: Dict[str, Any] | None = None
-    if not args.skip_fetch:
-        payload = _fetch_payload(args)
-        write_payload_json(output_json, payload)
+    if args.skip_fetch and not args.skip_render:
+        _require_existing_static_bundle(output_json)
+    request = StaticBuildRequest(
+        fetch=StaticFetchRequest(_payload_build_request(args, output_json=output_json)),
+        render=StaticRenderRequest(input_json=output_json, output_dir=args.output_dir),
+        skip_fetch=args.skip_fetch,
+        skip_render=args.skip_render,
+    )
+    result = build_static_site(request)
+    if result.fetch_result is not None:
         print(f"Done: {output_json}")
-
-    if not args.skip_render:
-        if payload is None:
-            payload = _load_existing_static_payload(output_json)
-        out = render_html(output_html, payload, data_url=_relative_url(output_html, output_json))
-        hourly_pages = render_hourly_pages(
-            output_html,
-            payload,
-            include_hourly_data=True,
-            hourly_mode="local",
-            hourly_source="",
-            cache_file=args.cache_file,
-            geocode_cache_hours=args.geocode_cache_hours,
-            forecast_cache_hours=args.forecast_cache_hours,
-            hourly_max_workers=args.max_workers,
-            api_retries=args.api_retries,
-        )
-        print(f"Done: {out}")
-        print(f"Done: {len(hourly_pages)} resort hourly page(s)")
-    copied_assets = copy_static_assets(args.output_dir)
-    print(f"Done: copied assets -> {', '.join(str(path) for path in copied_assets)}")
+        print(f"Done: {len(result.fetch_result.hourly_json_paths)} resort hourly artifact(s)")
+    if result.render_result is not None:
+        print(f"Done: {_index_html_for_output_dir(args.output_dir)}")
+        print(f"Done: {len(result.render_result.hourly_page_paths)} resort hourly page(s)")
+        print("Done: copied assets -> " + ", ".join(str(path) for path in result.render_result.asset_directories))
     return 0
 
 

--- a/src/web/pipelines/static_site.py
+++ b/src/web/pipelines/static_site.py
@@ -13,7 +13,7 @@ from src.web.weather_page_render_core import render_payload_html
 _HOURLY_TEMPLATE = (Path(__file__).resolve().parents[1] / "templates" / "resort_hourly_page.html").read_text(
     encoding="utf-8"
 )
-_RESORT_ARTIFACT_ID_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+_RESORT_ARTIFACT_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
 _RESORT_ARTIFACT_FILENAMES = frozenset({"index.html", "hourly.json"})
 
 

--- a/src/web/pipelines/static_site.py
+++ b/src/web/pipelines/static_site.py
@@ -1,18 +1,10 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
-from typing import Any, Dict, List, Optional
-from urllib.parse import quote
+from typing import Any, Dict, List, Mapping
 
-from src.backend.constants import (
-    API_RETRY_TIMES,
-    DEFAULT_FORECAST_CACHE_HOURS,
-    DEFAULT_GEOCODE_CACHE_HOURS,
-    DEFAULT_MAX_WORKERS,
-    DEFAULT_OPEN_METEO_CACHE_FILE,
-    DEFAULT_STATIC_HOURLY_HOURS,
-)
 from src.contract import WeatherPayloadV1
 from src.contract.hourly_payload import HourlyPayload
 from src.web.resort_hourly_context import build_resort_daily_summary_contexts
@@ -21,6 +13,8 @@ from src.web.weather_page_render_core import render_payload_html
 _HOURLY_TEMPLATE = (Path(__file__).resolve().parents[1] / "templates" / "resort_hourly_page.html").read_text(
     encoding="utf-8"
 )
+_RESORT_ARTIFACT_ID_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+_RESORT_ARTIFACT_FILENAMES = frozenset({"index.html", "hourly.json"})
 
 
 def write_payload_json(path: str, payload: Dict[str, Any]) -> Path:
@@ -37,7 +31,7 @@ def render_html(path: str, payload: WeatherPayloadV1, *, data_url: str = "./data
     return out
 
 
-def _iter_resort_ids(payload: WeatherPayloadV1) -> List[str]:
+def resort_ids_from_payload(payload: WeatherPayloadV1) -> List[str]:
     reports = payload.get("reports")
     if not isinstance(reports, list):
         return []
@@ -54,122 +48,62 @@ def _iter_resort_ids(payload: WeatherPayloadV1) -> List[str]:
     return resort_ids
 
 
-def _build_hourly_payload(
-    *,
-    mode: str,
-    source: str,
-    resort_id: str,
-    hours: int,
-    timeout: int,
-    cache_file: str,
-    geocode_cache_hours: int,
-    forecast_cache_hours: int,
-    api_retries: int,
-) -> Optional[HourlyPayload]:
-    from src.web.data_sources import load_hourly_payload
-
-    code, payload = load_hourly_payload(
-        mode=mode,
-        source=source,
-        resort_id=resort_id,
-        hours=hours,
-        timeout=timeout,
-        cache_file=cache_file,
-        geocode_cache_hours=geocode_cache_hours,
-        forecast_cache_hours=forecast_cache_hours,
-        api_retries=api_retries,
-    )
-    if code != 200 or "error" in payload:
-        return None
-    return payload
+def resort_artifact_dir_name(resort_id: str) -> str:
+    normalized = resort_id.strip()
+    if normalized != resort_id or _RESORT_ARTIFACT_ID_PATTERN.fullmatch(normalized) is None:
+        raise ValueError(f"Invalid resort_id for a static artifact path: {resort_id!r}")
+    return normalized
 
 
-def _build_local_hourly_payloads(
-    *,
-    resort_ids: List[str],
-    hours: int,
-    cache_file: str,
-    geocode_cache_hours: int,
-    forecast_cache_hours: int,
-    max_workers: int,
-    api_retries: int,
-) -> Dict[str, HourlyPayload | None]:
-    from src.backend.services.hourly_payload_service import build_hourly_payloads_for_resorts
-
-    return build_hourly_payloads_for_resorts(
-        resort_ids=resort_ids,
-        hours=hours,
-        cache_file=cache_file,
-        geocode_cache_hours=geocode_cache_hours,
-        forecast_cache_hours=forecast_cache_hours,
-        max_workers=max_workers,
-        api_retries=api_retries,
-    )
+def resort_artifact_path(root: str | Path, resort_id: str, filename: str) -> Path:
+    if filename not in _RESORT_ARTIFACT_FILENAMES:
+        raise ValueError(f"Unsupported static resort artifact filename: {filename!r}")
+    root_path = Path(root).resolve()
+    resort_root = root_path / "resort"
+    artifact_dir = resort_root / resort_artifact_dir_name(resort_id)
+    candidate = artifact_dir / filename
+    if resort_root.is_symlink() or artifact_dir.is_symlink() or candidate.is_symlink():
+        raise ValueError(f"Static resort artifact path must not contain symlinks: {candidate}")
+    resolved_candidate = candidate.resolve(strict=False)
+    try:
+        resolved_candidate.relative_to(root_path)
+    except ValueError as exc:
+        raise ValueError(f"Static resort artifact path escapes its selected root: {candidate}") from exc
+    return candidate
 
 
 def render_hourly_pages(
     index_html_path: str,
     payload: WeatherPayloadV1,
     *,
-    include_hourly_data: bool = True,
-    hourly_mode: str = "local",
-    hourly_source: str = "",
-    hourly_timeout: int = 20,
-    hourly_hours: int = DEFAULT_STATIC_HOURLY_HOURS,
-    cache_file: str = DEFAULT_OPEN_METEO_CACHE_FILE,
-    geocode_cache_hours: int = DEFAULT_GEOCODE_CACHE_HOURS,
-    forecast_cache_hours: int = DEFAULT_FORECAST_CACHE_HOURS,
-    hourly_max_workers: int = DEFAULT_MAX_WORKERS,
-    api_retries: int = API_RETRY_TIMES,
+    hourly_payloads: Mapping[str, HourlyPayload | None] | None = None,
 ) -> List[Path]:
+    """Render resort routes from already-fetched data without backend or network access."""
     site_root = Path(index_html_path).parent
     outputs: List[Path] = []
-    resort_ids = _iter_resort_ids(payload)
+    resort_ids = resort_ids_from_payload(payload)
     daily_summary_by_resort = build_resort_daily_summary_contexts(payload)
-    local_hourly_payloads: Dict[str, HourlyPayload | None] | None = None
-    if include_hourly_data and hourly_mode == "local":
-        local_hourly_payloads = _build_local_hourly_payloads(
-            resort_ids=resort_ids,
-            hours=hourly_hours,
-            cache_file=cache_file,
-            geocode_cache_hours=geocode_cache_hours,
-            forecast_cache_hours=forecast_cache_hours,
-            max_workers=hourly_max_workers,
-            api_retries=api_retries,
-        )
+    available_hourly = hourly_payloads or {}
 
     for resort_id in resort_ids:
-        encoded_id = quote(resort_id)
-        out_dir = site_root / "resort" / encoded_id
-        out = out_dir / "index.html"
+        out = resort_artifact_path(site_root, resort_id, "index.html")
+        out_dir = out.parent
+        hourly_data_path = resort_artifact_path(site_root, resort_id, "hourly.json")
         out_dir.mkdir(parents=True, exist_ok=True)
 
         hourly_context: Dict[str, Any] = {"resortId": resort_id}
         daily_summary = daily_summary_by_resort.get(resort_id)
         if daily_summary:
             hourly_context["dailySummary"] = daily_summary
-        if include_hourly_data:
-            if local_hourly_payloads is not None:
-                hourly_payload = local_hourly_payloads.get(resort_id)
-            else:
-                hourly_payload = _build_hourly_payload(
-                    mode=hourly_mode,
-                    source=hourly_source,
-                    resort_id=resort_id,
-                    hours=hourly_hours,
-                    timeout=hourly_timeout,
-                    cache_file=cache_file,
-                    geocode_cache_hours=geocode_cache_hours,
-                    forecast_cache_hours=forecast_cache_hours,
-                    api_retries=api_retries,
-                )
-            if isinstance(hourly_payload, dict) and "error" not in hourly_payload:
-                hourly_data_path = out_dir / "hourly.json"
-                hourly_data_path.write_text(
-                    json.dumps(hourly_payload, ensure_ascii=False, indent=2),
-                    encoding="utf-8",
-                )
-                hourly_context["hourlyDataUrl"] = "./hourly.json"
+        hourly_payload = available_hourly.get(resort_id)
+        if isinstance(hourly_payload, dict) and "error" not in hourly_payload:
+            hourly_data_path.write_text(
+                json.dumps(hourly_payload, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+            hourly_context["hourlyDataUrl"] = "./hourly.json"
+        elif hourly_data_path.is_file():
+            hourly_data_path.unlink()
 
         html = (
             _HOURLY_TEMPLATE.replace("{{asset_prefix}}", "../../assets")

--- a/src/web/static_site_builder.py
+++ b/src/web/static_site_builder.py
@@ -1,0 +1,411 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Mapping, Optional
+
+from src.backend.constants import DEFAULT_STATIC_HOURLY_HOURS
+from src.backend.runtime import WeatherPayloadBuildRequest
+from src.backend.services.hourly_payload_service import build_hourly_payloads_for_resorts
+from src.backend.services.weather_service import build_weather_payload_for_request
+from src.contract import HourlyPayload, WeatherPayloadV1
+from src.web.asset_manifest import WEB_ASSET_MANIFEST
+from src.web.data_sources.static_json_source import load_static_payload
+from src.web.pipelines.static_site import (
+    render_hourly_pages,
+    render_html,
+    resort_artifact_dir_name,
+    resort_artifact_path,
+    resort_ids_from_payload,
+)
+from src.web.static_assets import copy_static_assets
+from src.web.static_site_validator import validate_static_site
+
+BUNDLE_MANIFEST_FILENAME = ".closesnow-static-bundle.json"
+SITE_MANIFEST_FILENAME = ".closesnow-static-site.json"
+_BUNDLE_SCHEMA = "closesnow_static_bundle_v1"
+_SITE_SCHEMA = "closesnow_static_site_v1"
+
+
+@dataclass(frozen=True)
+class StaticFetchRequest:
+    payload_request: WeatherPayloadBuildRequest
+    hourly_hours: int = DEFAULT_STATIC_HOURLY_HOURS
+
+    def __post_init__(self) -> None:
+        if self.hourly_hours <= 0:
+            raise ValueError("Static hourly hours must be greater than zero")
+
+
+@dataclass(frozen=True)
+class StaticRenderRequest:
+    input_json: str
+    output_dir: Optional[str] = None
+
+    @property
+    def resolved_output_dir(self) -> Path:
+        if self.output_dir:
+            return Path(self.output_dir).resolve()
+        return Path(self.input_json).resolve().parent
+
+
+@dataclass(frozen=True)
+class StaticBuildRequest:
+    fetch: StaticFetchRequest
+    render: StaticRenderRequest
+    skip_fetch: bool = False
+    skip_render: bool = False
+
+    def __post_init__(self) -> None:
+        fetch_output = Path(self.fetch.payload_request.output_json).resolve()
+        render_input = Path(self.render.input_json).resolve()
+        if fetch_output != render_input:
+            raise ValueError("Static fetch output_json and render input_json must identify the same bundle")
+
+
+@dataclass(frozen=True)
+class StaticBundle:
+    payload: WeatherPayloadV1
+    input_json: Path
+    manifest_path: Optional[Path]
+    hourly_payloads: Mapping[str, HourlyPayload | None]
+    missing_hourly_resort_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class StaticFetchResult:
+    bundle: StaticBundle
+    hourly_json_paths: tuple[Path, ...]
+
+
+@dataclass(frozen=True)
+class StaticRenderResult:
+    index_html: Path
+    output_json: Path
+    hourly_page_paths: tuple[Path, ...]
+    hourly_json_paths: tuple[Path, ...]
+    asset_directories: tuple[Path, ...]
+
+
+@dataclass(frozen=True)
+class StaticBuildResult:
+    fetch_result: Optional[StaticFetchResult]
+    render_result: Optional[StaticRenderResult]
+
+
+@dataclass(frozen=True)
+class _BundleManifest:
+    daily_json: str
+    hourly_hours: int
+    hourly_paths: Mapping[str, str]
+
+
+def _atomic_write_json(path: Path, payload: Mapping[str, Any]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path: Optional[Path] = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temporary:
+            temporary_path = Path(temporary.name)
+            json.dump(payload, temporary, ensure_ascii=False, indent=2)
+            temporary.write("\n")
+            temporary.flush()
+            os.fsync(temporary.fileno())
+        os.replace(temporary_path, path)
+    finally:
+        if temporary_path is not None and temporary_path.exists():
+            temporary_path.unlink()
+    return path
+
+
+def _hourly_relative_path(resort_id: str) -> str:
+    return f"resort/{resort_artifact_dir_name(resort_id)}/hourly.json"
+
+
+def _hourly_path(root: Path, resort_id: str) -> Path:
+    return resort_artifact_path(root, resort_id, "hourly.json")
+
+
+def _bundle_manifest_path(input_json: Path) -> Path:
+    return input_json.parent / BUNDLE_MANIFEST_FILENAME
+
+
+def _site_manifest_path(output_dir: Path) -> Path:
+    return output_dir / SITE_MANIFEST_FILENAME
+
+
+def _is_hourly_payload(payload: Any) -> bool:
+    return isinstance(payload, dict) and "error" not in payload and isinstance(payload.get("hourly"), dict)
+
+
+def _validated_resort_ids(payload: WeatherPayloadV1) -> list[str]:
+    resort_ids = resort_ids_from_payload(payload)
+    for resort_id in resort_ids:
+        resort_artifact_dir_name(resort_id)
+    return resort_ids
+
+
+def _read_bundle_manifest(path: Path, *, expected_daily_json: Optional[str] = None) -> Optional[_BundleManifest]:
+    if not path.is_file():
+        return None
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict) or raw.get("schema_version") != _BUNDLE_SCHEMA:
+        raise ValueError(f"Invalid static bundle manifest: {path}")
+    daily_json = raw.get("daily_json")
+    hourly_hours = raw.get("hourly_hours")
+    hourly_paths = raw.get("hourly")
+    if not isinstance(daily_json, str) or not isinstance(hourly_hours, int) or hourly_hours <= 0:
+        raise ValueError(f"Invalid static bundle manifest metadata: {path}")
+    if expected_daily_json is not None and daily_json != expected_daily_json:
+        raise ValueError(f"Static bundle manifest {path} belongs to {daily_json}, not {expected_daily_json}")
+    if not isinstance(hourly_paths, dict):
+        raise ValueError(f"Invalid static bundle hourly map: {path}")
+    normalized: dict[str, str] = {}
+    for raw_resort_id, raw_relative_path in hourly_paths.items():
+        if not isinstance(raw_resort_id, str) or not raw_resort_id.strip() or not isinstance(raw_relative_path, str):
+            raise ValueError(f"Invalid static bundle hourly entry: {path}")
+        resort_id = raw_resort_id.strip()
+        expected_path = _hourly_relative_path(resort_id)
+        if raw_relative_path != expected_path:
+            raise ValueError(f"Unsafe static bundle hourly path for {resort_id}: {raw_relative_path}")
+        normalized[resort_id] = raw_relative_path
+    return _BundleManifest(
+        daily_json=daily_json,
+        hourly_hours=hourly_hours,
+        hourly_paths=MappingProxyType(normalized),
+    )
+
+
+def _try_load_previous_payload(path: Path) -> Optional[WeatherPayloadV1]:
+    if not path.is_file():
+        return None
+    try:
+        return load_static_payload(str(path))
+    except (OSError, UnicodeDecodeError, ValueError, TypeError):
+        return None
+
+
+def _try_read_previous_bundle_manifest(path: Path) -> Optional[_BundleManifest]:
+    try:
+        return _read_bundle_manifest(path)
+    except (OSError, UnicodeDecodeError, ValueError, TypeError):
+        return None
+
+
+def _unlink_owned_file(path: Path) -> None:
+    if path.is_file() or path.is_symlink():
+        path.unlink()
+    parent = path.parent
+    if parent.is_dir():
+        try:
+            parent.rmdir()
+        except OSError:
+            pass
+
+
+def fetch_static_bundle(request: StaticFetchRequest) -> StaticFetchResult:
+    """Fetch daily and hourly data once and persist a self-describing static bundle."""
+    output_json = Path(request.payload_request.output_json).resolve()
+    bundle_root = output_json.parent
+    manifest_path = _bundle_manifest_path(output_json)
+    previous_payload = _try_load_previous_payload(output_json)
+    previous_manifest = _try_read_previous_bundle_manifest(manifest_path)
+
+    payload = build_weather_payload_for_request(request.payload_request)
+    resort_ids = _validated_resort_ids(payload)
+    runtime = request.payload_request.runtime
+    fetched_hourly = build_hourly_payloads_for_resorts(
+        resort_ids=resort_ids,
+        hours=request.hourly_hours,
+        cache_file=runtime.cache_file,
+        geocode_cache_hours=runtime.geocode_cache_hours,
+        forecast_cache_hours=runtime.forecast_cache_hours,
+        max_workers=runtime.max_workers,
+        api_retries=runtime.api_retries,
+    )
+    hourly_payloads: dict[str, HourlyPayload | None] = {}
+    for resort_id in resort_ids:
+        hourly_payload = fetched_hourly.get(resort_id)
+        hourly_payloads[resort_id] = hourly_payload if _is_hourly_payload(hourly_payload) else None
+
+    previously_owned_ids: set[str] = set()
+    if previous_payload is not None:
+        previously_owned_ids.update(_validated_resort_ids(previous_payload))
+    if previous_manifest is not None:
+        previously_owned_ids.update(previous_manifest.hourly_paths)
+
+    successful_ids = {resort_id for resort_id, item in hourly_payloads.items() if item is not None}
+    for resort_id in previously_owned_ids.union(resort_ids).difference(successful_ids):
+        _unlink_owned_file(_hourly_path(bundle_root, resort_id))
+
+    hourly_paths: list[Path] = []
+    manifest_hourly: dict[str, str] = {}
+    for resort_id in resort_ids:
+        hourly_payload = hourly_payloads[resort_id]
+        if hourly_payload is None:
+            continue
+        hourly_path = _hourly_path(bundle_root, resort_id)
+        _atomic_write_json(hourly_path, hourly_payload)
+        hourly_paths.append(hourly_path)
+        manifest_hourly[resort_id] = _hourly_relative_path(resort_id)
+
+    _atomic_write_json(output_json, payload)
+    missing_ids = tuple(resort_id for resort_id in resort_ids if resort_id not in successful_ids)
+    _atomic_write_json(
+        manifest_path,
+        {
+            "schema_version": _BUNDLE_SCHEMA,
+            "daily_json": output_json.name,
+            "hourly_hours": request.hourly_hours,
+            "hourly": manifest_hourly,
+            "missing_hourly": list(missing_ids),
+        },
+    )
+    bundle = StaticBundle(
+        payload=payload,
+        input_json=output_json,
+        manifest_path=manifest_path,
+        hourly_payloads=MappingProxyType(hourly_payloads),
+        missing_hourly_resort_ids=missing_ids,
+    )
+    return StaticFetchResult(bundle=bundle, hourly_json_paths=tuple(hourly_paths))
+
+
+def load_static_bundle(input_json: str) -> StaticBundle:
+    """Load a static bundle from disk. This function performs file I/O only."""
+    daily_path = Path(input_json).resolve()
+    payload = load_static_payload(str(daily_path))
+    resort_ids = _validated_resort_ids(payload)
+    manifest_path = _bundle_manifest_path(daily_path)
+    manifest = _read_bundle_manifest(manifest_path, expected_daily_json=daily_path.name)
+    hourly_payloads: dict[str, HourlyPayload | None] = {}
+
+    if manifest is None:
+        candidate_ids = resort_ids
+    else:
+        candidate_ids = [resort_id for resort_id in resort_ids if resort_id in manifest.hourly_paths]
+
+    for resort_id in resort_ids:
+        hourly_payloads[resort_id] = None
+    for resort_id in candidate_ids:
+        hourly_path = _hourly_path(daily_path.parent, resort_id)
+        try:
+            hourly_payload = json.loads(hourly_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, ValueError, TypeError):
+            continue
+        if _is_hourly_payload(hourly_payload):
+            hourly_payloads[resort_id] = hourly_payload
+
+    missing_ids = tuple(resort_id for resort_id in resort_ids if hourly_payloads[resort_id] is None)
+    return StaticBundle(
+        payload=payload,
+        input_json=daily_path,
+        manifest_path=manifest_path if manifest is not None else None,
+        hourly_payloads=MappingProxyType(hourly_payloads),
+        missing_hourly_resort_ids=missing_ids,
+    )
+
+
+def _read_owned_site_resort_ids(output_dir: Path) -> tuple[str, ...]:
+    path = _site_manifest_path(output_dir)
+    if not path.is_file():
+        return ()
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, ValueError, TypeError):
+        return ()
+    if not isinstance(raw, dict) or raw.get("schema_version") != _SITE_SCHEMA:
+        return ()
+    resort_ids = raw.get("resort_ids")
+    if not isinstance(resort_ids, list) or not all(isinstance(item, str) for item in resort_ids):
+        return ()
+    return tuple(dict.fromkeys(item.strip() for item in resort_ids if item.strip()))
+
+
+def _cleanup_stale_site_routes(output_dir: Path, previous_ids: set[str], current_ids: set[str]) -> None:
+    for resort_id in previous_ids.difference(current_ids):
+        _unlink_owned_file(resort_artifact_path(output_dir, resort_id, "index.html"))
+        _unlink_owned_file(resort_artifact_path(output_dir, resort_id, "hourly.json"))
+
+
+def render_static_bundle(request: StaticRenderRequest) -> StaticRenderResult:
+    """Render a complete static site from a bundle without backend or network access."""
+    bundle = load_static_bundle(request.input_json)
+    output_dir = request.resolved_output_dir
+    output_json = output_dir / "data.json"
+    previous_payload = _try_load_previous_payload(output_json)
+    previous_ids = set(_read_owned_site_resort_ids(output_dir))
+    if previous_payload is not None:
+        previous_ids.update(_validated_resort_ids(previous_payload))
+    current_resort_ids = _validated_resort_ids(bundle.payload)
+    current_ids = set(current_resort_ids)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _cleanup_stale_site_routes(output_dir, previous_ids, current_ids)
+    _atomic_write_json(output_json, bundle.payload)
+    index_html = render_html(str(output_dir / "index.html"), bundle.payload, data_url="./data.json")
+    hourly_pages = render_hourly_pages(
+        str(index_html),
+        bundle.payload,
+        hourly_payloads=bundle.hourly_payloads,
+    )
+    asset_directories = copy_static_assets(str(output_dir))
+
+    issues = validate_static_site(output_dir)
+    if issues:
+        rendered_issues = "; ".join(issue.render() for issue in issues)
+        raise RuntimeError(f"Generated static site failed validation: {rendered_issues}")
+
+    _atomic_write_json(
+        _site_manifest_path(output_dir),
+        {
+            "schema_version": _SITE_SCHEMA,
+            "resort_ids": current_resort_ids,
+            "assets": [asset.repository_path for asset in WEB_ASSET_MANIFEST],
+        },
+    )
+    hourly_json_paths = tuple(
+        _hourly_path(output_dir, resort_id)
+        for resort_id in current_resort_ids
+        if bundle.hourly_payloads.get(resort_id) is not None
+    )
+    return StaticRenderResult(
+        index_html=index_html,
+        output_json=output_json,
+        hourly_page_paths=tuple(hourly_pages),
+        hourly_json_paths=hourly_json_paths,
+        asset_directories=tuple(asset_directories),
+    )
+
+
+def build_static_site(request: StaticBuildRequest) -> StaticBuildResult:
+    fetch_result = None if request.skip_fetch else fetch_static_bundle(request.fetch)
+    render_result = None if request.skip_render else render_static_bundle(request.render)
+    return StaticBuildResult(fetch_result=fetch_result, render_result=render_result)
+
+
+__all__ = [
+    "BUNDLE_MANIFEST_FILENAME",
+    "SITE_MANIFEST_FILENAME",
+    "StaticBuildRequest",
+    "StaticBuildResult",
+    "StaticBundle",
+    "StaticFetchRequest",
+    "StaticFetchResult",
+    "StaticRenderRequest",
+    "StaticRenderResult",
+    "build_static_site",
+    "fetch_static_bundle",
+    "load_static_bundle",
+    "render_static_bundle",
+]

--- a/src/web/static_site_builder.py
+++ b/src/web/static_site_builder.py
@@ -4,7 +4,7 @@ import json
 import os
 import tempfile
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from types import MappingProxyType
 from typing import Any, Mapping, Optional
 
@@ -13,6 +13,7 @@ from src.backend.runtime import WeatherPayloadBuildRequest
 from src.backend.services.hourly_payload_service import build_hourly_payloads_for_resorts
 from src.backend.services.weather_service import build_weather_payload_for_request
 from src.contract import HourlyPayload, WeatherPayloadV1
+from src.contract.hourly_payload import HOURLY_METRIC_KEYS
 from src.web.asset_manifest import WEB_ASSET_MANIFEST
 from src.web.data_sources.static_json_source import load_static_payload
 from src.web.pipelines.static_site import (
@@ -74,6 +75,7 @@ class StaticBundle:
     manifest_path: Optional[Path]
     hourly_payloads: Mapping[str, HourlyPayload | None]
     missing_hourly_resort_ids: tuple[str, ...]
+    hourly_hours: int
 
 
 @dataclass(frozen=True)
@@ -102,6 +104,12 @@ class _BundleManifest:
     daily_json: str
     hourly_hours: int
     hourly_paths: Mapping[str, str]
+
+
+@dataclass(frozen=True)
+class _SiteManifest:
+    resort_ids: tuple[str, ...] = ()
+    asset_paths: tuple[str, ...] = ()
 
 
 def _atomic_write_json(path: Path, payload: Mapping[str, Any]) -> Path:
@@ -144,8 +152,27 @@ def _site_manifest_path(output_dir: Path) -> Path:
     return output_dir / SITE_MANIFEST_FILENAME
 
 
-def _is_hourly_payload(payload: Any) -> bool:
-    return isinstance(payload, dict) and "error" not in payload and isinstance(payload.get("hourly"), dict)
+def _is_hourly_payload(payload: Any, resort_id: str) -> bool:
+    if not isinstance(payload, dict) or "error" in payload or payload.get("resort_id") != resort_id:
+        return False
+    hourly = payload.get("hourly")
+    if not isinstance(hourly, dict):
+        return False
+    times = hourly.get("time")
+    if not isinstance(times, list) or not all(isinstance(item, str) for item in times):
+        return False
+    hours = payload.get("hours")
+    if not isinstance(hours, int) or isinstance(hours, bool) or hours != len(times):
+        return False
+    for key in HOURLY_METRIC_KEYS:
+        values = hourly.get(key)
+        if not isinstance(values, list) or len(values) != len(times):
+            return False
+        if any(
+            value is not None and (not isinstance(value, (int, float)) or isinstance(value, bool)) for value in values
+        ):
+            return False
+    return True
 
 
 def _validated_resort_ids(payload: WeatherPayloadV1) -> list[str]:
@@ -236,7 +263,7 @@ def fetch_static_bundle(request: StaticFetchRequest) -> StaticFetchResult:
     hourly_payloads: dict[str, HourlyPayload | None] = {}
     for resort_id in resort_ids:
         hourly_payload = fetched_hourly.get(resort_id)
-        hourly_payloads[resort_id] = hourly_payload if _is_hourly_payload(hourly_payload) else None
+        hourly_payloads[resort_id] = hourly_payload if _is_hourly_payload(hourly_payload, resort_id) else None
 
     previously_owned_ids: set[str] = set()
     if previous_payload is not None:
@@ -277,6 +304,7 @@ def fetch_static_bundle(request: StaticFetchRequest) -> StaticFetchResult:
         manifest_path=manifest_path,
         hourly_payloads=MappingProxyType(hourly_payloads),
         missing_hourly_resort_ids=missing_ids,
+        hourly_hours=request.hourly_hours,
     )
     return StaticFetchResult(bundle=bundle, hourly_json_paths=tuple(hourly_paths))
 
@@ -303,7 +331,7 @@ def load_static_bundle(input_json: str) -> StaticBundle:
             hourly_payload = json.loads(hourly_path.read_text(encoding="utf-8"))
         except (OSError, UnicodeDecodeError, ValueError, TypeError):
             continue
-        if _is_hourly_payload(hourly_payload):
+        if _is_hourly_payload(hourly_payload, resort_id):
             hourly_payloads[resort_id] = hourly_payload
 
     missing_ids = tuple(resort_id for resort_id in resort_ids if hourly_payloads[resort_id] is None)
@@ -313,23 +341,73 @@ def load_static_bundle(input_json: str) -> StaticBundle:
         manifest_path=manifest_path if manifest is not None else None,
         hourly_payloads=MappingProxyType(hourly_payloads),
         missing_hourly_resort_ids=missing_ids,
+        hourly_hours=manifest.hourly_hours if manifest is not None else DEFAULT_STATIC_HOURLY_HOURS,
     )
 
 
-def _read_owned_site_resort_ids(output_dir: Path) -> tuple[str, ...]:
+def _normalize_owned_asset_path(raw_path: str) -> Optional[str]:
+    parsed = PurePosixPath(raw_path)
+    if (
+        parsed.is_absolute()
+        or not parsed.parts
+        or parsed.parts[0] != "assets"
+        or ".." in parsed.parts
+        or str(parsed) != raw_path
+    ):
+        return None
+    return raw_path
+
+
+def _read_owned_site_manifest(output_dir: Path) -> _SiteManifest:
     path = _site_manifest_path(output_dir)
     if not path.is_file():
-        return ()
+        return _SiteManifest()
     try:
         raw = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, UnicodeDecodeError, ValueError, TypeError):
-        return ()
+        return _SiteManifest()
     if not isinstance(raw, dict) or raw.get("schema_version") != _SITE_SCHEMA:
-        return ()
+        return _SiteManifest()
     resort_ids = raw.get("resort_ids")
     if not isinstance(resort_ids, list) or not all(isinstance(item, str) for item in resort_ids):
-        return ()
-    return tuple(dict.fromkeys(item.strip() for item in resort_ids if item.strip()))
+        resort_ids = []
+    asset_paths = raw.get("assets")
+    if not isinstance(asset_paths, list) or not all(isinstance(item, str) for item in asset_paths):
+        asset_paths = []
+    normalized_assets = [
+        normalized for item in asset_paths if (normalized := _normalize_owned_asset_path(item)) is not None
+    ]
+    return _SiteManifest(
+        resort_ids=tuple(dict.fromkeys(item.strip() for item in resort_ids if item.strip())),
+        asset_paths=tuple(dict.fromkeys(normalized_assets)),
+    )
+
+
+def _asset_artifact_path(output_dir: Path, relative_path: str) -> Path:
+    normalized = _normalize_owned_asset_path(relative_path)
+    if normalized is None:
+        raise ValueError(f"Invalid owned static asset path: {relative_path!r}")
+    root = output_dir.resolve()
+    candidate = root.joinpath(*PurePosixPath(normalized).parts)
+    cursor = root
+    for part in PurePosixPath(normalized).parts:
+        cursor /= part
+        if cursor.is_symlink():
+            raise ValueError(f"Static asset path must not contain symlinks: {candidate}")
+    try:
+        candidate.resolve(strict=False).relative_to(root)
+    except ValueError as exc:
+        raise ValueError(f"Static asset path escapes its selected root: {candidate}") from exc
+    return candidate
+
+
+def _cleanup_stale_assets(output_dir: Path, previous_paths: set[str], current_paths: set[str]) -> None:
+    for relative_path in previous_paths.difference(current_paths):
+        try:
+            path = _asset_artifact_path(output_dir, relative_path)
+        except ValueError:
+            continue
+        _unlink_owned_file(path)
 
 
 def _cleanup_stale_site_routes(output_dir: Path, previous_ids: set[str], current_ids: set[str]) -> None:
@@ -344,14 +422,19 @@ def render_static_bundle(request: StaticRenderRequest) -> StaticRenderResult:
     output_dir = request.resolved_output_dir
     output_json = output_dir / "data.json"
     previous_payload = _try_load_previous_payload(output_json)
-    previous_ids = set(_read_owned_site_resort_ids(output_dir))
+    previous_site_manifest = _read_owned_site_manifest(output_dir)
+    previous_ids = set(previous_site_manifest.resort_ids)
     if previous_payload is not None:
         previous_ids.update(_validated_resort_ids(previous_payload))
     current_resort_ids = _validated_resort_ids(bundle.payload)
     current_ids = set(current_resort_ids)
+    current_asset_paths = {asset.repository_path for asset in WEB_ASSET_MANIFEST}
 
     output_dir.mkdir(parents=True, exist_ok=True)
+    for relative_path in current_asset_paths:
+        _asset_artifact_path(output_dir, relative_path)
     _cleanup_stale_site_routes(output_dir, previous_ids, current_ids)
+    _cleanup_stale_assets(output_dir, set(previous_site_manifest.asset_paths), current_asset_paths)
     _atomic_write_json(output_json, bundle.payload)
     index_html = render_html(str(output_dir / "index.html"), bundle.payload, data_url="./data.json")
     hourly_pages = render_hourly_pages(
@@ -366,6 +449,21 @@ def render_static_bundle(request: StaticRenderRequest) -> StaticRenderResult:
         rendered_issues = "; ".join(issue.render() for issue in issues)
         raise RuntimeError(f"Generated static site failed validation: {rendered_issues}")
 
+    rendered_hourly = {
+        resort_id: _hourly_relative_path(resort_id)
+        for resort_id in current_resort_ids
+        if bundle.hourly_payloads.get(resort_id) is not None
+    }
+    _atomic_write_json(
+        _bundle_manifest_path(output_json),
+        {
+            "schema_version": _BUNDLE_SCHEMA,
+            "daily_json": output_json.name,
+            "hourly_hours": bundle.hourly_hours,
+            "hourly": rendered_hourly,
+            "missing_hourly": [resort_id for resort_id in current_resort_ids if resort_id not in rendered_hourly],
+        },
+    )
     _atomic_write_json(
         _site_manifest_path(output_dir),
         {

--- a/src/web/static_site_validator.py
+++ b/src/web/static_site_validator.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Final, Optional, Sequence
 
 from src.web.asset_manifest import WEB_ASSET_MANIFEST
+from src.web.pipelines.static_site import resort_artifact_path
 
 REQUIRED_ENTRY_ARTIFACTS: Final[tuple[str, ...]] = ("index.html", "data.json")
 PAGES_ENTRY_ARTIFACTS: Final[tuple[str, ...]] = (".nojekyll",)
@@ -23,6 +25,64 @@ class StaticSiteValidationIssue:
 
     def render(self) -> str:
         return f"{self.path}: {self.message}"
+
+
+def _pages_resort_ids(root: Path, issues: list[StaticSiteValidationIssue]) -> tuple[str, ...]:
+    data_path = root / "data.json"
+    if not data_path.is_file():
+        return ()
+    try:
+        payload = json.loads(data_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, ValueError, TypeError) as exc:
+        issues.append(StaticSiteValidationIssue(data_path, f"invalid Pages payload JSON: {exc}"))
+        return ()
+    reports = payload.get("reports") if isinstance(payload, dict) else None
+    if not isinstance(reports, list):
+        issues.append(StaticSiteValidationIssue(data_path, "Pages payload must contain a reports list"))
+        return ()
+    resort_ids: list[str] = []
+    seen: set[str] = set()
+    for index, report in enumerate(reports):
+        resort_id = report.get("resort_id") if isinstance(report, dict) else None
+        if not isinstance(resort_id, str) or not resort_id:
+            issues.append(
+                StaticSiteValidationIssue(
+                    data_path,
+                    f"reports[{index}] must contain a non-empty resort_id for Pages artifacts",
+                )
+            )
+            continue
+        try:
+            resort_artifact_path(root, resort_id, "index.html")
+        except ValueError as exc:
+            issues.append(StaticSiteValidationIssue(data_path, f"reports[{index}] has unsafe resort_id: {exc}"))
+            continue
+        if resort_id not in seen:
+            seen.add(resort_id)
+            resort_ids.append(resort_id)
+    return tuple(resort_ids)
+
+
+def _validate_pages_resort_artifacts(root: Path, issues: list[StaticSiteValidationIssue]) -> None:
+    for resort_id in _pages_resort_ids(root, issues):
+        for filename in ("index.html", "hourly.json"):
+            try:
+                path = resort_artifact_path(root, resort_id, filename)
+            except ValueError as exc:
+                issues.append(
+                    StaticSiteValidationIssue(
+                        root / "resort" / resort_id / filename,
+                        f"unsafe Pages artifact path: {exc}",
+                    )
+                )
+                continue
+            if not path.is_file():
+                issues.append(
+                    StaticSiteValidationIssue(
+                        path,
+                        f"missing Pages artifact for resort_id {resort_id}",
+                    )
+                )
 
 
 def validate_static_site(
@@ -60,6 +120,7 @@ def validate_static_site(
                         "no generated artifact matches required Pages pattern",
                     )
                 )
+        _validate_pages_resort_artifacts(root, issues)
 
     return tuple(issues)
 

--- a/src/web/weather_html_renderer.py
+++ b/src/web/weather_html_renderer.py
@@ -18,6 +18,20 @@ _PAGE_SHELL_PLACEHOLDER = """
 """
 
 
+def _payload_generated_utc(initial_payload: Dict[str, Any] | None) -> str | None:
+    raw_value = initial_payload.get("generated_at_utc") if isinstance(initial_payload, dict) else None
+    if not isinstance(raw_value, str) or not raw_value:
+        return None
+    parse_value = f"{raw_value[:-1]}+00:00" if raw_value.endswith("Z") else raw_value
+    try:
+        parsed = datetime.fromisoformat(parse_value)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return None
+    return raw_value
+
+
 def build_html(
     snowfall: List[Dict[str, str]],
     rain: List[Dict[str, str]],
@@ -38,8 +52,10 @@ def build_html(
     """
     del snowfall, rain, weather, sun, temp
 
-    now_utc = datetime.now(timezone.utc)
-    generated_utc_iso = now_utc.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    generated_utc_iso = _payload_generated_utc(initial_payload)
+    if generated_utc_iso is None:
+        now_utc = datetime.now(timezone.utc)
+        generated_utc_iso = now_utc.replace(microsecond=0).isoformat().replace("+00:00", "Z")
     filter_meta = {
         "available_filters": available_filters or {},
         "applied_filters": applied_filters or {},

--- a/src/web/weather_page_static_render.py
+++ b/src/web/weather_page_static_render.py
@@ -14,10 +14,14 @@ from typing import List
 if str(Path(__file__).resolve().parents[2]) not in sys.path:
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from src.backend.pipelines.static_pipeline import fetch_static_payload
+from src.backend.runtime import WeatherPayloadBuildRequest
 from src.shared.cli_options import add_cache_runtime_options, add_resort_options
-from src.web.pipelines import render_hourly_pages, render_html
-from src.web.static_assets import copy_static_assets
+from src.web.static_site_builder import (
+    StaticBuildRequest,
+    StaticFetchRequest,
+    StaticRenderRequest,
+    build_static_site,
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -37,34 +41,27 @@ def main() -> int:
 
     resorts: List[str] = [r.strip() for r in args.resort if r.strip()]
     resorts_file = "" if resorts else args.resorts_file
-
-    payload = fetch_static_payload(
+    output_json = str(Path(args.output_dir) / "data.json")
+    payload_request = WeatherPayloadBuildRequest.from_legacy_options(
         resorts=resorts,
         resorts_file=resorts_file,
+        output_json=output_json,
         cache_file=args.cache_file,
         geocode_cache_hours=args.geocode_cache_hours,
         forecast_cache_hours=args.forecast_cache_hours,
         max_workers=args.max_workers,
         api_retries=args.api_retries,
     )
-
-    output_html = str(Path(args.output_dir) / "index.html")
-    out = render_html(output_html, payload)
-    hourly_pages = render_hourly_pages(
-        output_html,
-        payload,
-        include_hourly_data=True,
-        hourly_mode="local",
-        hourly_source="",
-        cache_file=args.cache_file,
-        geocode_cache_hours=args.geocode_cache_hours,
-        forecast_cache_hours=args.forecast_cache_hours,
-        hourly_max_workers=args.max_workers,
-        api_retries=args.api_retries,
+    result = build_static_site(
+        StaticBuildRequest(
+            fetch=StaticFetchRequest(payload_request),
+            render=StaticRenderRequest(input_json=output_json, output_dir=args.output_dir),
+        )
     )
-    copy_static_assets(args.output_dir)
-    print(f"Done: {out}")
-    print(f"Done: {len(hourly_pages)} resort hourly page(s)")
+    if result.render_result is None:
+        raise RuntimeError("Legacy static renderer did not produce a rendered site")
+    print(f"Done: {Path(args.output_dir) / 'index.html'}")
+    print(f"Done: {len(result.render_result.hourly_page_paths)} resort hourly page(s)")
     return 0
 
 

--- a/tests/frontend/test_renderers.py
+++ b/tests/frontend/test_renderers.py
@@ -289,6 +289,22 @@ def test_build_html_keeps_legacy_table_args_out_of_page_shell():
     assert 'window.CLOSESNOW_INITIAL_PAYLOAD = {"reports": []};' in html
 
 
+def test_build_html_uses_initial_payload_generated_timestamp():
+    html = build_html(
+        [],
+        [],
+        [],
+        [],
+        [],
+        initial_payload={
+            "generated_at_utc": "2026-03-03T23:00:00Z",
+            "reports": [],
+        },
+    )
+
+    assert 'data-generated-utc="2026-03-03T23:00:00Z"' in html
+
+
 def test_render_payload_html_wires_transform_and_builder(monkeypatch):
     captured = {}
 

--- a/tests/frontend/test_static_site_pipeline.py
+++ b/tests/frontend/test_static_site_pipeline.py
@@ -10,11 +10,13 @@ from src.web.asset_manifest import WEB_ASSET_MANIFEST
 from src.web.pipelines.static_site import render_hourly_pages, render_html, write_payload_json
 from src.web.static_site_builder import (
     BUNDLE_MANIFEST_FILENAME,
+    SITE_MANIFEST_FILENAME,
     StaticBuildRequest,
     StaticFetchRequest,
     StaticRenderRequest,
     build_static_site,
     fetch_static_bundle,
+    load_static_bundle,
     render_static_bundle,
 )
 from src.web.static_site_validator import validate_static_site
@@ -204,6 +206,23 @@ def test_render_hourly_pages_removes_stale_hourly_data_when_bundle_has_none(tmp_
     assert len(context["dailySummary"]["past14dDaily"]) == 3
 
 
+def test_render_hourly_pages_preserves_safe_custom_resort_ids(tmp_path):
+    index_path = tmp_path / "site" / "index.html"
+    payload = {
+        "reports": [
+            {
+                "resort_id": "Snowbird_UT",
+                "query": "Snowbird, UT",
+                "daily": [],
+            }
+        ]
+    }
+
+    outputs = render_hourly_pages(str(index_path), payload)
+
+    assert outputs == [tmp_path / "site" / "resort" / "Snowbird_UT" / "index.html"]
+
+
 def test_fetch_static_bundle_writes_daily_and_hourly_with_shared_runtime(monkeypatch, tmp_path, valid_payload):
     valid_payload["reports"][0]["resort_id"] = "snowbird-ut"
     output_json = tmp_path / "bundle" / "data.json"
@@ -284,6 +303,63 @@ def test_fetch_static_bundle_removes_failed_stale_hourly_but_preserves_unknown_f
     assert manifest["hourly"] == {}
     assert manifest["missing_hourly"] == ["snowbird-ut"]
     assert result.bundle.missing_hourly_resort_ids == ("snowbird-ut",)
+
+
+@pytest.mark.parametrize("invalid_kind", ["swapped-resort", "malformed-series"])
+def test_fetch_static_bundle_rejects_mismatched_or_malformed_hourly_payloads(
+    monkeypatch, tmp_path, valid_payload, invalid_kind
+):
+    valid_payload["reports"][0]["resort_id"] = "snowbird-ut"
+    output_json = tmp_path / "bundle" / "data.json"
+    invalid_hourly = _static_hourly_payload()
+    if invalid_kind == "swapped-resort":
+        invalid_hourly["resort_id"] = "alta-ut"
+    else:
+        invalid_hourly["hourly"]["snowfall"] = "not-a-list"
+    monkeypatch.setattr(
+        "src.web.static_site_builder.build_weather_payload_for_request",
+        lambda request: valid_payload,
+    )
+    monkeypatch.setattr(
+        "src.web.static_site_builder.build_hourly_payloads_for_resorts",
+        lambda **kwargs: {"snowbird-ut": invalid_hourly},
+    )
+
+    result = fetch_static_bundle(StaticFetchRequest(WeatherPayloadBuildRequest(output_json=str(output_json))))
+
+    assert result.bundle.missing_hourly_resort_ids == ("snowbird-ut",)
+    assert not (output_json.parent / "resort" / "snowbird-ut" / "hourly.json").exists()
+    manifest = json.loads((output_json.parent / BUNDLE_MANIFEST_FILENAME).read_text(encoding="utf-8"))
+    assert manifest["hourly"] == {}
+
+
+@pytest.mark.parametrize("invalid_kind", ["swapped-resort", "malformed-series"])
+def test_load_static_bundle_rejects_manifest_hourly_with_wrong_identity_or_shape(
+    monkeypatch, tmp_path, valid_payload, invalid_kind
+):
+    valid_payload["reports"][0]["resort_id"] = "snowbird-ut"
+    output_json = tmp_path / "bundle" / "data.json"
+    monkeypatch.setattr(
+        "src.web.static_site_builder.build_weather_payload_for_request",
+        lambda request: valid_payload,
+    )
+    monkeypatch.setattr(
+        "src.web.static_site_builder.build_hourly_payloads_for_resorts",
+        lambda **kwargs: {"snowbird-ut": _static_hourly_payload()},
+    )
+    fetch_static_bundle(StaticFetchRequest(WeatherPayloadBuildRequest(output_json=str(output_json))))
+    hourly_path = output_json.parent / "resort" / "snowbird-ut" / "hourly.json"
+    invalid_hourly = _static_hourly_payload()
+    if invalid_kind == "swapped-resort":
+        invalid_hourly["resort_id"] = "alta-ut"
+    else:
+        invalid_hourly["hourly"]["visibility"] = [9000]
+    hourly_path.write_text(json.dumps(invalid_hourly), encoding="utf-8")
+
+    bundle = load_static_bundle(str(output_json))
+
+    assert bundle.hourly_payloads["snowbird-ut"] is None
+    assert bundle.missing_hourly_resort_ids == ("snowbird-ut",)
 
 
 def test_render_static_bundle_is_offline_and_self_contained_for_external_output(monkeypatch, tmp_path, valid_payload):
@@ -379,6 +455,65 @@ def test_render_static_bundle_cleans_only_owned_stale_route_files(monkeypatch, t
     assert unknown_file.read_text(encoding="utf-8") == "keep"
     assert (output_dir / "resort" / "alta-ut" / "index.html").is_file()
     assert (output_dir / "resort" / "alta-ut" / "hourly.json").is_file()
+
+
+def test_external_render_replaces_stale_bundle_manifest_with_deployed_bundle(monkeypatch, tmp_path, valid_payload):
+    valid_payload["reports"][0]["resort_id"] = "snowbird-ut"
+    monkeypatch.setattr(
+        "src.web.static_site_builder.build_weather_payload_for_request",
+        lambda request: valid_payload,
+    )
+    monkeypatch.setattr(
+        "src.web.static_site_builder.build_hourly_payloads_for_resorts",
+        lambda **kwargs: {resort_id: _static_hourly_payload(resort_id) for resort_id in kwargs["resort_ids"]},
+    )
+    old_input = tmp_path / "old-bundle" / "data.json"
+    output_dir = tmp_path / "deploy"
+    fetch_static_bundle(StaticFetchRequest(WeatherPayloadBuildRequest(output_json=str(old_input))))
+    render_static_bundle(StaticRenderRequest(input_json=str(old_input), output_dir=str(output_dir)))
+
+    valid_payload["reports"][0]["resort_id"] = "alta-ut"
+    new_input = tmp_path / "new-bundle" / "data.json"
+    fetch_static_bundle(StaticFetchRequest(WeatherPayloadBuildRequest(output_json=str(new_input))))
+    render_static_bundle(StaticRenderRequest(input_json=str(new_input), output_dir=str(output_dir)))
+
+    manifest = json.loads((output_dir / BUNDLE_MANIFEST_FILENAME).read_text(encoding="utf-8"))
+    assert manifest["daily_json"] == "data.json"
+    assert manifest["hourly"] == {"alta-ut": "resort/alta-ut/hourly.json"}
+    deployed_bundle = load_static_bundle(str(output_dir / "data.json"))
+    assert deployed_bundle.missing_hourly_resort_ids == ()
+    assert set(deployed_bundle.hourly_payloads) == {"alta-ut"}
+
+
+def test_render_static_bundle_cleans_manifest_owned_stale_assets_only(monkeypatch, tmp_path, valid_payload):
+    valid_payload["reports"][0]["resort_id"] = "snowbird-ut"
+    input_json = tmp_path / "bundle" / "data.json"
+    output_dir = tmp_path / "deploy"
+    monkeypatch.setattr(
+        "src.web.static_site_builder.build_weather_payload_for_request",
+        lambda request: valid_payload,
+    )
+    monkeypatch.setattr(
+        "src.web.static_site_builder.build_hourly_payloads_for_resorts",
+        lambda **kwargs: {"snowbird-ut": _static_hourly_payload()},
+    )
+    fetch_static_bundle(StaticFetchRequest(WeatherPayloadBuildRequest(output_json=str(input_json))))
+    render_request = StaticRenderRequest(input_json=str(input_json), output_dir=str(output_dir))
+    render_static_bundle(render_request)
+
+    stale_asset = output_dir / "assets" / "css" / "obsolete.css"
+    unknown_asset = output_dir / "assets" / "css" / "user-theme.css"
+    stale_asset.write_text("obsolete", encoding="utf-8")
+    unknown_asset.write_text("custom", encoding="utf-8")
+    site_manifest_path = output_dir / SITE_MANIFEST_FILENAME
+    site_manifest = json.loads(site_manifest_path.read_text(encoding="utf-8"))
+    site_manifest["assets"].append("assets/css/obsolete.css")
+    site_manifest_path.write_text(json.dumps(site_manifest), encoding="utf-8")
+
+    render_static_bundle(render_request)
+
+    assert not stale_asset.exists()
+    assert unknown_asset.read_text(encoding="utf-8") == "custom"
 
 
 def test_static_builder_rejects_traversal_resort_ids_before_fetch_or_render(monkeypatch, tmp_path, valid_payload):

--- a/tests/frontend/test_static_site_pipeline.py
+++ b/tests/frontend/test_static_site_pipeline.py
@@ -2,14 +2,47 @@ from __future__ import annotations
 
 import json
 import re
+from pathlib import Path
 
+import pytest
+from src.backend.runtime import WeatherPayloadBuildRequest, WeatherRuntimeOptions
+from src.web.asset_manifest import WEB_ASSET_MANIFEST
 from src.web.pipelines.static_site import render_hourly_pages, render_html, write_payload_json
+from src.web.static_site_builder import (
+    BUNDLE_MANIFEST_FILENAME,
+    StaticBuildRequest,
+    StaticFetchRequest,
+    StaticRenderRequest,
+    build_static_site,
+    fetch_static_bundle,
+    render_static_bundle,
+)
+from src.web.static_site_validator import validate_static_site
 
 
 def _hourly_context_from_html(html: str) -> dict:
     match = re.search(r"window\.CLOSESNOW_HOURLY_CONTEXT = (\{.*?\});", html, re.S)
     assert match is not None
     return json.loads(match.group(1))
+
+
+def _static_hourly_payload(resort_id: str = "snowbird-ut") -> dict:
+    return {
+        "resort_id": resort_id,
+        "query": "Snowbird, UT",
+        "display_name": "Snowbird, Utah",
+        "hours": 2,
+        "hourly": {
+            "time": ["2026-03-04T00:00", "2026-03-04T01:00"],
+            "snowfall": [0.0, 0.1],
+            "rain": [0.0, 0.0],
+            "precipitation_probability": [20, 10],
+            "snow_depth": [100, 100],
+            "wind_speed_10m": [5.0, 6.0],
+            "wind_direction_10m": [120, 110],
+            "visibility": [9000, 8800],
+        },
+    }
 
 
 def test_write_payload_json(tmp_path):
@@ -77,7 +110,7 @@ def test_render_hourly_pages(tmp_path):
             {"resort_id": "alta-ut", "query": "Alta, UT", "daily": []},
         ]
     }
-    outputs = render_hourly_pages(str(p), payload, include_hourly_data=False)
+    outputs = render_hourly_pages(str(p), payload)
     assert [x.relative_to(tmp_path / "site").as_posix() for x in outputs] == [
         "resort/snowbird-ut/index.html",
         "resort/alta-ut/index.html",
@@ -96,7 +129,7 @@ def test_render_hourly_pages(tmp_path):
     assert context["dailySummary"]["past14dDaily"][-1]["date"] == "2026-03-14"
 
 
-def test_render_hourly_pages_defaults_to_static_hourly_data(tmp_path, monkeypatch):
+def test_render_hourly_pages_uses_supplied_static_hourly_data(tmp_path):
     p = tmp_path / "site" / "index.html"
     payload = {
         "reports": [
@@ -111,97 +144,296 @@ def test_render_hourly_pages_defaults_to_static_hourly_data(tmp_path, monkeypatc
         ]
     }
 
+    hourly_payload = {
+        "resort_id": "snowbird-ut",
+        "query": "Snowbird, UT",
+        "display_name": "Snowbird, Utah",
+        "hours": 2,
+        "hourly": {
+            "time": ["2026-03-04T00:00", "2026-03-04T01:00"],
+            "snowfall": [0.0, 0.1],
+            "rain": [0.0, 0.0],
+            "precipitation_probability": [20, 10],
+            "snow_depth": [100, 100],
+            "wind_speed_10m": [5.0, 6.0],
+            "wind_direction_10m": [120, 110],
+            "visibility": [9000, 8800],
+        },
+    }
+
+    outputs = render_hourly_pages(str(p), payload, hourly_payloads={"snowbird-ut": hourly_payload})
+    assert len(outputs) == 1
+    hourly_json = tmp_path / "site" / "resort" / "snowbird-ut" / "hourly.json"
+    assert hourly_json.exists()
+    assert json.loads(hourly_json.read_text(encoding="utf-8")) == hourly_payload
+    html = outputs[0].read_text(encoding="utf-8")
+    context = _hourly_context_from_html(html)
+    assert context["hourlyDataUrl"] == "./hourly.json"
+    assert context["dailySummary"]["display_name"] == "Snowbird, Utah"
+    assert context["dailySummary"]["nearbyAirports"][0]["iata_code"] == "SLC"
+    assert len(context["dailySummary"]["past14dDaily"]) == 3
+
+
+def test_render_hourly_pages_removes_stale_hourly_data_when_bundle_has_none(tmp_path):
+    p = tmp_path / "site" / "index.html"
+    payload = {
+        "reports": [
+            {
+                "resort_id": "snowbird-ut",
+                "query": "Snowbird, UT",
+                "display_name": "Snowbird, Utah",
+                "nearby_airports": [{"airport_id": "slc-salt-lake-city", "iata_code": "SLC"}],
+                "daily": [{"date": "2026-03-13"}],
+                "past_14d_daily": [{"date": "2026-03-06"}, {"date": "2026-03-07"}, {"date": "2026-03-08"}],
+            }
+        ]
+    }
+
+    hourly_json = tmp_path / "site" / "resort" / "snowbird-ut" / "hourly.json"
+    hourly_json.parent.mkdir(parents=True)
+    hourly_json.write_text('{"stale": true}', encoding="utf-8")
+
+    outputs = render_hourly_pages(str(p), payload, hourly_payloads={"snowbird-ut": None})
+    assert len(outputs) == 1
+    assert not hourly_json.exists()
+    html = outputs[0].read_text(encoding="utf-8")
+    context = _hourly_context_from_html(html)
+    assert "hourlyDataUrl" not in context
+    assert context["dailySummary"]["display_name"] == "Snowbird, Utah"
+    assert context["dailySummary"]["nearbyAirports"][0]["iata_code"] == "SLC"
+    assert len(context["dailySummary"]["past14dDaily"]) == 3
+
+
+def test_fetch_static_bundle_writes_daily_and_hourly_with_shared_runtime(monkeypatch, tmp_path, valid_payload):
+    valid_payload["reports"][0]["resort_id"] = "snowbird-ut"
+    output_json = tmp_path / "bundle" / "data.json"
+    runtime = WeatherRuntimeOptions(
+        cache_file=".cache/test.json",
+        geocode_cache_hours=111,
+        forecast_cache_hours=7,
+        max_workers=6,
+        api_retries=4,
+    )
+    payload_request = WeatherPayloadBuildRequest(
+        resorts=("Snowbird, UT",),
+        output_json=str(output_json),
+        runtime=runtime,
+    )
     captured = {}
 
-    def fake_build_local_hourly_payloads(**kwargs):  # noqa: ANN001
-        captured.update(kwargs)
-        return {
-            "snowbird-ut": {
-                "resort_id": "snowbird-ut",
-                "query": "Snowbird, UT",
-                "display_name": "Snowbird, Utah",
-                "hours": 2,
-                "hourly": {
-                    "time": ["2026-03-04T00:00", "2026-03-04T01:00"],
-                    "snowfall": [0.0, 0.1],
-                    "rain": [0.0, 0.0],
-                    "precipitation_probability": [20, 10],
-                    "snow_depth": [100, 100],
-                    "wind_speed_10m": [5.0, 6.0],
-                    "wind_direction_10m": [120, 110],
-                    "visibility": [9000, 8800],
-                },
-            }
-        }
+    def fake_daily(request):  # noqa: ANN001
+        captured["daily_request"] = request
+        return valid_payload
 
-    monkeypatch.setattr("src.web.pipelines.static_site._build_local_hourly_payloads", fake_build_local_hourly_payloads)
+    def fake_hourly(**kwargs):  # noqa: ANN001
+        captured["hourly_kwargs"] = kwargs
+        return {"snowbird-ut": _static_hourly_payload()}
 
-    outputs = render_hourly_pages(str(p), payload)
-    assert len(outputs) == 1
-    assert captured["resort_ids"] == ["snowbird-ut"]
-    assert captured["max_workers"] == 8
-    hourly_json = tmp_path / "site" / "resort" / "snowbird-ut" / "hourly.json"
-    assert hourly_json.exists()
-    html = outputs[0].read_text(encoding="utf-8")
-    context = _hourly_context_from_html(html)
-    assert context["hourlyDataUrl"] == "./hourly.json"
-    assert context["dailySummary"]["display_name"] == "Snowbird, Utah"
-    assert context["dailySummary"]["nearbyAirports"][0]["iata_code"] == "SLC"
-    assert len(context["dailySummary"]["past14dDaily"]) == 3
+    monkeypatch.setattr("src.web.static_site_builder.build_weather_payload_for_request", fake_daily)
+    monkeypatch.setattr("src.web.static_site_builder.build_hourly_payloads_for_resorts", fake_hourly)
 
+    result = fetch_static_bundle(StaticFetchRequest(payload_request, hourly_hours=48))
 
-def test_render_hourly_pages_with_static_hourly_data(tmp_path, monkeypatch):
-    p = tmp_path / "site" / "index.html"
-    payload = {
-        "reports": [
-            {
-                "resort_id": "snowbird-ut",
-                "query": "Snowbird, UT",
-                "display_name": "Snowbird, Utah",
-                "nearby_airports": [{"airport_id": "slc-salt-lake-city", "iata_code": "SLC"}],
-                "daily": [{"date": "2026-03-13"}],
-                "past_14d_daily": [{"date": "2026-03-06"}, {"date": "2026-03-07"}, {"date": "2026-03-08"}],
-            }
-        ]
+    assert captured["daily_request"] is payload_request
+    assert captured["hourly_kwargs"] == {
+        "resort_ids": ["snowbird-ut"],
+        "hours": 48,
+        "cache_file": ".cache/test.json",
+        "geocode_cache_hours": 111,
+        "forecast_cache_hours": 7,
+        "max_workers": 6,
+        "api_retries": 4,
     }
+    assert json.loads(output_json.read_text(encoding="utf-8")) == valid_payload
+    hourly_path = output_json.parent / "resort" / "snowbird-ut" / "hourly.json"
+    assert json.loads(hourly_path.read_text(encoding="utf-8")) == _static_hourly_payload()
+    manifest = json.loads((output_json.parent / BUNDLE_MANIFEST_FILENAME).read_text(encoding="utf-8"))
+    assert manifest["hourly"] == {"snowbird-ut": "resort/snowbird-ut/hourly.json"}
+    assert manifest["missing_hourly"] == []
+    assert result.hourly_json_paths == (hourly_path.resolve(),)
+
+
+def test_fetch_static_bundle_removes_failed_stale_hourly_but_preserves_unknown_files(
+    monkeypatch, tmp_path, valid_payload
+):
+    valid_payload["reports"][0]["resort_id"] = "snowbird-ut"
+    output_json = tmp_path / "bundle" / "data.json"
+    request = StaticFetchRequest(WeatherPayloadBuildRequest(output_json=str(output_json)))
+    monkeypatch.setattr(
+        "src.web.static_site_builder.build_weather_payload_for_request",
+        lambda payload_request: valid_payload,
+    )
+    monkeypatch.setattr(
+        "src.web.static_site_builder.build_hourly_payloads_for_resorts",
+        lambda **kwargs: {"snowbird-ut": _static_hourly_payload()},
+    )
+    fetch_static_bundle(request)
+    route_dir = output_json.parent / "resort" / "snowbird-ut"
+    custom_file = route_dir / "notes.txt"
+    custom_file.write_text("keep", encoding="utf-8")
 
     monkeypatch.setattr(
-        "src.web.pipelines.static_site._build_local_hourly_payloads",
-        lambda **kwargs: {
-            "snowbird-ut": {
-                "resort_id": "snowbird-ut",
-                "query": "Snowbird, UT",
-                "display_name": "Snowbird, Utah",
-                "hours": 2,
-                "hourly": {
-                    "time": ["2026-03-04T00:00", "2026-03-04T01:00"],
-                    "snowfall": [0.0, 0.1],
-                    "rain": [0.0, 0.0],
-                    "precipitation_probability": [20, 10],
-                    "snow_depth": [100, 100],
-                    "wind_speed_10m": [5.0, 6.0],
-                    "wind_direction_10m": [120, 110],
-                    "visibility": [9000, 8800],
-                },
-            }
-        },
+        "src.web.static_site_builder.build_hourly_payloads_for_resorts",
+        lambda **kwargs: {"snowbird-ut": {"error": "temporary failure"}},
+    )
+    result = fetch_static_bundle(request)
+
+    assert not (route_dir / "hourly.json").exists()
+    assert custom_file.read_text(encoding="utf-8") == "keep"
+    manifest = json.loads((output_json.parent / BUNDLE_MANIFEST_FILENAME).read_text(encoding="utf-8"))
+    assert manifest["hourly"] == {}
+    assert manifest["missing_hourly"] == ["snowbird-ut"]
+    assert result.bundle.missing_hourly_resort_ids == ("snowbird-ut",)
+
+
+def test_render_static_bundle_is_offline_and_self_contained_for_external_output(monkeypatch, tmp_path, valid_payload):
+    valid_payload["reports"][0]["resort_id"] = "snowbird-ut"
+    input_json = tmp_path / "bundle" / "weather.json"
+    payload_request = WeatherPayloadBuildRequest(output_json=str(input_json))
+    monkeypatch.setattr(
+        "src.web.static_site_builder.build_weather_payload_for_request",
+        lambda request: valid_payload,
+    )
+    monkeypatch.setattr(
+        "src.web.static_site_builder.build_hourly_payloads_for_resorts",
+        lambda **kwargs: {"snowbird-ut": _static_hourly_payload()},
+    )
+    fetch_static_bundle(StaticFetchRequest(payload_request))
+
+    def fail_if_called(*args, **kwargs):  # noqa: ANN002, ANN003
+        raise AssertionError("render attempted to fetch data")
+
+    monkeypatch.setattr("src.web.static_site_builder.build_weather_payload_for_request", fail_if_called)
+    monkeypatch.setattr("src.web.static_site_builder.build_hourly_payloads_for_resorts", fail_if_called)
+    output_dir = tmp_path / "deploy"
+    output_dir.mkdir()
+    unknown_file = output_dir / "keep.txt"
+    unknown_file.write_text("keep", encoding="utf-8")
+
+    result = render_static_bundle(StaticRenderRequest(input_json=str(input_json), output_dir=str(output_dir)))
+
+    assert json.loads((output_dir / "data.json").read_text(encoding="utf-8")) == valid_payload
+    assert (
+        json.loads((output_dir / "resort" / "snowbird-ut" / "hourly.json").read_text(encoding="utf-8"))
+        == _static_hourly_payload()
+    )
+    assert '"dataUrl": "./data.json"' in result.index_html.read_text(encoding="utf-8")
+    assert '"hourlyDataUrl": "./hourly.json"' in result.hourly_page_paths[0].read_text(encoding="utf-8")
+    assert unknown_file.read_text(encoding="utf-8") == "keep"
+    assert not validate_static_site(output_dir)
+    assert all((output_dir / asset.repository_path).is_file() for asset in WEB_ASSET_MANIFEST)
+
+
+def test_split_and_one_shot_static_builds_are_artifact_equivalent(monkeypatch, tmp_path, valid_payload):
+    valid_payload["reports"][0]["resort_id"] = "snowbird-ut"
+    monkeypatch.setattr(
+        "src.web.static_site_builder.build_weather_payload_for_request",
+        lambda request: valid_payload,
+    )
+    monkeypatch.setattr(
+        "src.web.static_site_builder.build_hourly_payloads_for_resorts",
+        lambda **kwargs: {"snowbird-ut": _static_hourly_payload()},
+    )
+    split_dir = tmp_path / "split"
+    one_shot_dir = tmp_path / "one-shot"
+    split_fetch = StaticFetchRequest(WeatherPayloadBuildRequest(output_json=str(split_dir / "data.json")))
+    split_render = StaticRenderRequest(input_json=str(split_dir / "data.json"), output_dir=str(split_dir))
+    fetch_static_bundle(split_fetch)
+    render_static_bundle(split_render)
+
+    one_shot_fetch = StaticFetchRequest(WeatherPayloadBuildRequest(output_json=str(one_shot_dir / "data.json")))
+    one_shot_render = StaticRenderRequest(input_json=str(one_shot_dir / "data.json"), output_dir=str(one_shot_dir))
+    build_static_site(StaticBuildRequest(fetch=one_shot_fetch, render=one_shot_render))
+
+    def artifact_tree(root: Path) -> dict[str, bytes]:
+        return {path.relative_to(root).as_posix(): path.read_bytes() for path in root.rglob("*") if path.is_file()}
+
+    assert artifact_tree(split_dir) == artifact_tree(one_shot_dir)
+
+
+def test_render_static_bundle_cleans_only_owned_stale_route_files(monkeypatch, tmp_path, valid_payload):
+    valid_payload["reports"][0]["resort_id"] = "snowbird-ut"
+    output_dir = tmp_path / "site"
+    input_json = output_dir / "data.json"
+    monkeypatch.setattr(
+        "src.web.static_site_builder.build_weather_payload_for_request",
+        lambda request: valid_payload,
+    )
+    monkeypatch.setattr(
+        "src.web.static_site_builder.build_hourly_payloads_for_resorts",
+        lambda **kwargs: {resort_id: _static_hourly_payload(resort_id) for resort_id in kwargs["resort_ids"]},
+    )
+    request = StaticFetchRequest(WeatherPayloadBuildRequest(output_json=str(input_json)))
+    fetch_static_bundle(request)
+    render_static_bundle(StaticRenderRequest(input_json=str(input_json), output_dir=str(output_dir)))
+    old_route = output_dir / "resort" / "snowbird-ut"
+    unknown_file = old_route / "notes.txt"
+    unknown_file.write_text("keep", encoding="utf-8")
+
+    valid_payload["reports"][0]["resort_id"] = "alta-ut"
+    fetch_static_bundle(request)
+    render_static_bundle(StaticRenderRequest(input_json=str(input_json), output_dir=str(output_dir)))
+
+    assert not (old_route / "index.html").exists()
+    assert not (old_route / "hourly.json").exists()
+    assert unknown_file.read_text(encoding="utf-8") == "keep"
+    assert (output_dir / "resort" / "alta-ut" / "index.html").is_file()
+    assert (output_dir / "resort" / "alta-ut" / "hourly.json").is_file()
+
+
+def test_static_builder_rejects_traversal_resort_ids_before_fetch_or_render(monkeypatch, tmp_path, valid_payload):
+    valid_payload["reports"][0]["resort_id"] = ".."
+    input_json = tmp_path / "bundle" / "data.json"
+    fetch_request = StaticFetchRequest(WeatherPayloadBuildRequest(output_json=str(input_json)))
+    monkeypatch.setattr(
+        "src.web.static_site_builder.build_weather_payload_for_request",
+        lambda request: valid_payload,
     )
 
-    outputs = render_hourly_pages(
-        str(p),
-        payload,
-        include_hourly_data=True,
-        cache_file=".cache/x.json",
-        geocode_cache_hours=720,
-        forecast_cache_hours=3,
-        hourly_max_workers=3,
+    def fail_if_hourly_fetch_starts(**kwargs):  # noqa: ANN003
+        raise AssertionError("invalid resort id reached hourly fetch")
+
+    monkeypatch.setattr(
+        "src.web.static_site_builder.build_hourly_payloads_for_resorts",
+        fail_if_hourly_fetch_starts,
     )
-    assert len(outputs) == 1
-    hourly_json = tmp_path / "site" / "resort" / "snowbird-ut" / "hourly.json"
-    assert hourly_json.exists()
-    html = outputs[0].read_text(encoding="utf-8")
-    context = _hourly_context_from_html(html)
-    assert context["hourlyDataUrl"] == "./hourly.json"
-    assert context["dailySummary"]["display_name"] == "Snowbird, Utah"
-    assert context["dailySummary"]["nearbyAirports"][0]["iata_code"] == "SLC"
-    assert len(context["dailySummary"]["past14dDaily"]) == 3
+    with pytest.raises(ValueError, match="Invalid resort_id"):
+        fetch_static_bundle(fetch_request)
+    assert not input_json.exists()
+
+    write_payload_json(str(input_json), valid_payload)
+    output_dir = tmp_path / "deploy"
+    with pytest.raises(ValueError, match="Invalid resort_id"):
+        render_static_bundle(StaticRenderRequest(input_json=str(input_json), output_dir=str(output_dir)))
+    assert not output_dir.exists()
+
+
+def test_render_static_bundle_rejects_symlink_escape_and_preserves_external_files(monkeypatch, tmp_path, valid_payload):
+    valid_payload["reports"][0]["resort_id"] = "snowbird-ut"
+    input_json = tmp_path / "bundle" / "data.json"
+    monkeypatch.setattr(
+        "src.web.static_site_builder.build_weather_payload_for_request",
+        lambda request: valid_payload,
+    )
+    monkeypatch.setattr(
+        "src.web.static_site_builder.build_hourly_payloads_for_resorts",
+        lambda **kwargs: {"snowbird-ut": _static_hourly_payload()},
+    )
+    fetch_static_bundle(StaticFetchRequest(WeatherPayloadBuildRequest(output_json=str(input_json))))
+
+    output_dir = tmp_path / "deploy"
+    resort_root = output_dir / "resort"
+    resort_root.mkdir(parents=True)
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    outside_index = outside_dir / "index.html"
+    outside_hourly = outside_dir / "hourly.json"
+    outside_index.write_text("external index", encoding="utf-8")
+    outside_hourly.write_text("external hourly", encoding="utf-8")
+    (resort_root / "snowbird-ut").symlink_to(outside_dir, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="must not contain symlinks"):
+        render_static_bundle(StaticRenderRequest(input_json=str(input_json), output_dir=str(output_dir)))
+
+    assert outside_index.read_text(encoding="utf-8") == "external index"
+    assert outside_hourly.read_text(encoding="utf-8") == "external hourly"

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from src import cli
@@ -14,6 +15,7 @@ from src.backend.constants import (
 )
 from src.shared.config import DEFAULT_RESORTS_FILE
 from src.web.asset_manifest import WEB_ASSET_MANIFEST
+from src.web.static_assets import copy_static_assets
 
 
 def test_build_parser_has_all_commands():
@@ -123,51 +125,71 @@ def _build_fetch_like_args(tmp_path: Path):
     )
 
 
+def _fake_static_result(tmp_path: Path, *, fetched: bool = True, rendered: bool = True):
+    fetch_result = None
+    if fetched:
+        fetch_result = SimpleNamespace(
+            bundle=SimpleNamespace(input_json=tmp_path / "data.json"),
+            hourly_json_paths=(),
+        )
+    render_result = None
+    if rendered:
+        render_result = SimpleNamespace(
+            index_html=tmp_path / "index.html",
+            hourly_page_paths=(),
+            asset_directories=(),
+        )
+    return SimpleNamespace(fetch_result=fetch_result, render_result=render_result)
+
+
 def test_run_fetch(monkeypatch, tmp_path, capsys):
     args = _build_fetch_like_args(tmp_path)
-    called = {}
+    captured = {}
 
-    monkeypatch.setattr("src.cli.fetch_static_payload", lambda **kwargs: {"reports": [], "called": kwargs})
+    def fake_fetch_static_bundle(request):  # noqa: ANN001
+        captured["request"] = request
+        return SimpleNamespace(
+            bundle=SimpleNamespace(input_json=Path(args.output_json)),
+            hourly_json_paths=(tmp_path / "resort" / "snowbird-ut" / "hourly.json",),
+        )
 
-    def fake_write_payload_json(path, payload):  # noqa: ANN001
-        called["path"] = path
-        called["payload"] = payload
-        return Path(path)
-
-    monkeypatch.setattr("src.cli.write_payload_json", fake_write_payload_json)
+    monkeypatch.setattr("src.cli.fetch_static_bundle", fake_fetch_static_bundle)
     rc = cli.run_fetch(args)
     out = capsys.readouterr().out
     assert rc == 0
     assert "Done:" in out
-    assert called["path"] == args.output_json
-    assert called["payload"]["reports"] == []
+    request = captured["request"].payload_request
+    assert request.output_json == args.output_json
+    assert request.runtime.max_workers == 8
 
 
-def test_fetch_payload_forwards_include_all_resorts(monkeypatch, tmp_path):
+def test_payload_build_request_forwards_include_all_resorts(tmp_path):
     args = _build_fetch_like_args(tmp_path)
     args.include_all_resorts = True
-    captured = {}
-
-    def fake_fetch_static_payload(**kwargs):  # noqa: ANN001
-        captured.update(kwargs)
-        return {"reports": []}
-
-    monkeypatch.setattr("src.cli.fetch_static_payload", fake_fetch_static_payload)
-    cli._fetch_payload(args)
-    assert captured["include_all_resorts"] is True
-    assert captured["api_retries"] == 2
+    request = cli._payload_build_request(args, output_json=args.output_json)
+    assert request.include_all_resorts is True
+    assert request.runtime.api_retries == 2
 
 
 def test_run_render(monkeypatch, tmp_path, capsys):
     args = argparse.Namespace(input_json=str(tmp_path / "in.json"), output_dir=str(tmp_path / "out"))
-    monkeypatch.setattr("src.cli.load_payload", lambda mode, source: {"reports": [], "from": source, "mode": mode})
-    monkeypatch.setattr("src.cli.render_html", lambda path, payload, **kwargs: Path(path))
-    monkeypatch.setattr("src.cli.render_hourly_pages", lambda *args, **kwargs: [])
-    monkeypatch.setattr("src.cli.copy_static_assets", lambda directory: [Path(directory) / "assets" / "css"])
+    captured = {}
+
+    def fake_render_static_bundle(request):  # noqa: ANN001
+        captured["request"] = request
+        return SimpleNamespace(
+            index_html=Path(args.output_dir) / "index.html",
+            hourly_page_paths=(),
+            asset_directories=(Path(args.output_dir) / "assets" / "css",),
+        )
+
+    monkeypatch.setattr("src.cli.render_static_bundle", fake_render_static_bundle)
     rc = cli.run_render(args)
     out = capsys.readouterr().out
     assert rc == 0
     assert "Done:" in out
+    assert captured["request"].input_json == args.input_json
+    assert captured["request"].output_dir == args.output_dir
 
 
 def test_run_static_default(monkeypatch, tmp_path, capsys):
@@ -177,18 +199,22 @@ def test_run_static_default(monkeypatch, tmp_path, capsys):
     args.skip_fetch = False
     args.skip_render = False
 
-    monkeypatch.setattr("src.cli._fetch_payload", lambda a: {"reports": [{"query": "a", "daily": []}]})
-    monkeypatch.setattr("src.cli.write_payload_json", lambda path, payload: Path(path))
-    monkeypatch.setattr("src.cli.render_html", lambda path, payload, **kwargs: Path(path))
-    monkeypatch.setattr("src.cli.render_hourly_pages", lambda *args, **kwargs: [])
-    monkeypatch.setattr("src.cli.copy_static_assets", lambda directory: [Path(directory) / "assets" / "css"])
+    captured = {}
+
+    def fake_build_static_site(request):  # noqa: ANN001
+        captured["request"] = request
+        return _fake_static_result(Path(args.output_dir))
+
+    monkeypatch.setattr("src.cli.build_static_site", fake_build_static_site)
     rc = cli.run_static(args)
     out = capsys.readouterr().out
     assert rc == 0
     assert "Done:" in out
+    assert captured["request"].skip_fetch is False
+    assert captured["request"].skip_render is False
 
 
-def test_run_static_forwards_max_workers_to_hourly_render(monkeypatch, tmp_path):
+def test_run_static_forwards_max_workers_to_fetch_only(monkeypatch, tmp_path):
     args = _build_fetch_like_args(tmp_path)
     args.max_workers = 5
     args.output_dir = str(tmp_path / "site")
@@ -197,20 +223,17 @@ def test_run_static_forwards_max_workers_to_hourly_render(monkeypatch, tmp_path)
     args.skip_render = False
     captured = {}
 
-    def fake_render_hourly_pages(*args, **kwargs):  # noqa: ANN001
-        captured.update(kwargs)
-        return []
+    def fake_build_static_site(request):  # noqa: ANN001
+        captured["request"] = request
+        return _fake_static_result(Path(args.output_dir))
 
-    monkeypatch.setattr("src.cli._fetch_payload", lambda a: {"reports": [{"query": "a", "daily": []}]})
-    monkeypatch.setattr("src.cli.write_payload_json", lambda path, payload: Path(path))
-    monkeypatch.setattr("src.cli.render_html", lambda path, payload, **kwargs: Path(path))
-    monkeypatch.setattr("src.cli.render_hourly_pages", fake_render_hourly_pages)
-    monkeypatch.setattr("src.cli.copy_static_assets", lambda directory: [Path(directory) / "assets" / "css"])
+    monkeypatch.setattr("src.cli.build_static_site", fake_build_static_site)
 
     rc = cli.run_static(args)
 
     assert rc == 0
-    assert captured["hourly_max_workers"] == 5
+    assert captured["request"].fetch.payload_request.runtime.max_workers == 5
+    assert not hasattr(captured["request"].render, "runtime")
 
 
 def test_run_static_skip_fetch(monkeypatch, tmp_path):
@@ -222,12 +245,16 @@ def test_run_static_skip_fetch(monkeypatch, tmp_path):
     payload_path = Path(args.output_dir) / "data.json"
     payload_path.parent.mkdir(parents=True)
     payload_path.write_text("{}", encoding="utf-8")
-    monkeypatch.setattr("src.cli.load_payload", lambda mode, source: {"reports": [], "loaded": source, "mode": mode})
-    monkeypatch.setattr("src.cli.render_html", lambda path, payload, **kwargs: Path(path))
-    monkeypatch.setattr("src.cli.render_hourly_pages", lambda *args, **kwargs: [])
-    monkeypatch.setattr("src.cli.copy_static_assets", lambda directory: [Path(directory) / "assets" / "css"])
+    captured = {}
+
+    def fake_build_static_site(request):  # noqa: ANN001
+        captured["request"] = request
+        return _fake_static_result(Path(args.output_dir), fetched=False)
+
+    monkeypatch.setattr("src.cli.build_static_site", fake_build_static_site)
     rc = cli.run_static(args)
     assert rc == 0
+    assert captured["request"].skip_fetch is True
 
 
 def test_run_static_skip_fetch_reports_missing_payload(tmp_path):
@@ -247,11 +274,16 @@ def test_run_static_skip_render(monkeypatch, tmp_path):
     args.output_json = None
     args.skip_fetch = False
     args.skip_render = True
-    monkeypatch.setattr("src.cli._fetch_payload", lambda a: {"reports": []})
-    monkeypatch.setattr("src.cli.write_payload_json", lambda path, payload: Path(path))
-    monkeypatch.setattr("src.cli.copy_static_assets", lambda directory: [Path(directory) / "assets" / "css"])
+    captured = {}
+
+    def fake_build_static_site(request):  # noqa: ANN001
+        captured["request"] = request
+        return _fake_static_result(Path(args.output_dir), rendered=False)
+
+    monkeypatch.setattr("src.cli.build_static_site", fake_build_static_site)
     rc = cli.run_static(args)
     assert rc == 0
+    assert captured["request"].skip_render is True
 
 
 def test_run_static_uses_output_dir_for_json_and_html(monkeypatch, tmp_path):
@@ -262,22 +294,15 @@ def test_run_static_uses_output_dir_for_json_and_html(monkeypatch, tmp_path):
     args.skip_render = False
     captured = {}
 
-    def fake_write_payload_json(path, payload):  # noqa: ANN001
-        captured["json"] = path
-        return Path(path)
+    def fake_build_static_site(request):  # noqa: ANN001
+        captured["request"] = request
+        return _fake_static_result(Path(args.output_dir))
 
-    def fake_render_html(path, payload, **kwargs):  # noqa: ANN001
-        captured["html"] = path
-        return Path(path)
-
-    monkeypatch.setattr("src.cli._fetch_payload", lambda a: {"reports": []})
-    monkeypatch.setattr("src.cli.write_payload_json", fake_write_payload_json)
-    monkeypatch.setattr("src.cli.render_html", fake_render_html)
-    monkeypatch.setattr("src.cli.render_hourly_pages", lambda *args, **kwargs: [])
-    monkeypatch.setattr("src.cli.copy_static_assets", lambda directory: [Path(directory) / "assets" / "css"])
+    monkeypatch.setattr("src.cli.build_static_site", fake_build_static_site)
     cli.run_static(args)
-    assert captured["json"] == str(tmp_path / "site" / "data.json")
-    assert captured["html"] == str(tmp_path / "site" / "index.html")
+    request = captured["request"]
+    assert request.fetch.payload_request.output_json == str(tmp_path / "site" / "data.json")
+    assert request.render.resolved_output_dir == tmp_path / "site"
 
 
 def test_run_static_server_boot_path(monkeypatch, tmp_path, capsys):
@@ -365,7 +390,7 @@ def test_copy_static_assets_copies_only_manifest_assets_from_non_repo_cwd(tmp_pa
     output_dir = tmp_path / "site"
     monkeypatch.chdir(outside_repo)
 
-    copied = cli.copy_static_assets(str(output_dir))
+    copied = copy_static_assets(str(output_dir))
 
     expected_directories = list(
         dict.fromkeys((output_dir / Path(asset.repository_path)).parent for asset in WEB_ASSET_MANIFEST)
@@ -385,17 +410,18 @@ def test_run_render_uses_input_parent_when_output_dir_missing(monkeypatch, tmp_p
     input_json.write_text("{}", encoding="utf-8")
     captured = {}
 
-    def fake_render_html(path, payload, **kwargs):  # noqa: ANN001
-        captured["html"] = path
-        return Path(path)
+    def fake_render_static_bundle(request):  # noqa: ANN001
+        captured["request"] = request
+        return SimpleNamespace(
+            index_html=input_json.parent / "index.html",
+            hourly_page_paths=(),
+            asset_directories=(),
+        )
 
-    monkeypatch.setattr("src.cli.load_payload", lambda mode, source: {"reports": []})
-    monkeypatch.setattr("src.cli.render_html", fake_render_html)
-    monkeypatch.setattr("src.cli.render_hourly_pages", lambda *args, **kwargs: [])
-    monkeypatch.setattr("src.cli.copy_static_assets", lambda directory: [Path(directory) / "assets" / "css"])
+    monkeypatch.setattr("src.cli.render_static_bundle", fake_render_static_bundle)
 
     cli.run_render(argparse.Namespace(input_json=str(input_json), output_dir=None))
-    assert captured["html"] == str(input_json.parent / "index.html")
+    assert captured["request"].resolved_output_dir == input_json.parent.resolve()
 
 
 def test_run_server_boot_path(monkeypatch, capsys):

--- a/tests/integration/test_entrypoints.py
+++ b/tests/integration/test_entrypoints.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import argparse
+from pathlib import Path
+from types import SimpleNamespace
 
 from src.backend import ecmwf_unified_backend, weather_data_server
 from src.web import weather_page_static_render
@@ -45,26 +47,26 @@ def test_static_render_entrypoint_main(monkeypatch, capsys):
     )
     captured = {}
 
-    def fake_fetch_static_payload(**kwargs):  # noqa: ANN001
-        captured["kwargs"] = kwargs
-        return {"reports": []}
-
     monkeypatch.setattr("src.web.weather_page_static_render.parse_args", lambda: args)
-    monkeypatch.setattr("src.web.weather_page_static_render.fetch_static_payload", fake_fetch_static_payload)
-    monkeypatch.setattr("src.web.weather_page_static_render.render_html", lambda path, payload: path)
-    monkeypatch.setattr("src.web.weather_page_static_render.copy_static_assets", lambda output_dir: [])
 
-    def fake_render_hourly_pages(*args, **kwargs):  # noqa: ANN001
-        captured["render_kwargs"] = kwargs
-        return [f"{args[0]}:resort/snowbird-ut/index.html"]
+    def fake_build_static_site(request):  # noqa: ANN001
+        captured["request"] = request
+        return SimpleNamespace(
+            render_result=SimpleNamespace(
+                index_html=Path("site/index.html"),
+                hourly_page_paths=(Path("site/resort/snowbird-ut/index.html"),),
+            )
+        )
 
-    monkeypatch.setattr("src.web.weather_page_static_render.render_hourly_pages", fake_render_hourly_pages)
+    monkeypatch.setattr("src.web.weather_page_static_render.build_static_site", fake_build_static_site)
     rc = weather_page_static_render.main()
     out = capsys.readouterr().out
     assert rc == 0
-    assert captured["kwargs"]["resorts"] == ["A"]
-    assert captured["kwargs"]["resorts_file"] == ""
-    assert captured["render_kwargs"]["hourly_max_workers"] == 8
+    payload_request = captured["request"].fetch.payload_request
+    assert payload_request.resorts == ("A",)
+    assert payload_request.resorts_file == ""
+    assert payload_request.runtime.max_workers == 8
+    assert captured["request"].render.input_json == "site/data.json"
     assert "Done: site/index.html" in out
 
 

--- a/tests/integration/test_static_server.py
+++ b/tests/integration/test_static_server.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import threading
 import urllib.request
 from pathlib import Path
@@ -27,7 +28,10 @@ def _write_valid_pages_site(site_dir: Path) -> None:
     resort_dir = site_dir / "resort" / "snowbird-ut"
     resort_dir.mkdir(parents=True)
     (site_dir / "index.html").write_text("<!doctype html><title>CloseSnow</title>", encoding="utf-8")
-    (site_dir / "data.json").write_text('{"ok":true}', encoding="utf-8")
+    (site_dir / "data.json").write_text(
+        json.dumps({"reports": [{"resort_id": "snowbird-ut"}]}),
+        encoding="utf-8",
+    )
     (site_dir / ".nojekyll").touch()
     (resort_dir / "index.html").write_text("<!doctype html><title>Snowbird</title>", encoding="utf-8")
     (resort_dir / "hourly.json").write_text('{"hours":0,"hourly":{}}', encoding="utf-8")
@@ -69,6 +73,28 @@ def test_static_site_validator_reports_actionable_required_entry_paths(tmp_path,
     assert any(str(site_dir / "resort/*/hourly.json") in issue for issue in rendered)
     assert validate_static_site_main(["--site-dir", str(site_dir), "--require-pages-artifacts"]) == 1
     assert str(site_dir / "index.html") in capsys.readouterr().err
+
+
+def test_static_site_validator_requires_pages_artifacts_for_every_payload_resort(tmp_path):
+    site_dir = tmp_path / "site"
+    _write_valid_pages_site(site_dir)
+    (site_dir / "data.json").write_text(
+        json.dumps(
+            {
+                "reports": [
+                    {"resort_id": "snowbird-ut"},
+                    {"resort_id": "alta-ut"},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    issues = validate_static_site(site_dir, require_pages_artifacts=True)
+
+    missing = {issue.path.relative_to(site_dir).as_posix() for issue in issues}
+    assert "resort/alta-ut/index.html" in missing
+    assert "resort/alta-ut/hourly.json" in missing
 
 
 def test_static_server_serves_site_and_resort_routes(tmp_path):

--- a/tests/smoke/test_static_pipeline_smoke.py
+++ b/tests/smoke/test_static_pipeline_smoke.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 from pathlib import Path
 
 import pytest
@@ -9,6 +10,7 @@ from src import cli
 
 @pytest.mark.smoke
 def test_static_split_pipeline_smoke(monkeypatch, tmp_path, valid_payload):
+    valid_payload["reports"][0]["resort_id"] = "snowbird-ut"
     fetch_args = argparse.Namespace(
         resort=[],
         resorts_file="resorts.yml",
@@ -20,10 +22,36 @@ def test_static_split_pipeline_smoke(monkeypatch, tmp_path, valid_payload):
         api_retries=2,
         output_json=str(tmp_path / "data.json"),
     )
-    monkeypatch.setattr("src.cli.fetch_static_payload", lambda **kwargs: valid_payload)
+    hourly_payload = {
+        "resort_id": "snowbird-ut",
+        "hours": 2,
+        "hourly": {"time": ["2026-03-04T00:00", "2026-03-04T01:00"]},
+    }
+    monkeypatch.setattr(
+        "src.web.static_site_builder.build_weather_payload_for_request",
+        lambda request: valid_payload,
+    )
+    monkeypatch.setattr(
+        "src.web.static_site_builder.build_hourly_payloads_for_resorts",
+        lambda **kwargs: {"snowbird-ut": hourly_payload},
+    )
 
     assert cli.run_fetch(fetch_args) == 0
     assert Path(fetch_args.output_json).exists()
+    bundle_hourly = tmp_path / "resort" / "snowbird-ut" / "hourly.json"
+    assert json.loads(bundle_hourly.read_text(encoding="utf-8")) == hourly_payload
+
+    def fail_if_render_fetches(*args, **kwargs):  # noqa: ANN002, ANN003
+        raise AssertionError("render attempted backend or network access")
+
+    monkeypatch.setattr(
+        "src.web.static_site_builder.build_weather_payload_for_request",
+        fail_if_render_fetches,
+    )
+    monkeypatch.setattr(
+        "src.web.static_site_builder.build_hourly_payloads_for_resorts",
+        fail_if_render_fetches,
+    )
 
     render_args = argparse.Namespace(
         input_json=fetch_args.output_json,
@@ -37,3 +65,5 @@ def test_static_split_pipeline_smoke(monkeypatch, tmp_path, valid_payload):
     assert 'id="page-content-root"' in html
     assert "window.CLOSESNOW_PAGE_BOOTSTRAP" in html
     assert '"dataUrl": "./data.json"' in html
+    resort_html = Path(render_args.output_dir, "resort", "snowbird-ut", "index.html").read_text(encoding="utf-8")
+    assert '"hourlyDataUrl": "./hourly.json"' in resort_html

--- a/tests/smoke/test_static_pipeline_smoke.py
+++ b/tests/smoke/test_static_pipeline_smoke.py
@@ -25,7 +25,16 @@ def test_static_split_pipeline_smoke(monkeypatch, tmp_path, valid_payload):
     hourly_payload = {
         "resort_id": "snowbird-ut",
         "hours": 2,
-        "hourly": {"time": ["2026-03-04T00:00", "2026-03-04T01:00"]},
+        "hourly": {
+            "time": ["2026-03-04T00:00", "2026-03-04T01:00"],
+            "snowfall": [0.0, 0.1],
+            "rain": [0.0, 0.0],
+            "precipitation_probability": [20, 10],
+            "snow_depth": [100, 100],
+            "wind_speed_10m": [5.0, 6.0],
+            "wind_direction_10m": [120, 110],
+            "visibility": [9000, 8800],
+        },
     }
     monkeypatch.setattr(
         "src.web.static_site_builder.build_weather_payload_for_request",


### PR DESCRIPTION
Summary:
- add typed static fetch/render/build requests and results in one application service
- fetch daily and hourly artifacts into a manifest-backed bundle using shared runtime options
- make render file-only, self-contained for external output directories, and canonical-asset validated
- delegate unified CLI and legacy static entrypoint while preserving flags and layouts
- clean only manifest-owned stale routes/assets and reject traversal or symlink escape paths
- require every Pages resort to have index and validated hourly artifacts
- refresh bundle metadata in rendered output and preserve safe custom resort IDs
- derive static HTML generation metadata from the payload for deterministic split and one-shot output

Validation:
- required static target suite: 50 passed
- full pytest: 257 passed
- repository lint: Ruff, JS/HTML/CSS/shell, and asset lint passed
- static build with max-workers 8: 31 hourly artifacts/pages, no missing hourly, strict Pages validation passed
- offline render to separate output: 31 hourly artifacts/pages, data comparison and strict validation passed