### PR TITLE
Redesign forecast experience

### DIFF
--- a/assets/css/resort_hourly.css
+++ b/assets/css/resort_hourly.css
@@ -514,3 +514,754 @@ th .day-label-weekday {
   color: #475569;
   font-weight: 600;
 }
+
+/* Alpine resort detail shell */
+:root {
+  --ink-950: #081a29;
+  --ink-900: #10283a;
+  --ink-800: #1c3a4d;
+  --ink-700: #37566a;
+  --ink-500: #6a8291;
+  --snow-50: #f8fbfc;
+  --snow-100: #eef4f6;
+  --snow-200: #dce7eb;
+  --glacier-300: #8fd8e8;
+  --glacier-500: #28a9c2;
+  --glacier-600: #148ca8;
+  --surface: #ffffff;
+  --border: #d8e3e7;
+  --shadow-card: 0 12px 32px rgba(8, 26, 41, 0.08);
+  --radius-lg: 24px;
+  --radius-md: 16px;
+  --radius-sm: 11px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  background: var(--snow-100);
+}
+
+body {
+  min-width: 0;
+  overflow-x: clip;
+  color: var(--ink-900);
+  background:
+    radial-gradient(circle at 10% -8%, rgba(143, 216, 232, 0.3), transparent 32rem),
+    linear-gradient(180deg, #f7fbfc 0%, var(--snow-100) 45%, #f5f8f7 100%);
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
+button,
+select {
+  font: inherit;
+}
+
+button,
+a,
+select {
+  transition: border-color 160ms ease, box-shadow 160ms ease, color 160ms ease, background-color 160ms ease, transform 160ms ease;
+}
+
+button:focus-visible,
+a:focus-visible,
+select:focus-visible,
+summary:focus-visible {
+  outline: 3px solid rgba(40, 169, 194, 0.28);
+  outline-offset: 2px;
+}
+
+.site-header {
+  color: #fff;
+  background: var(--ink-950);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.09);
+}
+
+.site-header-inner {
+  width: min(1400px, 100%);
+  min-height: 72px;
+  margin: 0 auto;
+  padding: 0 28px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 11px;
+  color: #fff;
+  text-decoration: none;
+}
+
+.brand:hover {
+  color: var(--glacier-300);
+}
+
+.brand-mark {
+  width: 40px;
+  height: 40px;
+  border-radius: 13px;
+  display: grid;
+  place-items: center;
+  color: var(--ink-950);
+  background: linear-gradient(145deg, #d9f5fa, var(--glacier-300));
+  box-shadow: 0 8px 22px rgba(40, 169, 194, 0.22);
+}
+
+.brand-mark svg {
+  width: 30px;
+  height: 30px;
+  fill: currentColor;
+}
+
+.brand-mark svg path + path {
+  fill: none;
+  stroke: #eefdff;
+  stroke-width: 2.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.brand-copy {
+  display: grid;
+  gap: 1px;
+}
+
+.brand-copy strong {
+  font-size: 18px;
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+}
+
+.brand-copy span {
+  color: #a9bfca;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.site-header-note {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: #c7d5dc;
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.site-header-note > span {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #65d6aa;
+  box-shadow: 0 0 0 5px rgba(101, 214, 170, 0.1);
+}
+
+main {
+  width: min(1400px, 100%);
+  max-width: none;
+  min-width: 0;
+  padding: 28px;
+}
+
+.eyebrow {
+  margin: 0 0 7px;
+  color: var(--glacier-600);
+  font-size: 11px;
+  line-height: 1.2;
+  font-weight: 800;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.resort-hero {
+  position: relative;
+  min-height: 330px;
+  padding: clamp(32px, 4vw, 56px);
+  overflow: hidden;
+  border-radius: var(--radius-lg);
+  color: #fff;
+  background:
+    radial-gradient(circle at 78% 12%, rgba(143, 216, 232, 0.24), transparent 24rem),
+    linear-gradient(128deg, #0a1e2e 0%, #12364b 58%, #155268 100%);
+  box-shadow: 0 28px 70px rgba(8, 26, 41, 0.16);
+}
+
+.resort-hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.24;
+  background-image: radial-gradient(circle, rgba(255, 255, 255, 0.65) 0 1px, transparent 1.3px);
+  background-size: 42px 42px;
+  mask-image: linear-gradient(90deg, transparent 0%, #000 55%);
+}
+
+.resort-hero > :not(.resort-hero-mountain) {
+  position: relative;
+  z-index: 3;
+}
+
+.back-link {
+  margin-bottom: 28px;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: #c6e9ef;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.back-link:hover {
+  color: #fff;
+  text-decoration: none;
+  transform: translateX(-2px);
+}
+
+.resort-hero .eyebrow {
+  color: var(--glacier-300);
+}
+
+.resort-hero h1 {
+  max-width: 770px;
+  margin: 0;
+  color: #fff;
+  font-size: clamp(36px, 5.4vw, 68px);
+  line-height: 1.02;
+  letter-spacing: -0.05em;
+}
+
+.resort-identity-meta {
+  max-width: 760px;
+  margin: 22px 0 0;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  flex-wrap: wrap;
+}
+
+.resort-identity-meta p {
+  margin: 0;
+  padding: 7px 10px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 999px;
+  color: #d3e3e9;
+  background: rgba(255, 255, 255, 0.06);
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.resort-identity-meta a {
+  color: #fff;
+  text-decoration: none;
+}
+
+.resort-identity-meta a:hover {
+  color: var(--glacier-300);
+}
+
+.resort-snapshot {
+  max-width: 820px;
+  margin-top: 28px;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.snapshot-card {
+  min-width: 0;
+  padding: 13px 15px;
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(10px);
+}
+
+.snapshot-card > span:last-child {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.snapshot-card small,
+.snapshot-card em {
+  overflow: hidden;
+  color: #b9ccd5;
+  font-size: 9px;
+  font-style: normal;
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.snapshot-card strong {
+  overflow: hidden;
+  color: #fff;
+  font-size: 18px;
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.snapshot-icon {
+  flex: 0 0 auto;
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  border-radius: 11px;
+  background: rgba(255, 255, 255, 0.1);
+  font-size: 22px;
+}
+
+.snapshot-icon-snow {
+  color: #bfefff;
+}
+
+.snapshot-icon-rain {
+  color: #75d6e8;
+  font-size: 28px;
+}
+
+.resort-hero-mountain {
+  position: absolute;
+  z-index: 1;
+  right: -2%;
+  bottom: -7px;
+  width: min(45%, 600px);
+  height: 78%;
+  opacity: 0.68;
+  pointer-events: none;
+}
+
+.resort-hero-mountain svg {
+  width: 100%;
+  height: 100%;
+}
+
+.resort-hero-mountain path:first-child {
+  fill: rgba(4, 22, 34, 0.72);
+}
+
+.resort-hero-mountain path:last-child {
+  fill: none;
+  stroke: rgba(229, 250, 253, 0.7);
+  stroke-width: 5;
+  stroke-linejoin: round;
+}
+
+.resort-timeline-section,
+.resort-airport-access-section,
+.hourly-workspace {
+  min-width: 0;
+  margin: 18px 0 0;
+  padding: 22px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.94);
+  box-shadow: var(--shadow-card);
+}
+
+.section-heading,
+.hourly-workspace-heading {
+  margin-bottom: 14px;
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.section-heading .eyebrow,
+.hourly-workspace-heading .eyebrow {
+  margin-bottom: 4px;
+}
+
+.section-heading h2,
+.hourly-section-title {
+  margin: 0;
+  color: var(--ink-950);
+  font-size: 20px;
+  line-height: 1.2;
+  letter-spacing: -0.025em;
+}
+
+.section-heading > span {
+  color: var(--ink-500);
+  font-size: 10px;
+  font-weight: 650;
+}
+
+.resort-daily-summary-wrap,
+.table-wrap {
+  max-width: 100%;
+  border-color: var(--border);
+  border-radius: var(--radius-sm);
+  box-shadow: none;
+  scrollbar-color: #a9bdc7 var(--snow-100);
+  scrollbar-width: thin;
+}
+
+.resort-daily-summary-wrap::-webkit-scrollbar,
+.table-wrap::-webkit-scrollbar,
+.chart-svg-wrap::-webkit-scrollbar {
+  width: 9px;
+  height: 9px;
+}
+
+.resort-daily-summary-wrap::-webkit-scrollbar-thumb,
+.table-wrap::-webkit-scrollbar-thumb,
+.chart-svg-wrap::-webkit-scrollbar-thumb {
+  border: 2px solid var(--snow-100);
+  border-radius: 999px;
+  background: #a9bdc7;
+}
+
+.resort-daily-summary-table th,
+th {
+  color: var(--ink-800);
+  background: #e9f0f2;
+  border-color: #d7e2e6;
+}
+
+.resort-daily-summary-table th.compact-day-head-history {
+  background: #eef3f4;
+}
+
+.resort-daily-summary-table th.compact-day-head-forecast {
+  background: #e4f1f4;
+}
+
+td {
+  color: var(--ink-800);
+  border-color: #e7eef0;
+}
+
+.resort-airport-access-list {
+  gap: 12px;
+}
+
+.resort-airport-access-card {
+  padding: 16px;
+  border-color: var(--border);
+  border-radius: 14px;
+  box-shadow: none;
+}
+
+.resort-airport-access-card:hover {
+  border-color: #acd8e1;
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px rgba(8, 26, 41, 0.06);
+}
+
+.resort-airport-access-code {
+  color: #08748b;
+  background: #e8f7f9;
+}
+
+.resort-airport-access-distance,
+.resort-airport-access-name {
+  color: var(--ink-950);
+}
+
+.resort-airport-access-location {
+  color: var(--ink-500);
+}
+
+.hourly-workspace {
+  padding: 24px;
+}
+
+.hourly-controls {
+  margin: 0;
+  padding: 5px;
+  gap: 6px;
+  border: 1px solid var(--border);
+  border-radius: 13px;
+  background: var(--snow-50);
+}
+
+.hourly-controls label {
+  padding-left: 7px;
+  color: var(--ink-500);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+}
+
+.hourly-controls select,
+.hourly-controls button {
+  height: 34px;
+  padding: 0 10px;
+  border-color: var(--border);
+  border-radius: 9px;
+  color: var(--ink-800);
+  background: #fff;
+  font-size: 11px;
+}
+
+.hourly-controls button {
+  border-color: var(--ink-950);
+  color: #fff;
+  background: var(--ink-950);
+}
+
+.hourly-controls button:hover {
+  background: var(--ink-800);
+  transform: translateY(-1px);
+}
+
+.hourly-meta {
+  margin: 0 0 16px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  color: var(--ink-500);
+  background: var(--snow-50);
+  font-size: 11px;
+}
+
+.hourly-meta a {
+  color: #08748b;
+}
+
+.hourly-charts {
+  gap: 14px;
+  margin-bottom: 16px;
+}
+
+.chart-card {
+  padding: 16px 16px 11px;
+  border-color: var(--border);
+  border-radius: 14px;
+  box-shadow: none;
+}
+
+.chart-card:hover {
+  border-color: #b9d9df;
+  box-shadow: 0 10px 26px rgba(8, 26, 41, 0.05);
+}
+
+.chart-title {
+  color: var(--ink-950);
+  font-size: 14px;
+}
+
+.chart-subtitle,
+.chart-tick-text {
+  color: var(--ink-500);
+  fill: var(--ink-500);
+}
+
+.chart-grid-line {
+  stroke: #e7eef0;
+}
+
+.chart-axis-line {
+  stroke: #c8d7dc;
+}
+
+.chart-line {
+  stroke-width: 2.5;
+}
+
+.raw-data-panel {
+  border: 1px solid var(--border);
+  border-radius: 13px;
+  background: var(--snow-50);
+}
+
+.raw-data-panel summary {
+  padding: 13px 15px;
+  cursor: pointer;
+  color: var(--ink-700);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.raw-data-panel[open] summary {
+  color: var(--ink-950);
+  border-bottom: 1px solid var(--border);
+}
+
+.raw-data-panel .table-wrap {
+  border: 0;
+  border-radius: 0 0 12px 12px;
+}
+
+.page-footer {
+  width: min(1400px, 100%);
+  margin: 0 auto;
+  padding: 0 28px 28px;
+  color: var(--ink-500);
+  font-size: 11px;
+}
+
+.page-footer strong {
+  color: var(--ink-800);
+}
+
+@media (max-width: 980px) {
+  .resort-hero-mountain {
+    right: -12%;
+    width: 58%;
+    opacity: 0.48;
+  }
+
+  .resort-snapshot {
+    max-width: 100%;
+  }
+}
+
+@media (max-width: 700px) {
+  .site-header-inner {
+    min-height: 64px;
+    padding: 0 16px;
+  }
+
+  .site-header-note,
+  .brand-copy span {
+    display: none;
+  }
+
+  .brand-mark {
+    width: 36px;
+    height: 36px;
+  }
+
+  main {
+    padding: 14px;
+  }
+
+  .resort-hero {
+    min-height: 470px;
+    padding: 24px 20px 150px;
+    border-radius: 20px;
+  }
+
+  .back-link {
+    margin-bottom: 24px;
+  }
+
+  .resort-hero h1 {
+    font-size: clamp(36px, 11.5vw, 50px);
+  }
+
+  .resort-identity-meta {
+    margin-top: 17px;
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .resort-identity-meta p {
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .resort-snapshot {
+    width: calc(100% + 20px);
+    margin-top: 20px;
+    padding-right: 20px;
+    display: flex;
+    gap: 8px;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    scrollbar-width: none;
+  }
+
+  .resort-snapshot::-webkit-scrollbar {
+    display: none;
+  }
+
+  .snapshot-card {
+    min-width: 190px;
+    scroll-snap-align: start;
+  }
+
+  .resort-hero-mountain {
+    right: -15%;
+    width: 112%;
+    height: 42%;
+    opacity: 0.72;
+  }
+
+  .resort-timeline-section,
+  .resort-airport-access-section,
+  .hourly-workspace {
+    margin-top: 12px;
+    padding: 16px 12px;
+    border-radius: 15px;
+  }
+
+  .section-heading,
+  .hourly-workspace-heading {
+    padding: 0 3px;
+    align-items: flex-start;
+  }
+
+  .section-heading h2,
+  .hourly-section-title {
+    font-size: 18px;
+  }
+
+  .section-heading > span {
+    padding-top: 20px;
+  }
+
+  .resort-daily-summary-wrap {
+    position: relative;
+    box-shadow: 12px 0 18px -18px rgba(8, 26, 41, 0.55) inset;
+  }
+
+  .resort-airport-access-card {
+    padding: 14px;
+  }
+
+  .hourly-workspace-heading {
+    margin-bottom: 12px;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .hourly-controls {
+    width: 100%;
+  }
+
+  .hourly-controls select {
+    min-width: 0;
+    flex: 1;
+  }
+
+  .chart-card {
+    padding: 14px 10px 8px;
+  }
+
+  .page-footer {
+    padding: 0 16px 24px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}

--- a/assets/css/weather_page.css
+++ b/assets/css/weather_page.css
@@ -1169,4 +1169,1107 @@
     body.mobile-simple .sun-single-table .query-col {
       max-width: min(var(--sun-query-w), var(--mobile-leading-col-max));
     }
+
+/* Alpine product shell */
+:root {
+  --ink-950: #081a29;
+  --ink-900: #10283a;
+  --ink-800: #1c3a4d;
+  --ink-700: #37566a;
+  --ink-500: #6a8291;
+  --snow-50: #f8fbfc;
+  --snow-100: #eef4f6;
+  --snow-200: #dce7eb;
+  --glacier-300: #8fd8e8;
+  --glacier-500: #28a9c2;
+  --glacier-600: #148ca8;
+  --sun-400: #f7c969;
+  --surface: #ffffff;
+  --surface-soft: #f4f8f9;
+  --border: #d8e3e7;
+  --shadow-soft: 0 18px 50px rgba(8, 26, 41, 0.08);
+  --shadow-card: 0 10px 28px rgba(8, 26, 41, 0.07);
+  --radius-lg: 24px;
+  --radius-md: 16px;
+  --radius-sm: 11px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  background: var(--snow-100);
+}
+
+body {
+  min-width: 0;
+  overflow-x: clip;
+  color: var(--ink-900);
+  background:
+    radial-gradient(circle at 12% -10%, rgba(143, 216, 232, 0.32), transparent 34rem),
+    linear-gradient(180deg, #f7fbfc 0%, var(--snow-100) 42%, #f5f8f7 100%);
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
+button,
+input,
+select {
+  font: inherit;
+}
+
+button,
+a,
+input,
+select {
+  transition: border-color 160ms ease, box-shadow 160ms ease, color 160ms ease, background-color 160ms ease, transform 160ms ease;
+}
+
+button:focus-visible,
+a:focus-visible,
+input:focus-visible,
+select:focus-visible {
+  outline: 3px solid rgba(40, 169, 194, 0.28);
+  outline-offset: 2px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.site-header {
+  position: relative;
+  z-index: 30;
+  color: #fff;
+  background: var(--ink-950);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.09);
+}
+
+.site-header-inner {
+  width: min(1440px, 100%);
+  min-height: 72px;
+  margin: 0 auto;
+  padding: 0 28px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 11px;
+  color: #fff;
+  text-decoration: none;
+}
+
+.brand:hover {
+  color: var(--glacier-300);
+}
+
+.brand-mark {
+  width: 40px;
+  height: 40px;
+  border-radius: 13px;
+  display: grid;
+  place-items: center;
+  color: var(--ink-950);
+  background: linear-gradient(145deg, #d9f5fa, var(--glacier-300));
+  box-shadow: 0 8px 22px rgba(40, 169, 194, 0.22);
+}
+
+.brand-mark svg {
+  width: 30px;
+  height: 30px;
+  fill: currentColor;
+}
+
+.brand-mark svg path + path {
+  fill: none;
+  stroke: #eefdff;
+  stroke-width: 2.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.brand-copy {
+  display: grid;
+  gap: 1px;
+}
+
+.brand-copy strong {
+  font-size: 18px;
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+}
+
+.brand-copy span {
+  color: #a9bfca;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.site-header-note {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: #c7d5dc;
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.site-header-note > span {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #65d6aa;
+  box-shadow: 0 0 0 5px rgba(101, 214, 170, 0.1);
+}
+
+main {
+  width: min(1440px, 100%);
+  max-width: none;
+  min-width: 0;
+  padding: 28px;
+}
+
+.forecast-hero {
+  position: relative;
+  min-height: 320px;
+  padding: clamp(34px, 5vw, 66px);
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  border-radius: var(--radius-lg);
+  color: #fff;
+  background:
+    radial-gradient(circle at 82% 20%, rgba(143, 216, 232, 0.22), transparent 24rem),
+    linear-gradient(128deg, #0a1e2e 0%, #13364b 55%, #155268 100%);
+  box-shadow: 0 28px 70px rgba(8, 26, 41, 0.16);
+}
+
+.forecast-hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.3;
+  background-image: radial-gradient(circle, rgba(255, 255, 255, 0.65) 0 1px, transparent 1.3px);
+  background-size: 42px 42px;
+  mask-image: linear-gradient(90deg, transparent 0%, #000 55%);
+}
+
+.forecast-hero-copy {
+  position: relative;
+  z-index: 3;
+  max-width: 650px;
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: var(--glacier-600);
+  font-size: 11px;
+  line-height: 1.2;
+  font-weight: 800;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.forecast-hero .eyebrow {
+  color: var(--glacier-300);
+}
+
+.forecast-hero h1 {
+  max-width: 620px;
+  margin: 0;
+  font-size: clamp(42px, 6.2vw, 78px);
+  line-height: 0.98;
+  letter-spacing: -0.055em;
+}
+
+.forecast-hero h1 span {
+  color: var(--glacier-300);
+}
+
+.hero-lede {
+  max-width: 580px;
+  margin: 22px 0 0;
+  color: #d6e5eb;
+  font-size: clamp(15px, 1.6vw, 18px);
+  line-height: 1.55;
+  font-weight: 500;
+}
+
+.report-date {
+  margin: 26px 0 0;
+  padding-top: 18px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  border-top: 1px solid rgba(255, 255, 255, 0.14);
+}
+
+.report-powered,
+.report-generated {
+  margin: 0;
+  color: #b9ccd5;
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.report-powered a {
+  color: #fff;
+}
+
+.report-generated {
+  padding-left: 16px;
+  border-left: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.hero-landscape {
+  position: absolute;
+  z-index: 1;
+  right: -2%;
+  bottom: -6px;
+  width: min(56%, 760px);
+  height: 92%;
+  pointer-events: none;
+}
+
+.hero-landscape svg {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  width: 100%;
+  height: 82%;
+}
+
+.mountain-back {
+  fill: rgba(103, 170, 190, 0.22);
+}
+
+.mountain-front {
+  fill: rgba(4, 22, 34, 0.7);
+}
+
+.snow-line {
+  fill: none;
+  stroke: rgba(214, 245, 250, 0.55);
+  stroke-width: 5;
+  stroke-linejoin: round;
+}
+
+.snow-line-front {
+  stroke: rgba(240, 253, 255, 0.72);
+}
+
+.hero-sun {
+  position: absolute;
+  top: 22%;
+  right: 20%;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: var(--sun-400);
+  box-shadow: 0 0 50px rgba(247, 201, 105, 0.28);
+}
+
+.hero-contour {
+  position: absolute;
+  border: 1px solid rgba(143, 216, 232, 0.13);
+  border-radius: 48% 52% 42% 58%;
+  transform: rotate(-10deg);
+}
+
+.hero-contour-one {
+  width: 360px;
+  height: 128px;
+  right: 2%;
+  top: 5%;
+}
+
+.hero-contour-two {
+  width: 290px;
+  height: 96px;
+  right: 9%;
+  top: 13%;
+}
+
+.control-panel {
+  position: sticky;
+  top: 12px;
+  z-index: 24;
+  margin: 18px 0 24px;
+  padding: 18px 20px;
+  border: 1px solid rgba(216, 227, 231, 0.88);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.94);
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(16px);
+}
+
+.control-panel-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 14px;
+}
+
+.control-panel-heading .eyebrow {
+  margin-bottom: 3px;
+}
+
+.control-panel-heading h2 {
+  margin: 0;
+  color: var(--ink-950);
+  font-size: 19px;
+  letter-spacing: -0.02em;
+}
+
+.filter-summary {
+  max-width: 55%;
+  padding: 7px 11px;
+  overflow: hidden;
+  border-radius: 999px;
+  color: var(--ink-700);
+  background: var(--snow-100);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.resort-controls {
+  margin: 0;
+  display: grid;
+  grid-template-columns: minmax(260px, 1fr) auto auto;
+  align-items: center;
+  gap: 12px;
+}
+
+.resort-search {
+  min-width: 0;
+  flex-wrap: nowrap;
+}
+
+.search-field {
+  min-width: 0;
+  flex: 1;
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.search-field svg {
+  position: absolute;
+  left: 14px;
+  width: 18px;
+  height: 18px;
+  fill: none;
+  stroke: var(--ink-500);
+  stroke-width: 1.8;
+}
+
+.resort-search input {
+  width: 100%;
+  min-width: 0;
+  height: 44px;
+  padding: 0 16px 0 42px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--ink-950);
+  background: var(--surface-soft);
+  font-size: 13px;
+}
+
+.resort-search input:focus {
+  border-color: var(--glacier-500);
+  background: #fff;
+  box-shadow: 0 0 0 4px rgba(40, 169, 194, 0.1);
+  outline: none;
+}
+
+.resort-search button {
+  height: 40px;
+  padding: 0 12px;
+  border-color: transparent;
+  color: var(--ink-700);
+  background: transparent;
+}
+
+.resort-search button:hover {
+  color: var(--ink-950);
+  background: var(--snow-100);
+}
+
+.resort-search-options {
+  margin: 0;
+  gap: 8px;
+  flex-wrap: nowrap;
+}
+
+.resort-search-toggle {
+  position: relative;
+  gap: 0;
+  cursor: pointer;
+}
+
+.resort-search-toggle input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.resort-search-toggle span {
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--ink-700);
+  background: #fff;
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.resort-search-toggle input:checked + span {
+  border-color: #b9e4ec;
+  color: #08748b;
+  background: #eaf8fa;
+}
+
+.resort-search-toggle input:focus-visible + span {
+  outline: 3px solid rgba(40, 169, 194, 0.25);
+  outline-offset: 2px;
+}
+
+#filter-open-btn {
+  height: 42px;
+  padding: 0 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: var(--ink-950);
+  box-shadow: 0 8px 18px rgba(8, 26, 41, 0.16);
+}
+
+#filter-open-btn:hover {
+  background: var(--ink-800);
+  transform: translateY(-1px);
+}
+
+#filter-open-btn svg {
+  width: 17px;
+  height: 17px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  stroke-linecap: round;
+}
+
+.filter-modal {
+  background: rgba(5, 18, 28, 0.64);
+  backdrop-filter: blur(8px);
+}
+
+.filter-panel {
+  padding: 22px;
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  border-radius: var(--radius-md);
+  box-shadow: 0 28px 80px rgba(5, 18, 28, 0.3);
+}
+
+.filter-actions button:last-child {
+  border-color: var(--ink-950);
+  color: #fff;
+  background: var(--ink-950);
+}
+
+.forecast-overview {
+  margin: 0 0 24px;
+  padding: 24px;
+  border: 1px solid #cfe4e9;
+  border-radius: var(--radius-lg);
+  background:
+    radial-gradient(circle at 96% 10%, rgba(143, 216, 232, 0.2), transparent 22rem),
+    linear-gradient(145deg, #edf8fa 0%, #f9fcfd 62%);
+  box-shadow: var(--shadow-card);
+}
+
+.overview-heading {
+  margin-bottom: 17px;
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.overview-heading .eyebrow {
+  margin-bottom: 4px;
+}
+
+.overview-heading h2 {
+  margin: 0;
+  color: var(--ink-950);
+  font-size: clamp(23px, 2.4vw, 31px);
+  letter-spacing: -0.035em;
+}
+
+.overview-heading > span {
+  color: var(--ink-500);
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.snow-pick-grid,
+.loading-card-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 13px;
+}
+
+.snow-pick-card {
+  min-width: 0;
+  padding: 18px;
+  border: 1px solid rgba(207, 228, 233, 0.9);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: 0 6px 18px rgba(8, 26, 41, 0.04);
+}
+
+.snow-pick-card:hover {
+  border-color: #a8d8e2;
+  transform: translateY(-2px);
+  box-shadow: 0 14px 28px rgba(8, 26, 41, 0.08);
+}
+
+.snow-pick-card-topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.snow-pick-rank {
+  color: var(--glacier-600);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.snow-pick-weather {
+  font-size: 26px;
+  line-height: 1;
+}
+
+.snow-pick-card h3 {
+  margin: 12px 0 3px;
+  overflow: hidden;
+  font-size: 17px;
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.snow-pick-card h3 a {
+  color: var(--ink-950);
+  text-decoration: none;
+}
+
+.snow-pick-card h3 a:hover {
+  color: var(--glacier-600);
+}
+
+.snow-pick-card > p {
+  margin: 0 0 16px;
+  overflow: hidden;
+  color: var(--ink-500);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.snow-pick-metrics {
+  padding-top: 13px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  border-top: 1px solid var(--snow-200);
+}
+
+.snow-pick-metrics > span {
+  display: grid;
+  gap: 3px;
+}
+
+.snow-pick-metrics small {
+  color: var(--ink-500);
+  font-size: 10px;
+  font-weight: 650;
+}
+
+.snow-pick-metrics strong {
+  display: flex;
+  align-items: baseline;
+  gap: 3px;
+  color: var(--ink-950);
+  font-size: 20px;
+  line-height: 1;
+  letter-spacing: -0.025em;
+}
+
+.snow-pick-metrics em {
+  color: var(--ink-500);
+  font-size: 10px;
+  font-style: normal;
+  letter-spacing: 0;
+}
+
+.overview-empty {
+  grid-column: 1 / -1;
+  padding: 26px;
+  display: grid;
+  gap: 4px;
+  text-align: center;
+  color: var(--ink-500);
+}
+
+.overview-empty strong {
+  color: var(--ink-900);
+}
+
+#page-content-root {
+  min-width: 0;
+}
+
+.forecast-section {
+  min-width: 0;
+  margin: 0 0 18px;
+  padding: 20px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.94);
+  box-shadow: var(--shadow-card);
+}
+
+.forecast-section > h2,
+.forecast-section .section-header {
+  margin: 0 0 14px;
+}
+
+.forecast-section h2 {
+  margin: 0;
+  color: var(--ink-950);
+  font-size: 18px;
+  letter-spacing: -0.02em;
+}
+
+.section-note {
+  color: var(--ink-500);
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.unit-toggle {
+  padding: 3px;
+  border-color: var(--border);
+  background: var(--surface-soft);
+}
+
+.unit-toggle::before {
+  top: 3px;
+  left: 3px;
+  width: calc(50% - 3px);
+  height: calc(100% - 6px);
+  background: var(--ink-950);
+}
+
+.unit-btn {
+  font-size: 11px;
+}
+
+.compact-grid-mobile-wrap,
+.snowfall-sticky-wrap,
+.rain-sticky-wrap,
+.temperature-sticky-wrap,
+.weather-table-wrap,
+.sun-single-wrap {
+  max-width: 100%;
+  border-color: var(--border);
+  border-radius: var(--radius-sm);
+  box-shadow: none;
+  scrollbar-color: #a9bdc7 var(--snow-100);
+  scrollbar-width: thin;
+}
+
+.compact-grid-mobile-wrap::-webkit-scrollbar,
+.snowfall-sticky-wrap::-webkit-scrollbar,
+.rain-sticky-wrap::-webkit-scrollbar,
+.temperature-sticky-wrap::-webkit-scrollbar,
+.weather-table-wrap::-webkit-scrollbar,
+.sun-single-wrap::-webkit-scrollbar {
+  width: 9px;
+  height: 9px;
+}
+
+.compact-grid-mobile-wrap::-webkit-scrollbar-thumb,
+.snowfall-sticky-wrap::-webkit-scrollbar-thumb,
+.rain-sticky-wrap::-webkit-scrollbar-thumb,
+.temperature-sticky-wrap::-webkit-scrollbar-thumb,
+.weather-table-wrap::-webkit-scrollbar-thumb,
+.sun-single-wrap::-webkit-scrollbar-thumb {
+  border: 2px solid var(--snow-100);
+  border-radius: 999px;
+  background: #a9bdc7;
+}
+
+th {
+  color: var(--ink-800);
+  background: #e9f0f2;
+  border-color: #d7e2e6;
+}
+
+td {
+  color: var(--ink-800);
+  border-color: #e7eef0;
+}
+
+tbody tr:hover td {
+  box-shadow: inset 0 1px rgba(40, 169, 194, 0.18), inset 0 -1px rgba(40, 169, 194, 0.18);
+}
+
+.query-col .resort-link {
+  color: #0c7890;
+}
+
+.favorite-btn {
+  color: #9eafb8;
+}
+
+.favorite-btn[data-favorite-active="1"] {
+  color: #e35769;
+}
+
+.skeleton {
+  position: relative;
+  overflow: hidden;
+  border-radius: 10px;
+  background: #e6eef1;
+}
+
+.skeleton::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.72), transparent);
+  animation: skeleton-shimmer 1.4s infinite;
+}
+
+.skeleton-heading {
+  width: 210px;
+  height: 28px;
+  margin-bottom: 18px;
+}
+
+.skeleton-card {
+  height: 160px;
+}
+
+.skeleton-table {
+  height: 220px;
+  margin-top: 14px;
+}
+
+@keyframes skeleton-shimmer {
+  to {
+    transform: translateX(100%);
+  }
+}
+
+.page-load-error {
+  padding: 20px;
+  border: 1px solid #f2c6c3;
+  border-radius: var(--radius-md);
+  color: #8f2722;
+  background: #fff3f2;
+}
+
+.page-footer {
+  width: min(1440px, 100%);
+  max-width: none;
+  margin: 0 auto;
+  padding: 8px 28px 28px;
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  color: var(--ink-500);
+  font-size: 11px;
+}
+
+.page-footer strong {
+  color: var(--ink-800);
+}
+
+.page-footer a {
+  color: #0c7890;
+}
+
+@media (max-width: 960px) {
+  .hero-landscape {
+    right: -12%;
+    width: 66%;
+    opacity: 0.68;
+  }
+
+  .resort-controls {
+    grid-template-columns: minmax(240px, 1fr) auto;
+  }
+
+  .resort-filter-bar {
+    grid-column: 2;
+    grid-row: 1;
+  }
+
+  .resort-search-options {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 700px) {
+  .site-header-inner {
+    min-height: 64px;
+    padding: 0 16px;
+  }
+
+  .site-header-note,
+  .brand-copy span {
+    display: none;
+  }
+
+  .brand-mark {
+    width: 36px;
+    height: 36px;
+  }
+
+  main {
+    padding: 14px;
+  }
+
+  .forecast-hero {
+    min-height: 360px;
+    padding: 30px 24px 180px;
+    align-items: flex-start;
+    border-radius: 20px;
+  }
+
+  .forecast-hero h1 {
+    font-size: clamp(42px, 13vw, 58px);
+  }
+
+  .hero-lede {
+    margin-top: 16px;
+    font-size: 14px;
+  }
+
+  .report-date {
+    margin-top: 18px;
+    padding-top: 14px;
+    display: grid;
+    gap: 5px;
+  }
+
+  .report-generated {
+    padding-left: 0;
+    border-left: 0;
+  }
+
+  .hero-landscape {
+    right: -9%;
+    width: 112%;
+    height: 56%;
+    opacity: 0.85;
+  }
+
+  .hero-sun {
+    top: 10%;
+    right: 23%;
+    width: 44px;
+    height: 44px;
+  }
+
+  .control-panel {
+    position: static;
+    top: 8px;
+    margin: 12px 0 16px;
+    padding: 15px;
+    border-radius: 14px;
+  }
+
+  .control-panel-heading {
+    align-items: flex-start;
+    margin-bottom: 12px;
+  }
+
+  .control-panel-heading .eyebrow {
+    display: none;
+  }
+
+  .control-panel-heading h2 {
+    font-size: 16px;
+  }
+
+  .filter-summary {
+    max-width: 56%;
+    padding: 5px 8px;
+  }
+
+  .resort-controls {
+    grid-template-columns: 1fr auto;
+    gap: 9px;
+  }
+
+  .resort-search {
+    grid-column: 1 / -1;
+  }
+
+  .resort-search input {
+    height: 42px;
+  }
+
+  .resort-search-options {
+    grid-column: 1;
+    min-width: 0;
+    overflow-x: auto;
+    padding: 2px 0;
+  }
+
+  .resort-search-toggle span {
+    padding: 8px 10px;
+  }
+
+  .resort-filter-bar {
+    grid-column: 2;
+    grid-row: 2;
+  }
+
+  #filter-open-btn {
+    width: 42px;
+    padding: 0;
+    font-size: 0;
+  }
+
+  #filter-open-btn svg {
+    width: 19px;
+    height: 19px;
+  }
+
+  .forecast-overview {
+    margin-bottom: 16px;
+    padding: 18px 0 18px 18px;
+    border-radius: 18px;
+  }
+
+  .overview-heading {
+    padding-right: 18px;
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 5px;
+  }
+
+  .overview-heading h2 {
+    font-size: 24px;
+  }
+
+  .snow-pick-grid,
+  .loading-card-grid {
+    padding-right: 18px;
+    display: flex;
+    gap: 10px;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    scrollbar-width: none;
+  }
+
+  .snow-pick-grid::-webkit-scrollbar,
+  .loading-card-grid::-webkit-scrollbar {
+    display: none;
+  }
+
+  .snow-pick-card,
+  .skeleton-card {
+    width: min(78vw, 290px);
+    min-width: min(78vw, 290px);
+    scroll-snap-align: start;
+  }
+
+  .overview-empty {
+    width: calc(100vw - 64px);
+    min-width: calc(100vw - 64px);
+  }
+
+  .forecast-section {
+    margin-bottom: 12px;
+    padding: 16px 12px;
+    border-radius: 15px;
+  }
+
+  .forecast-section > h2,
+  .forecast-section .section-header {
+    padding: 0 3px;
+  }
+
+  .forecast-section h2 {
+    font-size: 17px;
+  }
+
+  body.mobile-simple {
+    --mobile-leading-col-max: max(0px, calc(42vw - 28px));
+    --mobile-single-leading-col-max: 42vw;
+  }
+
+  .compact-grid-mobile-wrap,
+  .snowfall-sticky-wrap,
+  .rain-sticky-wrap,
+  .temperature-sticky-wrap,
+  .weather-table-wrap,
+  .sun-single-wrap {
+    position: relative;
+    border-radius: 9px;
+    box-shadow: 12px 0 18px -18px rgba(8, 26, 41, 0.55) inset;
+  }
+
+  .page-footer {
+    padding: 8px 16px 24px;
+    flex-direction: column;
+    gap: 4px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}
   

--- a/assets/js/compact_daily_summary.js
+++ b/assets/js/compact_daily_summary.js
@@ -44,21 +44,21 @@
   const _tempColor = (value) => {
     const v = _asFiniteNumber(value);
     if (v === null) return "";
-    if (v < -10) return "background:#CFE8FF;";
+    if (v < -10) return "background:#DCEFF8;";
     if (v < 0) {
       const x = (v + 10) / 10;
-      const r = Math.round(207 + ((255 - 207) * x));
-      const g = Math.round(232 + ((255 - 232) * x));
-      return `background:rgb(${r},${g},255);`;
+      const r = Math.round(220 + ((248 - 220) * x));
+      const g = Math.round(239 + ((251 - 239) * x));
+      return `background:rgb(${r},${g},252);`;
     }
     if (v <= 20) {
       if (v <= 4) return "background:#FFFFFF;";
       const x = (v - 4) / 16;
-      const g = Math.round(255 + ((214 - 255) * x));
-      const b = Math.round(255 + ((214 - 255) * x));
+      const g = Math.round(255 + ((248 - 255) * x));
+      const b = Math.round(255 + ((240 - 255) * x));
       return `background:rgb(255,${g},${b});`;
     }
-    return "background:#FFD6D6;";
+    return "background:#FFF2E8;";
   };
 
   const _formatCompactValue = (value, digits = 1) => {

--- a/assets/js/resort_hourly.js
+++ b/assets/js/resort_hourly.js
@@ -11,6 +11,7 @@ const titleEl = document.getElementById("hourly-title");
 const localTimeEl = document.getElementById("resort-local-time");
 const websiteLinkEl = document.getElementById("resort-website-link");
 const locationLinkEl = document.getElementById("resort-location-link");
+const snapshotEl = document.getElementById("resort-snapshot");
 const timelineSection = document.getElementById("resort-timeline-section");
 const timelineRoot = document.getElementById("resort-timeline-root");
 const airportAccessSectionEl = document.getElementById("resort-airport-access-section");
@@ -413,6 +414,40 @@ const setChartError = (msg) => {
   chartErrorEl.textContent = text;
 };
 
+const renderResortSnapshot = () => {
+  if (!snapshotEl) return;
+  const daily = Array.isArray(dailySummary?.daily) ? dailySummary.daily : [];
+  const today = daily[0] && typeof daily[0] === "object" ? daily[0] : null;
+  if (!today) {
+    snapshotEl.hidden = true;
+    snapshotEl.innerHTML = "";
+    return;
+  }
+  const high = toFiniteNumber(today.temperature_max_c);
+  const low = toFiniteNumber(today.temperature_min_c);
+  const snow = daily.slice(0, 7).reduce((sum, day) => sum + (toFiniteNumber(day?.snowfall_cm) || 0), 0);
+  const rain = daily.slice(0, 7).reduce((sum, day) => sum + (toFiniteNumber(day?.rain_mm) || 0), 0);
+  const weatherCode = today.weather_code;
+  const weatherEmoji = window.CloseSnowWeatherCode?.emojiForWeatherCode
+    ? window.CloseSnowWeatherCode.emojiForWeatherCode(weatherCode)
+    : "❓";
+  const temperature = high === null || low === null ? "--" : `${Math.round(high)}° / ${Math.round(low)}°`;
+  snapshotEl.innerHTML = `
+    <article class="snapshot-card snapshot-card-weather">
+      <span class="snapshot-icon" aria-hidden="true">${weatherEmoji}</span>
+      <span><small>Today</small><strong>${temperature}</strong><em>High / low °C</em></span>
+    </article>
+    <article class="snapshot-card">
+      <span class="snapshot-icon snapshot-icon-snow" aria-hidden="true">❄</span>
+      <span><small>Next 7 days</small><strong>${snow.toFixed(1)} cm</strong><em>Forecast snow</em></span>
+    </article>
+    <article class="snapshot-card">
+      <span class="snapshot-icon snapshot-icon-rain" aria-hidden="true">◌</span>
+      <span><small>Next 7 days</small><strong>${rain.toFixed(1)} mm</strong><em>Forecast rain</em></span>
+    </article>`;
+  snapshotEl.hidden = false;
+};
+
 const toFiniteNumber = (value) => {
   if (value === null || value === undefined || value === "") return null;
   const num = Number(value);
@@ -798,6 +833,7 @@ if (hoursSelect) {
 }
 window.addEventListener("resize", rerenderChartsForResize);
 
+renderResortSnapshot();
 renderTimelineSummary();
 renderNearbyAirports(null);
 loadHourly();

--- a/assets/js/weather_page.js
+++ b/assets/js/weather_page.js
@@ -235,6 +235,65 @@ const _fallbackDayLabels = (count) => Array.from({ length: count }, (_, idx) => 
 
 const _emptyStateRow = (colspan, message) => `<tr><td class="empty-state-cell" colspan="${colspan}">${_escapeHtml(message)}</td></tr>`;
 
+const _overviewLocation = (report) => {
+  const parts = [report?.city, report?.admin1 || report?.country_code]
+    .map((value) => String(value || "").trim())
+    .filter(Boolean);
+  return parts.join(", ") || String(report?.region || "Mountain forecast").trim();
+};
+
+const _overviewValue = (kind, value, fallback = "--") => {
+  const numeric = _asFiniteNumber(value);
+  if (numeric === null) return `<span class="overview-value">${fallback}</span>`;
+  const display = kind === "temp" ? String(Math.round(numeric)) : numeric.toFixed(1);
+  return `<span class="overview-value" data-compact-unit-kind="${kind}" data-compact-metric-value="${numeric.toFixed(6)}">${display}</span>`;
+};
+
+const _renderForecastOverview = (reports) => {
+  const snowSorted = [...reports].sort((a, b) => (_weeklySnowfall(b) || 0) - (_weeklySnowfall(a) || 0));
+  const hasSnow = snowSorted.some((report) => (_weeklySnowfall(report) || 0) > 0);
+  const candidates = (hasSnow
+    ? snowSorted
+    : [...reports].sort((a, b) => (Number(b?.week1_total_rain_mm) || 0) - (Number(a?.week1_total_rain_mm) || 0)))
+    .slice(0, 3);
+  const outlookKind = hasSnow ? "snow" : "rain";
+  const outlookLabel = hasSnow ? "7-day snow" : "7-day rain";
+  const outlookUnit = hasSnow ? "cm" : "mm";
+  const cards = candidates.map((report, index) => {
+    const today = _dailyAt(report, 0);
+    const weatherCode = today.weather_code;
+    const weatherTitle = weatherCode === null || weatherCode === undefined || weatherCode === ""
+      ? "Weather unavailable"
+      : `WMO code: ${weatherCode}`;
+    return `
+      <article class="snow-pick-card">
+        <div class="snow-pick-card-topline">
+          <span class="snow-pick-rank">#${index + 1} ${hasSnow ? "snow" : "storm"} pick</span>
+          <span class="snow-pick-weather" title="${_escapeHtml(weatherTitle)}">${_weatherEmoji(weatherCode)}</span>
+        </div>
+        <h3>${_resortLinkHtml(report)}</h3>
+        <p>${_escapeHtml(_overviewLocation(report))}</p>
+        <div class="snow-pick-metrics">
+          <span><small>${outlookLabel}</small><strong>${_overviewValue(outlookKind, hasSnow ? _weeklySnowfall(report) : report?.week1_total_rain_mm)}<em data-compact-unit-label="${outlookKind}">${outlookUnit}</em></strong></span>
+          <span><small>Today high</small><strong>${_overviewValue("temp", today.temperature_max_c)}<em data-compact-unit-label="temp">°C</em></strong></span>
+        </div>
+      </article>`;
+  }).join("");
+  const empty = `
+    <div class="overview-empty">
+      <strong>No mountains in view</strong>
+      <span>Adjust your search or filters to bring forecast candidates back.</span>
+    </div>`;
+  return `
+    <section class="forecast-overview" aria-labelledby="forecast-overview-title">
+      <div class="overview-heading">
+        <div><p class="eyebrow">At a glance</p><h2 id="forecast-overview-title">${hasSnow ? "Best bets this week" : "Storm watch this week"}</h2></div>
+        <span>${hasSnow ? "Ranked by forecast snowfall" : "No accumulating snow · ranked by forecast rain"} across ${reports.length} visible resort${reports.length === 1 ? "" : "s"}</span>
+      </div>
+      <div class="snow-pick-grid">${cards || empty}</div>
+    </section>`;
+};
+
 const _renderCompactGridSection = (reports, emptyMessage = "No resorts match the current filters.") => {
   const displayDays = _displayDays();
   const labels = reports.length
@@ -251,7 +310,7 @@ const _renderCompactGridSection = (reports, emptyMessage = "No resorts match the
     return `<tr${attrs}>${_resortCellHtml(report)}${cells}</tr>`;
   }).join("") : _emptyStateRow(2 + Math.max(1, displayDays), emptyMessage);
   return `
-    <section>
+    <section class="forecast-section forecast-section-daily">
       <div class="section-header">
         <h2>Daily Summary</h2>
         <div class="unit-toggle" role="group" aria-label="Daily Summary unit system" data-compact-summary-toggle="1" data-mode="${appState.compactSummaryUnitMode}">
@@ -298,7 +357,7 @@ const _renderPrecipSection = (title, kind, metricUnit, imperialUnit, reports, op
       return `<tr${attrs}>${_mobilePrecipResortCellHtml(report)}${weeklyValues.join("")}${dailyValues.join("")}</tr>`;
     }).join("") : _emptyStateRow(3 + Math.max(1, displayDays), emptyMessage);
     return `
-      <section>
+      <section class="forecast-section forecast-section-precip">
         <div class="section-header">
           <h2>${title}</h2>
           <div class="unit-toggle" role="group" aria-label="${title} unit system" data-target-kind="${kind}">
@@ -335,7 +394,7 @@ const _renderPrecipSection = (title, kind, metricUnit, imperialUnit, reports, op
     return `<tr${attrs}>${_resortCellHtml(report)}${weeklyValues.join("")}${dailyValues}</tr>`;
   }).join("") : _emptyStateRow(4 + Math.max(1, displayDays), emptyMessage);
   return `
-    <section>
+    <section class="forecast-section forecast-section-precip">
       <div class="section-header">
         <h2>${title}</h2>
         <div class="unit-toggle" role="group" aria-label="${title} unit system" data-target-kind="${kind}">
@@ -377,7 +436,7 @@ const _renderTemperatureSection = (reports, emptyMessage = "No resorts match the
     return `<tr${attrs}>${_resortCellHtml(report)}${cells}</tr>`;
   }).join("") : _emptyStateRow(2 + Math.max(1, displayDays * 2), emptyMessage);
   return `
-    <section>
+    <section class="forecast-section forecast-section-temperature">
       <div class="section-header">
         <h2>Temperature</h2>
         <div class="unit-toggle" role="group" aria-label="Temperature unit system" data-target-kind="temp">
@@ -414,8 +473,11 @@ const _renderWeatherSection = (reports, emptyMessage = "No resorts match the cur
   }).join("");
   const rows = reports.length ? reports.map((report) => `<tr${_filterAttrs(report)}>${_resortCellHtml(report)}${weatherCells(report)}</tr>`).join("") : _emptyStateRow(2 + Math.max(1, displayDays), emptyMessage);
   return `
-    <section>
-      <h2>Weather</h2>
+    <section class="forecast-section forecast-section-weather">
+      <div class="section-header">
+        <h2>Weather</h2>
+        <span class="section-note">Daily conditions</span>
+      </div>
       <div
         class='weather-table-wrap'
         id='weather-table-wrap'
@@ -466,7 +528,7 @@ const _renderSunSection = (reports, emptyMessage = "No resorts match the current
     return `<tr${attrs}>${_resortCellHtml(report)}${cells}</tr>`;
   }).join("") : _emptyStateRow(totalColumns, emptyMessage);
   return `
-    <section>
+    <section class="forecast-section forecast-section-sun">
       <div class="section-header">
         <h2>Sunrise / Sunset</h2>
         <div class="unit-toggle" role="group" aria-label="Sunrise and sunset time format" data-sun-time-toggle="1" data-mode="${appState.sunTimeToggleMode}">
@@ -492,6 +554,7 @@ const _renderSunSection = (reports, emptyMessage = "No resorts match the current
 };
 
 const _renderSections = (reports, emptyMessage = "No resorts match the current filters.") => [
+  _renderForecastOverview(reports),
   _renderCompactGridSection(reports, emptyMessage),
   _renderPrecipSection("Snowfall", "snow", "cm", "in", reports, {
     prefix: "snowfall",
@@ -1369,6 +1432,12 @@ const renderCompactSummaryValues = () => {
         ? (metricValue / 25.4).toFixed(2)
         : metricValue.toFixed(1);
     }
+  });
+  document.querySelectorAll("[data-compact-unit-label]").forEach((el) => {
+    const kind = String(el.getAttribute("data-compact-unit-label") || "").trim();
+    if (kind === "snow") el.textContent = mode === "imperial" ? "in" : "cm";
+    if (kind === "temp") el.textContent = mode === "imperial" ? "°F" : "°C";
+    if (kind === "rain") el.textContent = mode === "imperial" ? "in" : "mm";
   });
 };
 

--- a/assets/js/weather_page_formatters.js
+++ b/assets/js/weather_page_formatters.js
@@ -78,21 +78,21 @@
   const tempColor = (value) => {
     const v = asFiniteNumber(value);
     if (v === null) return "";
-    if (v < -10) return "background:#CFE8FF;";
+    if (v < -10) return "background:#DCEFF8;";
     if (v < 0) {
       const x = (v + 10) / 10;
-      const r = Math.round(207 + ((255 - 207) * x));
-      const g = Math.round(232 + ((255 - 232) * x));
-      return `background:rgb(${r},${g},255);`;
+      const r = Math.round(220 + ((248 - 220) * x));
+      const g = Math.round(239 + ((251 - 239) * x));
+      return `background:rgb(${r},${g},252);`;
     }
     if (v <= 20) {
       if (v <= 4) return "background:#FFFFFF;";
       const x = (v - 4) / 16;
-      const g = Math.round(255 + ((214 - 255) * x));
-      const b = Math.round(255 + ((214 - 255) * x));
+      const g = Math.round(255 + ((248 - 255) * x));
+      const b = Math.round(255 + ((240 - 255) * x));
       return `background:rgb(255,${g},${b});`;
     }
-    return "background:#FFD6D6;";
+    return "background:#FFF2E8;";
   };
 
   const metricCellHtml = (rawValue, kind, style = "", klass = "") => {

--- a/src/web/templates/resort_hourly_page.html
+++ b/src/web/templates/resort_hourly_page.html
@@ -7,42 +7,78 @@
   <link rel="stylesheet" href="{{asset_prefix}}/css/resort_hourly.css" />
 </head>
 <body>
+  <header class="site-header">
+    <div class="site-header-inner">
+      <a class="brand" href="{{back_href}}" aria-label="CloseSnow home">
+        <span class="brand-mark" aria-hidden="true">
+          <svg viewBox="0 0 42 42" role="img"><path d="M4 31.5 14.3 17l5.1 6.7L27.1 11 38 31.5H4Z" /><path d="m14.3 17 3.1 4.1 2-2.4 3.3 4.7 4.4-12.4" /></svg>
+        </span>
+        <span class="brand-copy"><strong>CloseSnow</strong><span>Mountain weather, made useful</span></span>
+      </a>
+      <span class="site-header-note"><span aria-hidden="true"></span> Resort intelligence</span>
+    </div>
+  </header>
   <main>
-    <a class="back-link" href="{{back_href}}">Back to Main Forecast</a>
-    <h1 id="hourly-title">Resort Forecast</h1>
-    <p id="resort-local-time" class="resort-local-time"></p>
-    <p id="resort-website-link" class="resort-website-link"></p>
-    <p id="resort-location-link" class="resort-location-link"></p>
+    <section class="resort-hero" aria-labelledby="hourly-title">
+      <a class="back-link" href="{{back_href}}"><span aria-hidden="true">←</span> Back to all resorts</a>
+      <p class="eyebrow">Mountain forecast</p>
+      <h1 id="hourly-title">Resort Forecast</h1>
+      <div class="resort-identity-meta">
+        <p id="resort-local-time" class="resort-local-time"></p>
+        <p id="resort-website-link" class="resort-website-link"></p>
+        <p id="resort-location-link" class="resort-location-link"></p>
+      </div>
+      <div id="resort-snapshot" class="resort-snapshot" aria-label="Resort forecast overview"></div>
+      <div class="resort-hero-mountain" aria-hidden="true">
+        <svg viewBox="0 0 420 180" preserveAspectRatio="none"><path d="M18 178 120 62l42 50 56-86 170 152H18Z" /><path d="m120 62 42 50 56-86 55 49" /></svg>
+      </div>
+    </section>
     <section id="resort-timeline-section" class="resort-timeline-section" hidden>
-      <h2>Past 14 days + forecast</h2>
+      <div class="section-heading">
+        <div><p class="eyebrow">Snow timeline</p><h2>Past 14 days + forecast</h2></div>
+        <span>Swipe to explore</span>
+      </div>
       <div id="resort-timeline-root"></div>
     </section>
     <section id="resort-airport-access-section" class="resort-airport-access-section" hidden>
-      <h2>Nearby airports (&lt;250 miles)</h2>
+      <div class="section-heading">
+        <div><p class="eyebrow">Getting there</p><h2>Nearby airports (&lt;250 miles)</h2></div>
+      </div>
       <div id="resort-airport-access-root"></div>
     </section>
-    <p class="hourly-section-title">Hourly forecast</p>
-    <div class="hourly-controls">
-      <label for="hours-select">Hours</label>
-      <select id="hours-select">
-        <option value="24">24</option>
-        <option value="48">48</option>
-        <option value="72" selected>72</option>
-        <option value="120">120</option>
-      </select>
-      <button id="hours-refresh-btn" type="button">Refresh</button>
-    </div>
-    <p id="hourly-meta" class="hourly-meta">Loading...</p>
-    <div id="hourly-error" class="hourly-error" hidden></div>
-    <div id="hourly-chart-error" class="hourly-chart-error" hidden></div>
-    <section id="hourly-charts" class="hourly-charts" aria-live="polite"></section>
-    <div class="table-wrap">
-      <table id="hourly-table" class="hourly-table">
-        <thead></thead>
-        <tbody></tbody>
-      </table>
-    </div>
+    <section class="hourly-workspace" aria-labelledby="hourly-section-title">
+      <div class="hourly-workspace-heading">
+        <div>
+          <p class="eyebrow">Weather, hour by hour</p>
+          <h2 id="hourly-section-title" class="hourly-section-title">Hourly forecast</h2>
+        </div>
+        <div class="hourly-controls">
+          <label for="hours-select">Range</label>
+          <select id="hours-select">
+            <option value="24">24 hours</option>
+            <option value="48">48 hours</option>
+            <option value="72" selected>72 hours</option>
+            <option value="120">120 hours</option>
+          </select>
+          <button id="hours-refresh-btn" type="button">Refresh</button>
+        </div>
+      </div>
+      <p id="hourly-meta" class="hourly-meta">Loading...</p>
+      <div id="hourly-error" class="hourly-error" hidden></div>
+      <div id="hourly-chart-error" class="hourly-chart-error" hidden></div>
+      <section id="hourly-charts" class="hourly-charts" aria-live="polite"></section>
+      <details class="raw-data-panel">
+        <summary>View raw hourly data</summary>
+        <div class="table-wrap">
+          <table id="hourly-table" class="hourly-table">
+            <thead></thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </details>
+    </section>
   </main>
+  <footer class="page-footer"><strong>CloseSnow</strong> · Forecast data for better mountain days.</footer>
   <script>
     window.CLOSESNOW_HOURLY_CONTEXT = {{hourly_context_json}};
   </script>

--- a/src/web/templates/weather_page.html
+++ b/src/web/templates/weather_page.html
@@ -15,35 +15,83 @@
   <link rel="stylesheet" href="assets/css/weather_page.css" />
 </head>
 <body class="units-pending">
-  <main>
-    <h1>Ski Resorts Weather Forecast</h1>
-    <div class="report-date">
-      <div class="report-powered">
-        Powered by <a href="https://open-meteo.com/en/docs/ecmwf-api" target="_blank" rel="noopener noreferrer">Open-Meteo ECMWF IFS 0.25</a>
-      </div>
-      <div id="report-date" class="report-generated" data-generated-utc="{{generated_utc_iso}}">Generated At: loading...</div>
+  <header class="site-header">
+    <div class="site-header-inner">
+      <a class="brand" href="./" aria-label="CloseSnow home">
+        <span class="brand-mark" aria-hidden="true">
+          <svg viewBox="0 0 42 42" role="img">
+            <path d="M4 31.5 14.3 17l5.1 6.7L27.1 11 38 31.5H4Z" />
+            <path d="m14.3 17 3.1 4.1 2-2.4 3.3 4.7 4.4-12.4" />
+          </svg>
+        </span>
+        <span class="brand-copy">
+          <strong>CloseSnow</strong>
+          <span>Mountain weather, made useful</span>
+        </span>
+      </a>
+      <span class="site-header-note"><span aria-hidden="true"></span> Fresh mountain intelligence</span>
     </div>
-    <div class="resort-controls">
-      <div class="resort-search">
-        <label for="resort-search-input">Search Resorts</label>
-        <input id="resort-search-input" type="search" placeholder="Name, state, or pass type" autocomplete="off" />
-        <button id="resort-search-clear" type="button">Clear</button>
+  </header>
+  <main>
+    <section class="forecast-hero" aria-labelledby="page-title">
+      <div class="forecast-hero-copy">
+        <p class="eyebrow">Ski Resorts Weather Forecast</p>
+        <h1 id="page-title">Find your next <span>snow day.</span></h1>
+        <p class="hero-lede">Compare the mountains at a glance, follow the strongest storms, and plan with confidence.</p>
+        <div class="report-date">
+          <div class="report-powered">
+            Forecast model <a href="https://open-meteo.com/en/docs/ecmwf-api" target="_blank" rel="noopener noreferrer">Open-Meteo ECMWF IFS 0.25</a>
+          </div>
+          <div id="report-date" class="report-generated" data-generated-utc="{{generated_utc_iso}}">Generated At: loading...</div>
+        </div>
       </div>
-      <div class="resort-search-options">
-        <label class="resort-search-toggle">
-          <input type="checkbox" id="filter-search-all" checked />
-          Search all resorts
-        </label>
-        <label class="resort-search-toggle">
-          <input type="checkbox" id="favorites-only-toggle" />
-          Favorites only
-        </label>
+      <div class="hero-landscape" aria-hidden="true">
+        <span class="hero-sun"></span>
+        <svg viewBox="0 0 560 250" preserveAspectRatio="none">
+          <path class="mountain-back" d="M0 207 78 137l44 36 77-105 63 84 40-51 100 106H0Z" />
+          <path class="mountain-front" d="M138 220 262 92l41 48 46-62 135 142H138Z" />
+          <path class="snow-line" d="m78 137 23 19 21 17 77-105 29 39 34 45 40-51 36 38" />
+          <path class="snow-line snow-line-front" d="m262 92 41 48 46-62 48 51" />
+        </svg>
+        <span class="hero-contour hero-contour-one"></span>
+        <span class="hero-contour hero-contour-two"></span>
       </div>
-      <div class="resort-filter-bar">
-        <button id="filter-open-btn" type="button">Filters</button>
+    </section>
+    <section class="control-panel" aria-labelledby="explore-title">
+      <div class="control-panel-heading">
+        <div>
+          <p class="eyebrow">Your mountain finder</p>
+          <h2 id="explore-title">Explore the forecast</h2>
+        </div>
         <span id="filter-summary" class="filter-summary">Default resorts</span>
       </div>
-    </div>
+      <div class="resort-controls">
+        <div class="resort-search">
+          <label class="sr-only" for="resort-search-input">Search Resorts</label>
+          <span class="search-field">
+            <svg aria-hidden="true" viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"></circle><path d="m16.2 16.2 4.1 4.1"></path></svg>
+            <input id="resort-search-input" type="search" placeholder="Search name, state, or pass" autocomplete="off" />
+          </span>
+          <button id="resort-search-clear" type="button">Clear</button>
+        </div>
+        <div class="resort-search-options" aria-label="Quick filters">
+          <label class="resort-search-toggle">
+            <input type="checkbox" id="filter-search-all" checked />
+            <span>Search all resorts</span>
+          </label>
+          <label class="resort-search-toggle">
+            <input type="checkbox" id="favorites-only-toggle" />
+            <span>Favorites only</span>
+          </label>
+        </div>
+        <div class="resort-filter-bar">
+          <button id="filter-open-btn" type="button">
+            <svg aria-hidden="true" viewBox="0 0 24 24"><path d="M4 7h16M7 12h10M10 17h4"></path></svg>
+            Filters &amp; sorting
+          </button>
+        </div>
+      </div>
+    </section>
     <div id="filter-modal" class="filter-modal" hidden>
       <div class="filter-panel" role="dialog" aria-modal="true" aria-labelledby="filter-title">
         <h3 id="filter-title">Resort Filters</h3>
@@ -91,7 +139,8 @@
     </div>
   </main>
   <footer class="page-footer">
-    Author: Codex, vibed by <a href="https://ljcc0930.github.io/" target="_blank" rel="noopener noreferrer">ljcc</a>. <a href="https://github.com/ljcc0930/CloseSnow/issues/new?template=feature_request.yml" target="_blank" rel="noopener noreferrer">Feature requests</a> are welcome.
+    <span><strong>CloseSnow</strong> · Built for better mountain days.</span>
+    <span>Made by <a href="https://ljcc0930.github.io/" target="_blank" rel="noopener noreferrer">ljcc</a> with Codex · <a href="https://github.com/ljcc0930/CloseSnow/issues/new?template=feature_request.yml" target="_blank" rel="noopener noreferrer">Request a feature</a></span>
   </footer>
   <script>
     window.CLOSESNOW_FILTER_META = {{filter_meta_json}};

--- a/src/web/weather_html_renderer.py
+++ b/src/web/weather_html_renderer.py
@@ -9,12 +9,16 @@ from typing import Any, Dict, List
 _PAGE_TEMPLATE = (Path(__file__).resolve().parent / "templates" / "weather_page.html").read_text(encoding="utf-8")
 
 _PAGE_SHELL_PLACEHOLDER = """
-    <section><h2>Daily Summary</h2><p class="section-loading">Loading forecast...</p></section>
-    <section><h2>Snowfall</h2><p class="section-loading">Loading forecast...</p></section>
-    <section><h2>Rainfall</h2><p class="section-loading">Loading forecast...</p></section>
-    <section><h2>Temperature</h2><p class="section-loading">Loading forecast...</p></section>
-    <section><h2>Weather</h2><p class="section-loading">Loading forecast...</p></section>
-    <section><h2>Sunrise / Sunset</h2><p class="section-loading">Loading forecast...</p></section>
+    <section class="forecast-overview forecast-loading-overview" aria-hidden="true">
+      <div class="skeleton skeleton-heading"></div>
+      <div class="loading-card-grid"><div class="skeleton skeleton-card"></div><div class="skeleton skeleton-card"></div><div class="skeleton skeleton-card"></div></div>
+    </section>
+    <section class="forecast-section forecast-section-loading"><h2>Daily Summary</h2><div class="skeleton skeleton-table"></div><p class="section-loading sr-only">Loading forecast...</p></section>
+    <section class="forecast-section forecast-section-loading"><h2>Snowfall</h2><div class="skeleton skeleton-table"></div></section>
+    <section class="forecast-section forecast-section-loading"><h2>Rainfall</h2><div class="skeleton skeleton-table"></div></section>
+    <section class="forecast-section forecast-section-loading"><h2>Temperature</h2><div class="skeleton skeleton-table"></div></section>
+    <section class="forecast-section forecast-section-loading"><h2>Weather</h2><div class="skeleton skeleton-table"></div></section>
+    <section class="forecast-section forecast-section-loading"><h2>Sunrise / Sunset</h2><div class="skeleton skeleton-table"></div></section>
 """
 
 

--- a/tests/frontend/test_renderers.py
+++ b/tests/frontend/test_renderers.py
@@ -243,6 +243,10 @@ def test_build_html_contains_meta_sections():
     )
     assert "<!doctype html>" in html
     assert "Ski Resorts Weather Forecast" in html
+    assert "CloseSnow" in html
+    assert "Find your next <span>snow day.</span>" in html
+    assert "forecast-loading-overview" in html
+    assert 'class="skeleton skeleton-table"' in html
     assert "<h2>Daily Summary</h2>" in html
     assert "<h2>Sunrise / Sunset</h2>" in html
     assert 'src="assets/js/weather_page_formatters.js"' in html

--- a/tests/frontend/test_static_site_pipeline.py
+++ b/tests/frontend/test_static_site_pipeline.py
@@ -122,7 +122,9 @@ def test_render_hourly_pages(tmp_path):
     assert "../../assets/js/resort_hourly_metrics.js" in html
     assert html.index("../../assets/js/resort_hourly_metrics.js") < html.index("../../assets/js/resort_hourly.js")
     assert '<h1 id="hourly-title">Resort Forecast</h1>' in html
+    assert 'id="resort-snapshot"' in html
     assert 'id="hourly-charts"' in html
+    assert 'class="raw-data-panel"' in html
     context = _hourly_context_from_html(html)
     assert context["resortId"] == "snowbird-ut"
     assert context["dailySummary"]["display_name"] == "Snowbird, Utah"


### PR DESCRIPTION
## Summary

- introduce a cohesive CloseSnow alpine brand shell across the homepage and resort pages
- add a data-derived weekly storm outlook with snowfall-first and rain fallback ranking
- reorganize filters, forecast tables, resort context, charts, and raw hourly data into responsive cards
- replace repetitive loading copy with structured skeleton surfaces
- refine forecast heat colors and contain horizontal tables at mobile widths

## Validation

- `./scripts/lint.sh`
- `python3 -m pytest -q` — 257 passed
- `python3 -m src.cli static --output-dir /private/tmp/closesnow-alpine-ui-preview --max-workers 8`
- browser QA at desktop, 1280px, and 390px widths; no page-level horizontal overflow
