### PR TITLE
Add Netlify deploy previews for pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,25 @@ python -m src.cli static --output-dir site --max-workers 8 --include-all-resorts
 touch site/.nojekyll
 ```
 
+## Netlify Pull Request Previews
+
+The repository includes `netlify.toml` for optional Netlify Deploy Previews. GitHub Pages remains the canonical production deployment; Netlify is an auxiliary review surface for pull requests.
+
+One-time repository administrator setup:
+
+1. In Netlify, import this repository through the Netlify GitHub App.
+2. Select `main` as the production branch and keep the repository-provided build settings.
+3. Confirm Deploy Previews are enabled under **Project configuration > Build & deploy > Continuous deployment**.
+4. Confirm GitHub pull request comments are enabled under **Project configuration > Notifications > Deploy notifications**.
+
+Netlify then runs the complete static build for each pull request and publishes `site/`. The Netlify bot adds or updates a pull request comment with a URL shaped like:
+
+```text
+https://deploy-preview-<pr-number>--<site-name>.netlify.app
+```
+
+No Netlify token, account id, or site id is required in this repository. App authorization and project ownership remain in Netlify and GitHub settings.
+
 ## Compatibility Surfaces
 
 Legacy-compatible backend entrypoint:

--- a/agent_docs/features/netlify-pr-previews-01-deploy-config.md
+++ b/agent_docs/features/netlify-pr-previews-01-deploy-config.md
@@ -1,0 +1,39 @@
+# Atomic Feature Request
+
+## Request ID
+- `netlify-pr-previews-01-deploy-config`
+
+## Title
+- Add Netlify PR preview configuration
+
+## Feature Branch
+- `ljcc/feature/netlify-pr-previews`
+
+## Dependencies
+- None.
+
+## Background
+- Reviewers currently receive test results for pull requests but no hosted interface for visually checking generated static pages. Netlify can create a unique Deploy Preview and GitHub comment for each pull request once its GitHub App is connected.
+
+## Goal
+- Add deterministic, repository-owned Netlify build settings and concise administrator setup documentation so connected pull requests build the complete CloseSnow static site into a Netlify Deploy Preview.
+
+## Constraints / Forbidden Behaviors
+- Do not replace or modify the existing GitHub Pages production deployment workflow.
+- Do not commit Netlify credentials, access tokens, account identifiers, or site identifiers.
+- Use Python 3.11 and the repository convention of eight static-build workers.
+- Generate the complete resort catalog and publish only the generated `site/` directory.
+- Keep configuration usable for production and deploy-preview Netlify contexts without branch-specific secrets.
+
+## Acceptance Criteria
+- [ ] A root `netlify.toml` declares the complete static build command, `site` publish directory, and Python 3.11 runtime.
+- [ ] README documents the one-time Netlify GitHub App connection, expected Deploy Preview comment/URL, and that GitHub Pages remains production.
+- [ ] The configured command succeeds locally and produces a Pages-valid complete static site.
+- [ ] Configuration contains no repository or account secrets.
+- [ ] A dedicated PR targets `ljcc/feature/netlify-pr-previews` before the final feature PR targets `main`.
+
+## Test Plan
+- Parse `netlify.toml` with Python 3.11 `tomllib` and assert the build command, publish directory, and runtime value.
+- Run `python3 -m src.cli static --output-dir <temporary-output> --max-workers 8 --include-all-resorts`.
+- Run `python3 -m src.web.static_site_validator --site-dir <temporary-output>` when available on the feature base; otherwise verify the generated index, data, assets, resort pages, and hourly JSON artifacts directly.
+- Run the repository lint suite and full pytest suite.

--- a/agent_docs/graphs/netlify-pr-previews.md
+++ b/agent_docs/graphs/netlify-pr-previews.md
@@ -1,0 +1,20 @@
+# Netlify PR Previews
+
+## Summary
+- Add repository-owned Netlify build configuration so a connected Netlify GitHub App can build every pull request as a shareable Deploy Preview without changing the existing GitHub Pages production workflow.
+
+## Feature Branch
+- `ljcc/feature/netlify-pr-previews`
+
+## Global Assumptions
+- Netlify remains an auxiliary preview host; GitHub Pages stays the canonical production deployment.
+- A repository administrator will authorize the Netlify GitHub App and connect this repository after the configuration PR is available.
+
+## Atomic Requests
+- `netlify-pr-previews-01-deploy-config`: Add Netlify preview build configuration and setup documentation.
+
+## Dependency Graph
+- None; the single atomic request is independently executable.
+
+## Notes
+- No Netlify token or project identifier belongs in the repository.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,6 @@
+[build]
+command = "python3 -m src.cli static --output-dir site --max-workers 8 --include-all-resorts"
+publish = "site"
+
+[build.environment]
+PYTHON_VERSION = "3.11"


### PR DESCRIPTION
## Summary

- add netlify.toml with the complete CloseSnow static build and site publish directory
- pin Netlify builds to Python 3.11 and retain the existing 8-worker convention
- document one-time Netlify GitHub App setup and automatic pull request preview comments
- keep GitHub Pages as the canonical production deployment

## Validation

- parsed and asserted every netlify.toml setting
- exact configured command generated 125 resort pages and 125 hourly JSON artifacts
- 223 pytest tests passed locally and in PR #77 CI
- Ruff, formatting, and asset lint passed
- confirmed no Netlify credentials, site id, or account id are committed

## Administrator follow-up

After merge, import the repository in Netlify through the Netlify GitHub App. Keep main as the production branch and enable Deploy Preview pull request comments. Netlify will then add a deploy-preview URL to each PR.