### PR TITLE
Build Alpine Field Guide frontend foundation

### DIFF
--- a/assets/css/field_guide_foundation.css
+++ b/assets/css/field_guide_foundation.css
@@ -1,0 +1,471 @@
+/* CloseSnow Alpine Field Guide: shared visual primitives for every forecast surface. */
+:root {
+  color-scheme: light;
+  --fg-ink: #17252e;
+  --fg-ink-muted: #526671;
+  --fg-ink-subtle: #71838c;
+  --fg-paper: #fbfcfa;
+  --fg-surface: #ffffff;
+  --fg-surface-muted: #f1f5f3;
+  --fg-line: #d8e1dd;
+  --fg-line-strong: #b8c7c1;
+  --fg-glacier: #167a9b;
+  --fg-glacier-soft: #dceff5;
+  --fg-pine: #16705d;
+  --fg-pine-soft: #dcefe9;
+  --fg-signal: #c75518;
+  --fg-signal-soft: #fbe7da;
+  --fg-danger: #a43e38;
+  --fg-focus: #167a9b;
+  --fg-header: #122b36;
+  --fg-header-copy: #f7fbfa;
+  --fg-radius-sm: 4px;
+  --fg-radius-md: 8px;
+  --fg-radius-lg: 12px;
+  --fg-shadow-overlay: 0 18px 48px rgba(23, 37, 46, 0.2);
+  --fg-shadow-raised: 0 8px 22px rgba(23, 37, 46, 0.1);
+  --fg-space-1: 0.25rem;
+  --fg-space-2: 0.5rem;
+  --fg-space-3: 0.75rem;
+  --fg-space-4: 1rem;
+  --fg-space-5: 1.5rem;
+  --fg-space-6: 2rem;
+  --fg-page-gutter: clamp(0.875rem, 2.4vw, 1.75rem);
+  --fg-content-max: 90rem;
+
+  /* Compatibility aliases while page-specific styles move onto the foundation. */
+  --ink-950: var(--fg-header);
+  --ink-900: var(--fg-ink);
+  --ink-800: #29414c;
+  --ink-700: var(--fg-ink-muted);
+  --ink-500: var(--fg-ink-subtle);
+  --snow-50: var(--fg-paper);
+  --snow-100: var(--fg-surface-muted);
+  --snow-200: var(--fg-line);
+  --glacier-300: #8dcbdc;
+  --glacier-500: #2c94b0;
+  --glacier-600: var(--fg-glacier);
+  --surface: var(--fg-surface);
+  --surface-soft: var(--fg-surface-muted);
+  --border: var(--fg-line);
+  --radius-sm: var(--fg-radius-sm);
+  --radius-md: var(--fg-radius-md);
+  --radius-lg: var(--fg-radius-lg);
+  --shadow-card: none;
+  --shadow-soft: var(--fg-shadow-overlay);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  min-width: 20rem;
+  background: var(--fg-paper);
+  text-size-adjust: 100%;
+}
+
+body {
+  min-width: 0;
+  margin: 0;
+  overflow-x: clip;
+  color: var(--fg-ink);
+  background: var(--fg-paper);
+  font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 1rem;
+  line-height: 1.55;
+  font-variant-numeric: tabular-nums lining-nums;
+  -webkit-font-smoothing: antialiased;
+}
+
+button,
+input,
+select,
+textarea {
+  color: inherit;
+  font: inherit;
+  font-variant-numeric: inherit;
+}
+
+a {
+  color: var(--fg-glacier);
+  text-underline-offset: 0.18em;
+}
+
+:where(a, button, input, select, textarea, summary, [tabindex]):focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--fg-focus) 34%, transparent);
+  outline-offset: 3px;
+}
+
+.sr-only,
+.fg-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.site-header {
+  position: relative;
+  z-index: 30;
+  min-height: 56px;
+  color: var(--fg-header-copy);
+  background: var(--fg-header);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.site-header-inner {
+  width: min(var(--fg-content-max), 100%);
+  height: 56px;
+  min-height: 56px;
+  margin-inline: auto;
+  padding-inline: var(--fg-page-gutter);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--fg-space-3);
+}
+
+.brand {
+  min-width: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.625rem;
+  color: var(--fg-header-copy);
+  text-decoration: none;
+}
+
+.brand:hover {
+  color: #bde8f2;
+}
+
+.brand-mark {
+  width: 34px;
+  height: 34px;
+  flex: 0 0 34px;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  border-radius: var(--fg-radius-md);
+  display: grid;
+  place-items: center;
+  color: var(--fg-header);
+  background: #dceff5;
+  box-shadow: none;
+}
+
+.brand-mark svg {
+  width: 26px;
+  height: 26px;
+  fill: currentColor;
+}
+
+.brand-mark svg path + path {
+  fill: none;
+  stroke: #ffffff;
+  stroke-width: 2.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.brand-copy {
+  min-width: 0;
+  display: grid;
+  gap: 0;
+}
+
+.brand-copy strong {
+  font-size: 1rem;
+  line-height: 1.1;
+  letter-spacing: -0.015em;
+}
+
+.brand-copy span {
+  overflow: hidden;
+  color: #b9cbd1;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  text-transform: none;
+  white-space: nowrap;
+}
+
+.site-header-actions {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--fg-space-3);
+}
+
+.site-header-note {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--fg-space-2);
+  color: #cad8dc;
+  font-size: 0.75rem;
+  font-weight: 650;
+}
+
+.site-header-note > span {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: #71d3af;
+  box-shadow: none;
+}
+
+.field-guide-unit-switch {
+  min-height: 34px;
+  padding: 0.375rem 0.625rem;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  border-radius: var(--fg-radius-md);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  color: var(--fg-header-copy);
+  background: rgba(255, 255, 255, 0.08);
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 750;
+  line-height: 1;
+}
+
+.field-guide-unit-switch:hover {
+  border-color: rgba(255, 255, 255, 0.52);
+  background: rgba(255, 255, 255, 0.14);
+}
+
+.field-guide-unit-switch svg {
+  width: 1rem;
+  height: 1rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.8;
+}
+
+.fg-button {
+  min-height: 40px;
+  padding: 0.625rem 0.875rem;
+  border: 1px solid var(--fg-line-strong);
+  border-radius: var(--fg-radius-md);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--fg-space-2);
+  color: var(--fg-ink);
+  background: var(--fg-surface);
+  cursor: pointer;
+  font-weight: 700;
+  line-height: 1.1;
+  text-decoration: none;
+}
+
+.fg-button:hover {
+  border-color: var(--fg-glacier);
+  color: var(--fg-glacier);
+}
+
+.fg-button--primary {
+  border-color: var(--fg-glacier);
+  color: #ffffff;
+  background: var(--fg-glacier);
+}
+
+.fg-button--primary:hover {
+  border-color: #0f647f;
+  color: #ffffff;
+  background: #0f647f;
+}
+
+.fg-card {
+  border: 1px solid var(--fg-line);
+  border-radius: var(--fg-radius-md);
+  color: var(--fg-ink);
+  background: var(--fg-surface);
+  box-shadow: none;
+}
+
+.fg-card[data-elevation="raised"] {
+  box-shadow: var(--fg-shadow-raised);
+}
+
+.fg-overlay {
+  box-shadow: var(--fg-shadow-overlay);
+}
+
+.fg-tab-list,
+[data-field-guide-tabs] {
+  padding: 0.25rem;
+  border: 1px solid var(--fg-line);
+  border-radius: var(--fg-radius-md);
+  display: inline-flex;
+  gap: 0.25rem;
+  background: var(--fg-surface-muted);
+}
+
+.fg-tab,
+[data-field-guide-tab] {
+  min-height: 36px;
+  padding: 0.5rem 0.75rem;
+  border: 0;
+  border-radius: var(--fg-radius-sm);
+  color: var(--fg-ink-muted);
+  background: transparent;
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.fg-tab[aria-selected="true"],
+[data-field-guide-tab][aria-selected="true"] {
+  color: var(--fg-ink);
+  background: var(--fg-surface);
+}
+
+.fg-disclosure,
+details[data-field-guide-disclosure] {
+  border: 1px solid var(--fg-line);
+  border-radius: var(--fg-radius-md);
+  background: var(--fg-surface);
+}
+
+.fg-disclosure > summary,
+details[data-field-guide-disclosure] > summary {
+  padding: 0.75rem 0.875rem;
+  cursor: pointer;
+  font-weight: 750;
+}
+
+.fg-number,
+[data-field-guide-number] {
+  font-variant-numeric: tabular-nums lining-nums;
+  letter-spacing: -0.01em;
+}
+
+.fg-stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--fg-stack-space, var(--fg-space-4));
+}
+
+.fg-cluster {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--fg-cluster-space, var(--fg-space-3));
+}
+
+.fg-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, var(--fg-grid-min, 15rem)), 1fr));
+  gap: var(--fg-grid-space, var(--fg-space-4));
+}
+
+.field-guide-weather-icon {
+  width: 1.5em;
+  height: 1.5em;
+  display: inline-grid;
+  place-items: center;
+  color: var(--fg-ink-muted);
+  line-height: 1;
+  vertical-align: -0.3em;
+}
+
+.field-guide-weather-icon svg {
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.8;
+}
+
+.field-guide-weather-icon[data-weather-kind="clear"],
+.field-guide-weather-icon[data-weather-kind="partly-cloudy"] {
+  color: var(--fg-signal);
+}
+
+.field-guide-weather-icon[data-weather-kind="snow"],
+.field-guide-weather-icon[data-metric-kind="snow"],
+.field-guide-weather-icon[data-metric-kind="temperature"] {
+  color: var(--fg-glacier);
+}
+
+.field-guide-weather-icon[data-weather-kind="rain"],
+.field-guide-weather-icon[data-weather-kind="drizzle"],
+.field-guide-weather-icon[data-metric-kind="rain"] {
+  color: var(--fg-pine);
+}
+
+.field-guide-weather-icon[data-weather-kind="thunderstorm"],
+.field-guide-weather-icon[data-weather-kind="unknown"] {
+  color: var(--fg-signal);
+}
+
+.compact-weather .field-guide-weather-icon,
+.weather-emoji-cell .field-guide-weather-icon,
+.snow-pick-weather .field-guide-weather-icon {
+  width: 1em;
+  height: 1em;
+}
+
+.compact-pair-icon .field-guide-weather-icon {
+  width: 1rem;
+  height: 1rem;
+  vertical-align: -0.2em;
+}
+
+.snapshot-icon .field-guide-weather-icon {
+  width: 1.5rem;
+  height: 1.5rem;
+  color: currentColor;
+}
+
+.snapshot-card-weather .snapshot-icon {
+  color: #dceff5;
+}
+
+@media (max-width: 700px) {
+  :root {
+    --fg-page-gutter: 0.875rem;
+  }
+
+  .site-header-inner {
+    height: 56px;
+    min-height: 56px;
+  }
+
+  .site-header-note,
+  .brand-copy span {
+    display: none;
+  }
+
+  .site-header-actions {
+    gap: var(--fg-space-2);
+  }
+
+  .field-guide-unit-switch {
+    padding-inline: 0.5rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}

--- a/assets/js/compact_daily_summary.js
+++ b/assets/js/compact_daily_summary.js
@@ -1,4 +1,8 @@
 (function () {
+  const fieldGuide = window.CloseSnowFieldGuide || {};
+  const fieldGuideUnits = fieldGuide.units || {};
+  const fieldGuideWeather = fieldGuide.weather || {};
+
   const _asFiniteNumber = (value) => {
     if (value === null || value === undefined || value === "") return null;
     const num = Number(value);
@@ -26,10 +30,13 @@
     return `${month}-${day}\n${weekday}`;
   };
 
-  const _weatherEmoji = (rawCode) => {
-    const helper = window.CloseSnowWeatherCode?.emojiForWeatherCode;
-    return helper ? helper(rawCode) : "❓";
-  };
+  const _weatherIcon = (rawCode) => (fieldGuideWeather.iconHtml
+    ? fieldGuideWeather.iconHtml(rawCode)
+    : '<span class="field-guide-weather-icon" role="img" aria-label="Conditions unavailable">?</span>');
+
+  const _metricIcon = (kind, label) => (fieldGuideWeather.metricIconHtml
+    ? fieldGuideWeather.metricIconHtml(kind, { label })
+    : `<span class="field-guide-weather-icon" role="img" aria-label="${_escapeHtml(label)}">?</span>`);
 
   const _snowColor = (value) => {
     const v = _asFiniteNumber(value);
@@ -71,6 +78,9 @@
   const _formatCompactSnowValue = (value, unitMode) => {
     const num = _asFiniteNumber(value);
     if (num === null) return "--";
+    if (fieldGuideUnits.formatSnow) {
+      return fieldGuideUnits.formatSnow(num, unitMode, { withUnit: false, fallback: "--" });
+    }
     if (_normalizeUnitMode(unitMode) === "imperial") return (num / 2.54).toFixed(1);
     return _formatCompactValue(num);
   };
@@ -78,6 +88,9 @@
   const _formatCompactRainValue = (value, unitMode) => {
     const num = _asFiniteNumber(value);
     if (num === null) return "--";
+    if (fieldGuideUnits.formatRain) {
+      return fieldGuideUnits.formatRain(num, unitMode, { withUnit: false, fallback: "--" });
+    }
     if (_normalizeUnitMode(unitMode) === "imperial") return (num / 25.4).toFixed(2);
     return _formatCompactValue(num);
   };
@@ -85,6 +98,9 @@
   const _formatCompactTempValue = (value, unitMode) => {
     const num = _asFiniteNumber(value);
     if (num === null) return "--";
+    if (fieldGuideUnits.formatTemperature) {
+      return fieldGuideUnits.formatTemperature(num, unitMode, { withUnit: false, digits: 0, fallback: "--" });
+    }
     if (_normalizeUnitMode(unitMode) === "imperial") return String(Math.round((num * 9 / 5) + 32));
     return String(Math.round(num));
   };
@@ -116,7 +132,7 @@
   const dayCellHtml = (day, options = {}) => {
     const unitMode = _normalizeUnitMode(options.unitMode);
     const weatherCode = day?.weather_code;
-    const weatherEmoji = _weatherEmoji(weatherCode);
+    const weatherIcon = _weatherIcon(weatherCode);
     const highTemp = _formatCompactTempValue(day?.temperature_max_c, unitMode);
     const lowTemp = _formatCompactTempValue(day?.temperature_min_c, unitMode);
     const snowValue = _formatCompactSnowValue(day?.snowfall_cm, unitMode);
@@ -124,15 +140,15 @@
     return `
       <div class="compact-day-card">
         <div class="compact-row compact-row-primary">
-          <div class="compact-weather" title="${_escapeHtml(weatherCode === null || weatherCode === undefined || weatherCode === "" ? "WMO code: unknown" : `WMO code: ${weatherCode}`)}">${weatherEmoji}</div>
+          <div class="compact-weather">${weatherIcon}</div>
           <div class="compact-temp-stack">
             <div class="compact-temp-high">${_compactValueSpan("temp", day?.temperature_max_c, highTemp)}</div>
             <div class="compact-temp-low">${_compactValueSpan("temp", day?.temperature_min_c, lowTemp)}</div>
           </div>
         </div>
         <div class="compact-row compact-row-secondary">
-          <div class="compact-pair compact-snow"><span class="compact-pair-icon">❄</span>${_compactValueSpan("snow", day?.snowfall_cm, snowValue)}</div>
-          <div class="compact-pair compact-rain"><span class="compact-pair-icon">☔</span>${_compactValueSpan("rain", day?.rain_mm, rainValue)}</div>
+          <div class="compact-pair compact-snow"><span class="compact-pair-icon">${_metricIcon("snow", "Snowfall")}</span>${_compactValueSpan("snow", day?.snowfall_cm, snowValue)}</div>
+          <div class="compact-pair compact-rain"><span class="compact-pair-icon">${_metricIcon("rain", "Rainfall")}</span>${_compactValueSpan("rain", day?.rain_mm, rainValue)}</div>
         </div>
       </div>`;
   };

--- a/assets/js/field_guide_foundation.js
+++ b/assets/js/field_guide_foundation.js
@@ -1,0 +1,349 @@
+(function () {
+  "use strict";
+
+  /*
+   * Public contract: window.CloseSnowFieldGuide.{weather,copy,units}.
+   * weather.*Html methods return escaped inline markup; condition/copy methods return plain text.
+   * units.setMode() emits `closesnow:unitschange` with the normalized mode in event.detail.mode.
+   */
+  const UNIT_STORAGE_KEY = "closesnow_unit_system_v1";
+  const LEGACY_UNIT_STORAGE_KEYS = [
+    "closesnow_unit_mode_compact_summary",
+    "closesnow_unit_mode_temp",
+    "closesnow_unit_mode_snow",
+    "closesnow_unit_mode_rain",
+  ];
+
+  const asFiniteNumber = (value) => {
+    if (value === null || value === undefined || typeof value === "boolean") return null;
+    if (typeof value === "string" && !value.trim()) return null;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  };
+
+  const escapeHtml = (value) => String(value === null || value === undefined ? "" : value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll("\"", "&quot;")
+    .replaceAll("'", "&#39;");
+
+  const normalizeUnitMode = (value) => (value === "imperial" ? "imperial" : "metric");
+  const validUnitMode = (value) => value === "metric" || value === "imperial";
+
+  const defaultStorage = () => {
+    try {
+      return window.localStorage || null;
+    } catch (_error) {
+      return null;
+    }
+  };
+
+  const storageGet = (storage, key) => {
+    try {
+      return storage && typeof storage.getItem === "function" ? storage.getItem(key) : null;
+    } catch (_error) {
+      return null;
+    }
+  };
+
+  const storageSet = (storage, key, value) => {
+    try {
+      if (storage && typeof storage.setItem === "function") storage.setItem(key, value);
+    } catch (_error) {
+      // Storage can be unavailable in private or embedded browsing contexts.
+    }
+  };
+
+  const readPreference = (storage = defaultStorage()) => {
+    const saved = storageGet(storage, UNIT_STORAGE_KEY);
+    if (validUnitMode(saved)) return saved;
+
+    for (const legacyKey of LEGACY_UNIT_STORAGE_KEYS) {
+      const legacyValue = storageGet(storage, legacyKey);
+      if (!validUnitMode(legacyValue)) continue;
+      storageSet(storage, UNIT_STORAGE_KEY, legacyValue);
+      return legacyValue;
+    }
+    return "metric";
+  };
+
+  const unitKind = (kind) => {
+    const normalized = String(kind || "").trim().toLowerCase();
+    if (normalized === "temp") return "temperature";
+    return normalized;
+  };
+
+  const unitLabel = (kind, mode = readPreference()) => {
+    const normalizedKind = unitKind(kind);
+    const normalizedMode = normalizeUnitMode(mode);
+    const labels = {
+      temperature: normalizedMode === "imperial" ? "°F" : "°C",
+      snow: normalizedMode === "imperial" ? "in" : "cm",
+      rain: normalizedMode === "imperial" ? "in" : "mm",
+      distance: normalizedMode === "imperial" ? "mi" : "km",
+    };
+    return labels[normalizedKind] || "";
+  };
+
+  const convertValue = (kind, rawValue, mode = readPreference()) => {
+    const value = asFiniteNumber(rawValue);
+    if (value === null) return null;
+    if (normalizeUnitMode(mode) !== "imperial") return value;
+    const normalizedKind = unitKind(kind);
+    if (normalizedKind === "temperature") return (value * 9 / 5) + 32;
+    if (normalizedKind === "snow") return value / 2.54;
+    if (normalizedKind === "rain") return value / 25.4;
+    if (normalizedKind === "distance") return value / 1.609344;
+    return value;
+  };
+
+  const defaultDigits = (kind, mode) => {
+    const normalizedKind = unitKind(kind);
+    if (normalizedKind === "temperature" || normalizedKind === "distance") return 0;
+    if (normalizedKind === "rain" && normalizeUnitMode(mode) === "imperial") return 2;
+    return 1;
+  };
+
+  const formatValue = (kind, rawValue, mode = readPreference(), options = {}) => {
+    const normalizedMode = normalizeUnitMode(mode);
+    const converted = convertValue(kind, rawValue, normalizedMode);
+    if (converted === null) return options.fallback === undefined ? "—" : String(options.fallback);
+    const requestedDigits = Number(options.digits);
+    const digits = Number.isInteger(requestedDigits) && requestedDigits >= 0
+      ? Math.min(requestedDigits, 3)
+      : defaultDigits(kind, normalizedMode);
+    const formatted = converted.toFixed(digits);
+    if (options.withUnit === false) return formatted;
+    const label = unitLabel(kind, normalizedMode);
+    return label ? `${formatted} ${label}` : formatted;
+  };
+
+  const formatTemperature = (value, mode, options) => formatValue("temperature", value, mode, options);
+  const formatSnow = (value, mode, options) => formatValue("snow", value, mode, options);
+  const formatRain = (value, mode, options) => formatValue("rain", value, mode, options);
+  const formatDistance = (value, mode, options) => formatValue("distance", value, mode, options);
+
+  const CONDITIONS = Object.freeze([
+    { codes: [0], label: "Clear sky", kind: "clear", icon: "clear" },
+    { codes: [1], label: "Mostly clear", kind: "partly-cloudy", icon: "partly-cloudy" },
+    { codes: [2], label: "Partly cloudy", kind: "partly-cloudy", icon: "partly-cloudy" },
+    { codes: [3], label: "Overcast", kind: "cloudy", icon: "cloud" },
+    { codes: [45, 48], label: "Fog", kind: "fog", icon: "fog" },
+    { codes: [51, 53, 55], label: "Drizzle", kind: "drizzle", icon: "drizzle" },
+    { codes: [56, 57], label: "Freezing drizzle", kind: "drizzle", icon: "drizzle" },
+    { codes: [61, 63, 65], label: "Rain", kind: "rain", icon: "rain" },
+    { codes: [66, 67], label: "Freezing rain", kind: "rain", icon: "rain" },
+    { codes: [71, 73, 75, 77], label: "Snow", kind: "snow", icon: "snow" },
+    { codes: [80, 81, 82], label: "Rain showers", kind: "rain", icon: "rain" },
+    { codes: [85, 86], label: "Snow showers", kind: "snow", icon: "snow" },
+    { codes: [95], label: "Thunderstorm", kind: "thunderstorm", icon: "thunder" },
+    { codes: [96, 99], label: "Thunderstorm with hail", kind: "thunderstorm", icon: "thunder" },
+  ]);
+
+  const UNKNOWN_CONDITION = Object.freeze({
+    codes: [],
+    label: "Conditions unavailable",
+    kind: "unknown",
+    icon: "unknown",
+  });
+
+  const conditionForCode = (rawCode) => {
+    const code = asFiniteNumber(rawCode);
+    if (code === null) return UNKNOWN_CONDITION;
+    return CONDITIONS.find((condition) => condition.codes.includes(code)) || UNKNOWN_CONDITION;
+  };
+
+  const conditionName = (rawCode) => conditionForCode(rawCode).label;
+
+  const WEATHER_ICON_PATHS = Object.freeze({
+    clear: "<circle cx='12' cy='12' r='3.5'></circle><path d='M12 2.5v2M12 19.5v2M2.5 12h2M19.5 12h2M5.3 5.3l1.4 1.4M17.3 17.3l1.4 1.4M18.7 5.3l-1.4 1.4M6.7 17.3l-1.4 1.4'></path>",
+    "partly-cloudy": "<circle cx='8.5' cy='8' r='3'></circle><path d='M8.5 2.5v1.2M3.2 8h1.2M4.7 4.2l.9.9M13.1 4.2l-.9.9'></path><path d='M7 18.5h10.2a3.3 3.3 0 0 0 .2-6.6 5.1 5.1 0 0 0-9.7 1.3A2.7 2.7 0 0 0 7 18.5Z'></path>",
+    cloud: "<path d='M5.7 18.3h11.5a3.8 3.8 0 0 0 .2-7.6A5.8 5.8 0 0 0 6.5 12a3.2 3.2 0 0 0-.8 6.3Z'></path>",
+    fog: "<path d='M6.5 14.5h10.1a3.2 3.2 0 0 0 .2-6.4 5.1 5.1 0 0 0-9.6 1.2 2.7 2.7 0 0 0-.7 5.2Z'></path><path d='M4 18h15M6 21h11'></path>",
+    drizzle: "<path d='M5.7 14.8h11.5a3.8 3.8 0 0 0 .2-7.6A5.8 5.8 0 0 0 6.5 8.5a3.2 3.2 0 0 0-.8 6.3Z'></path><path d='M8 18.2l-.6 1M12.5 18.2l-.6 1M17 18.2l-.6 1'></path>",
+    rain: "<path d='M5.7 14.2h11.5a3.8 3.8 0 0 0 .2-7.6A5.8 5.8 0 0 0 6.5 7.9a3.2 3.2 0 0 0-.8 6.3Z'></path><path d='M8.5 17.2 7.4 20M13 17.2 11.9 20M17.5 17.2 16.4 20'></path>",
+    snow: "<path d='M5.7 13.8h11.5a3.8 3.8 0 0 0 .2-7.6A5.8 5.8 0 0 0 6.5 7.5a3.2 3.2 0 0 0-.8 6.3Z'></path><path d='M8.5 17v4M6.8 18l3.4 2M10.2 18l-3.4 2M16 17v4M14.3 18l3.4 2M17.7 18l-3.4 2'></path>",
+    thunder: "<path d='M5.7 13.8h11.5a3.8 3.8 0 0 0 .2-7.6A5.8 5.8 0 0 0 6.5 7.5a3.2 3.2 0 0 0-.8 6.3Z'></path><path d='m13 15.5-2.2 3h2l-1 3 3.5-4.4h-2.2l1.4-1.6'></path>",
+    unknown: "<circle cx='12' cy='12' r='8.5'></circle><path d='M9.7 9.3A2.5 2.5 0 0 1 12 7.8c1.5 0 2.7.9 2.7 2.3 0 1.8-2.7 2-2.7 4.1M12 17.4h.01'></path>",
+    "metric-snow": "<path d='M12 3v18M4.2 7.5l15.6 9M4.2 16.5l15.6-9M8.8 4.8 12 7l3.2-2.2M8.8 19.2 12 17l3.2 2.2'></path>",
+    "metric-rain": "<path d='M12 3.2s5.2 6.3 5.2 10.7A5.2 5.2 0 1 1 6.8 14C6.8 9.5 12 3.2 12 3.2Z'></path><path d='M9.3 15.2c.4 1.1 1.3 1.7 2.5 1.9'></path>",
+    "metric-temperature": "<path d='M9.5 5.5a2.5 2.5 0 0 1 5 0v8.1a4.2 4.2 0 1 1-5 0V5.5Z'></path><path d='M12 7v8'></path>",
+    "metric-distance": "<path d='M12 21s6-5.6 6-11a6 6 0 1 0-12 0c0 5.4 6 11 6 11Z'></path><circle cx='12' cy='10' r='2'></circle>",
+  });
+
+  const svgIconHtml = ({ path, label, dataAttribute, dataValue, className = "" }) => {
+    const renderedClass = ["field-guide-weather-icon", className].filter(Boolean).join(" ");
+    return `<span class="${escapeHtml(renderedClass)}" role="img" aria-label="${escapeHtml(label)}" ${dataAttribute}="${escapeHtml(dataValue)}"><svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">${path}</svg></span>`;
+  };
+
+  const iconHtml = (rawCode, options = {}) => {
+    const condition = conditionForCode(rawCode);
+    const label = String(options.label || condition.label);
+    return svgIconHtml({
+      path: WEATHER_ICON_PATHS[condition.icon] || WEATHER_ICON_PATHS.unknown,
+      label,
+      dataAttribute: "data-weather-kind",
+      dataValue: condition.kind,
+      className: String(options.className || ""),
+    });
+  };
+
+  const METRIC_ICON_LABELS = Object.freeze({
+    snow: "Snowfall",
+    rain: "Rainfall",
+    temperature: "Temperature",
+    distance: "Distance",
+  });
+
+  const metricIconHtml = (rawKind, options = {}) => {
+    const kind = unitKind(rawKind);
+    const safeKind = Object.prototype.hasOwnProperty.call(METRIC_ICON_LABELS, kind) ? kind : "distance";
+    return svgIconHtml({
+      path: WEATHER_ICON_PATHS[`metric-${safeKind}`],
+      label: String(options.label || METRIC_ICON_LABELS[safeKind]),
+      dataAttribute: "data-metric-kind",
+      dataValue: safeKind,
+      className: String(options.className || ""),
+    });
+  };
+
+  const asDailyList = (daily, limit = 7) => (Array.isArray(daily) ? daily : [])
+    .filter((item) => item && typeof item === "object")
+    .slice(0, Math.max(1, Number(limit) || 7));
+
+  const precipitationOutlook = (daily, options = {}) => {
+    const days = asDailyList(daily, options.days);
+    const mode = normalizeUnitMode(options.mode || readPreference());
+    const snowValues = days.map((day) => asFiniteNumber(day.snowfall_cm)).filter((value) => value !== null);
+    const rainValues = days.map((day) => asFiniteNumber(day.rain_mm)).filter((value) => value !== null);
+    if (!snowValues.length && !rainValues.length) return "Snow and rain estimates are not available yet.";
+    const snow = snowValues.reduce((total, value) => total + value, 0);
+    const rain = rainValues.reduce((total, value) => total + value, 0);
+    const horizon = days.length === 1 ? "today" : `over the next ${days.length} days`;
+    if (snow > 0 && rain > 0) {
+      return `Expect ${formatSnow(snow, mode)} of snow and ${formatRain(rain, mode)} of rain ${horizon}.`;
+    }
+    if (snow > 0) return `Expect ${formatSnow(snow, mode)} of snow ${horizon}.`;
+    if (rain > 0) return `Expect ${formatRain(rain, mode)} of rain ${horizon}.`;
+    return `Little to no snow or rain is expected ${horizon}.`;
+  };
+
+  const temperatureOutlook = (day, options = {}) => {
+    if (!day || typeof day !== "object") return "Temperature details are not available yet.";
+    const mode = normalizeUnitMode(options.mode || readPreference());
+    const high = asFiniteNumber(day.temperature_max_c);
+    const low = asFiniteNumber(day.temperature_min_c);
+    if (high === null && low === null) return "Temperature details are not available yet.";
+    if (high === null) return `Low near ${formatTemperature(low, mode)}.`;
+    if (low === null) return `High near ${formatTemperature(high, mode)}.`;
+    return `High ${formatTemperature(high, mode)}, low ${formatTemperature(low, mode)}.`;
+  };
+
+  const dailyOutlook = (daily, options = {}) => {
+    const days = asDailyList(daily, options.days);
+    if (!days.length) return "Forecast details are not available yet.";
+    const condition = conditionName(days[0].weather_code);
+    const conditionSentence = condition === UNKNOWN_CONDITION.label ? "" : `${condition} today.`;
+    return [
+      conditionSentence,
+      precipitationOutlook(days, options),
+      temperatureOutlook(days[0], options),
+    ].filter(Boolean).join(" ");
+  };
+
+  const syncUnitSwitches = (mode = readPreference()) => {
+    if (typeof document === "undefined") return;
+    const normalizedMode = normalizeUnitMode(mode);
+    document.querySelectorAll("[data-field-guide-unit-toggle]").forEach((button) => {
+      button.setAttribute("data-mode", normalizedMode);
+      button.setAttribute("aria-pressed", normalizedMode === "imperial" ? "true" : "false");
+      button.setAttribute(
+        "aria-label",
+        normalizedMode === "imperial" ? "Switch to metric units" : "Switch to imperial units",
+      );
+      button.querySelectorAll("[data-field-guide-unit-label]").forEach((label) => {
+        label.textContent = normalizedMode === "imperial" ? "Imperial" : "Metric";
+      });
+    });
+  };
+
+  const dispatchUnitChange = (mode) => {
+    if (typeof window.dispatchEvent !== "function" || typeof window.CustomEvent !== "function") return;
+    // Shared page contract: listeners read the normalized mode from event.detail.mode.
+    window.dispatchEvent(new window.CustomEvent("closesnow:unitschange", { detail: { mode } }));
+  };
+
+  const setPreference = (mode, storage = defaultStorage(), options = {}) => {
+    const normalizedMode = normalizeUnitMode(mode);
+    storageSet(storage, UNIT_STORAGE_KEY, normalizedMode);
+    syncUnitSwitches(normalizedMode);
+    if (options.dispatch !== false) dispatchUnitChange(normalizedMode);
+    return normalizedMode;
+  };
+
+  const togglePreference = () => {
+    const current = readPreference();
+    return setPreference(current === "imperial" ? "metric" : "imperial");
+  };
+
+  const bindUnitPreference = () => {
+    syncUnitSwitches(readPreference());
+    if (typeof document === "undefined") return;
+    document.addEventListener("click", (event) => {
+      const toggle = event.target.closest("[data-field-guide-unit-toggle]");
+      if (!toggle) return;
+      event.preventDefault();
+      togglePreference();
+    });
+  };
+
+  window.CloseSnowFieldGuide = Object.freeze({
+    copy: Object.freeze({
+      conditionName,
+      dailyOutlook,
+      precipitationOutlook,
+      temperatureOutlook,
+    }),
+    units: Object.freeze({
+      LEGACY_STORAGE_KEYS: LEGACY_UNIT_STORAGE_KEYS,
+      STORAGE_KEY: UNIT_STORAGE_KEY,
+      asFiniteNumber,
+      convertValue,
+      formatDistance,
+      formatRain,
+      formatSnow,
+      formatTemperature,
+      formatValue,
+      normalizeMode: normalizeUnitMode,
+      readPreference,
+      setMode: setPreference,
+      setPreference,
+      togglePreference,
+      unitLabel,
+    }),
+    weather: Object.freeze({
+      conditionForCode,
+      conditionName,
+      iconHtml,
+      metricIconHtml,
+    }),
+  });
+
+  if (typeof document !== "undefined") {
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", bindUnitPreference, { once: true });
+    } else {
+      bindUnitPreference();
+    }
+  }
+
+  if (typeof window.addEventListener === "function") {
+    window.addEventListener("storage", (event) => {
+      if (event.key !== UNIT_STORAGE_KEY) return;
+      const mode = readPreference();
+      syncUnitSwitches(mode);
+      dispatchUnitChange(mode);
+    });
+  }
+}());

--- a/assets/js/resort_hourly.js
+++ b/assets/js/resort_hourly.js
@@ -4,6 +4,10 @@ const hourlyDataUrl = String(context.hourlyDataUrl || "").trim();
 const dailySummary = context.dailySummary && typeof context.dailySummary === "object" ? context.dailySummary : null;
 const compactDailySummary = window.CloseSnowCompactDailySummary || {};
 const hourlyMetricHelpers = window.CloseSnowResortHourlyMetrics || {};
+const fieldGuide = window.CloseSnowFieldGuide || {};
+const fieldGuideCopy = fieldGuide.copy || {};
+const fieldGuideUnits = fieldGuide.units || {};
+const fieldGuideWeather = fieldGuide.weather || {};
 
 const hoursSelect = document.getElementById("hours-select");
 const refreshBtn = document.getElementById("hours-refresh-btn");
@@ -59,6 +63,10 @@ const formatValue = (value) => {
   }
   return String(value);
 };
+
+const currentUnitMode = () => (fieldGuideUnits.readPreference
+  ? fieldGuideUnits.readPreference()
+  : "metric");
 
 const formatCoordinate = (value) => {
   const num = Number(value);
@@ -361,7 +369,10 @@ const renderNearbyAirports = (payload) => {
     if (airport.distanceMiles !== null) {
       const distance = document.createElement("span");
       distance.className = "resort-airport-access-distance";
-      distance.textContent = `${Math.round(airport.distanceMiles)} mi`;
+      const distanceKm = airport.distanceMiles * 1.609344;
+      distance.textContent = fieldGuideUnits.formatDistance
+        ? fieldGuideUnits.formatDistance(distanceKm, currentUnitMode(), { digits: 0 })
+        : `${Math.round(airport.distanceMiles)} mi`;
       head.appendChild(distance);
     }
 
@@ -428,23 +439,42 @@ const renderResortSnapshot = () => {
   const snow = daily.slice(0, 7).reduce((sum, day) => sum + (toFiniteNumber(day?.snowfall_cm) || 0), 0);
   const rain = daily.slice(0, 7).reduce((sum, day) => sum + (toFiniteNumber(day?.rain_mm) || 0), 0);
   const weatherCode = today.weather_code;
-  const weatherEmoji = window.CloseSnowWeatherCode?.emojiForWeatherCode
-    ? window.CloseSnowWeatherCode.emojiForWeatherCode(weatherCode)
-    : "❓";
-  const temperature = high === null || low === null ? "--" : `${Math.round(high)}° / ${Math.round(low)}°`;
+  const unitMode = currentUnitMode();
+  const weatherIcon = fieldGuideWeather.iconHtml
+    ? fieldGuideWeather.iconHtml(weatherCode)
+    : '<span class="field-guide-weather-icon" role="img" aria-label="Conditions unavailable">?</span>';
+  const metricIcon = (kind, label) => (fieldGuideWeather.metricIconHtml
+    ? fieldGuideWeather.metricIconHtml(kind, { label })
+    : `<span class="field-guide-weather-icon" role="img" aria-label="${label}">?</span>`);
+  const temperatureUnit = fieldGuideUnits.unitLabel ? fieldGuideUnits.unitLabel("temperature", unitMode) : "°C";
+  const formattedHigh = high === null
+    ? "--"
+    : (fieldGuideUnits.formatTemperature
+      ? fieldGuideUnits.formatTemperature(high, unitMode, { withUnit: false, digits: 0 })
+      : String(Math.round(high)));
+  const formattedLow = low === null
+    ? "--"
+    : (fieldGuideUnits.formatTemperature
+      ? fieldGuideUnits.formatTemperature(low, unitMode, { withUnit: false, digits: 0 })
+      : String(Math.round(low)));
+  const temperature = `${formattedHigh} / ${formattedLow} ${temperatureUnit}`;
+  const snowValue = fieldGuideUnits.formatSnow ? fieldGuideUnits.formatSnow(snow, unitMode) : `${snow.toFixed(1)} cm`;
+  const rainValue = fieldGuideUnits.formatRain ? fieldGuideUnits.formatRain(rain, unitMode) : `${rain.toFixed(1)} mm`;
+  const outlook = fieldGuideCopy.dailyOutlook ? fieldGuideCopy.dailyOutlook(daily, { mode: unitMode }) : "";
   snapshotEl.innerHTML = `
     <article class="snapshot-card snapshot-card-weather">
-      <span class="snapshot-icon" aria-hidden="true">${weatherEmoji}</span>
-      <span><small>Today</small><strong>${temperature}</strong><em>High / low °C</em></span>
+      <span class="snapshot-icon">${weatherIcon}</span>
+      <span><small>Today</small><strong>${temperature}</strong><em>High / low</em></span>
     </article>
     <article class="snapshot-card">
-      <span class="snapshot-icon snapshot-icon-snow" aria-hidden="true">❄</span>
-      <span><small>Next 7 days</small><strong>${snow.toFixed(1)} cm</strong><em>Forecast snow</em></span>
+      <span class="snapshot-icon snapshot-icon-snow">${metricIcon("snow", "Snowfall")}</span>
+      <span><small>Next 7 days</small><strong>${snowValue}</strong><em>Forecast snow</em></span>
     </article>
     <article class="snapshot-card">
-      <span class="snapshot-icon snapshot-icon-rain" aria-hidden="true">◌</span>
-      <span><small>Next 7 days</small><strong>${rain.toFixed(1)} mm</strong><em>Forecast rain</em></span>
+      <span class="snapshot-icon snapshot-icon-rain">${metricIcon("rain", "Rainfall")}</span>
+      <span><small>Next 7 days</small><strong>${rainValue}</strong><em>Forecast rain</em></span>
     </article>`;
+  if (outlook) snapshotEl.setAttribute("aria-label", outlook);
   snapshotEl.hidden = false;
 };
 
@@ -733,6 +763,7 @@ const renderTimelineSummary = () => {
   }
   timelineRoot.innerHTML = compactDailySummary.renderSingleResortHtml(merged, {
     emptyText: "No forecast or recent history",
+    unitMode: currentUnitMode(),
   });
   timelineSection.hidden = false;
   window.requestAnimationFrame(centerTimelineOnToday);
@@ -832,6 +863,12 @@ if (hoursSelect) {
   hoursSelect.addEventListener("change", loadHourly);
 }
 window.addEventListener("resize", rerenderChartsForResize);
+window.addEventListener("closesnow:unitschange", () => {
+  renderResortSnapshot();
+  timelineAutoCentered = false;
+  renderTimelineSummary();
+  renderNearbyAirports(lastHourlyPayload);
+});
 
 renderResortSnapshot();
 renderTimelineSummary();

--- a/assets/js/weather_page.js
+++ b/assets/js/weather_page.js
@@ -57,6 +57,9 @@ const LEADING_FAVORITE_COL_PX = 28;
 const compactDailySummary = window.CloseSnowCompactDailySummary || {};
 const filterStateHelpers = window.CloseSnowFilterState || {};
 const stickySingleTableLayout = window.CloseSnowStickySingleTableLayout || {};
+const fieldGuide = window.CloseSnowFieldGuide || {};
+const fieldGuideUnits = fieldGuide.units || {};
+const fieldGuideWeather = fieldGuide.weather || {};
 const COMPACT_SUMMARY_UNIT_KIND = "compact_summary";
 const SUN_TIME_TOGGLE_KIND = "sun_time";
 // Reserve section keys so later workers can move one section at a time to shared single-table layout.
@@ -156,10 +159,9 @@ const _isDynamicApiDataUrl = () => {
   }
 };
 
-const _weatherEmoji = (rawCode) => {
-  const helper = window.CloseSnowWeatherCode?.emojiForWeatherCode;
-  return helper ? helper(rawCode) : "❓";
-};
+const _weatherIcon = (rawCode, className = "") => (fieldGuideWeather.iconHtml
+  ? fieldGuideWeather.iconHtml(rawCode, { className })
+  : '<span class="field-guide-weather-icon" role="img" aria-label="Conditions unavailable">?</span>');
 
 const _filterAttrs = (report) => {
   const passTypes = Array.isArray(report.pass_types) ? report.pass_types.join(",").toLowerCase() : "";
@@ -262,14 +264,14 @@ const _renderForecastOverview = (reports) => {
   const cards = candidates.map((report, index) => {
     const today = _dailyAt(report, 0);
     const weatherCode = today.weather_code;
-    const weatherTitle = weatherCode === null || weatherCode === undefined || weatherCode === ""
-      ? "Weather unavailable"
-      : `WMO code: ${weatherCode}`;
+    const weatherTitle = fieldGuideWeather.conditionName
+      ? fieldGuideWeather.conditionName(weatherCode)
+      : "Conditions unavailable";
     return `
       <article class="snow-pick-card">
         <div class="snow-pick-card-topline">
           <span class="snow-pick-rank">#${index + 1} ${hasSnow ? "snow" : "storm"} pick</span>
-          <span class="snow-pick-weather" title="${_escapeHtml(weatherTitle)}">${_weatherEmoji(weatherCode)}</span>
+          <span class="snow-pick-weather" title="${_escapeHtml(weatherTitle)}">${_weatherIcon(weatherCode)}</span>
         </div>
         <h3>${_resortLinkHtml(report)}</h3>
         <p>${_escapeHtml(_overviewLocation(report))}</p>
@@ -468,8 +470,10 @@ const _renderWeatherSection = (reports, emptyMessage = "No resorts match the cur
     : _fallbackDayLabels(displayDays);
   const weatherCells = (report) => Array.from({ length: displayDays }, (_, idx) => {
     const code = _dailyAt(report, idx).weather_code;
-    const title = code === null || code === undefined || code === "" ? "WMO code: unknown" : `WMO code: ${code}`;
-    return `<td class='weather-emoji-cell' title='${_escapeHtml(title)}'>${_weatherEmoji(code)}</td>`;
+    const title = fieldGuideWeather.conditionName
+      ? fieldGuideWeather.conditionName(code)
+      : "Conditions unavailable";
+    return `<td class='weather-emoji-cell' title='${_escapeHtml(title)}'>${_weatherIcon(code)}</td>`;
   }).join("");
   const rows = reports.length ? reports.map((report) => `<tr${_filterAttrs(report)}>${_resortCellHtml(report)}${weatherCells(report)}</tr>`).join("") : _emptyStateRow(2 + Math.max(1, displayDays), emptyMessage);
   return `
@@ -1381,6 +1385,9 @@ const observeLayoutContainers = () => {
 };
 
 const getStoredUnitMode = (kind) => {
+  if (kind !== SUN_TIME_TOGGLE_KIND && fieldGuideUnits.readPreference) {
+    return fieldGuideUnits.readPreference();
+  }
   try {
     const saved = localStorage.getItem(`${UNIT_STORAGE_KEY_PREFIX}${kind}`);
     return saved === "imperial" || saved === "metric" ? saved : "metric";
@@ -1415,6 +1422,10 @@ const renderCompactSummaryValues = () => {
     const kind = String(el.getAttribute("data-compact-unit-kind") || "").trim();
     const metricValue = Number(el.getAttribute("data-compact-metric-value"));
     if (!Number.isFinite(metricValue)) return;
+    if (fieldGuideUnits.formatValue && ["temp", "snow", "rain"].includes(kind)) {
+      el.textContent = fieldGuideUnits.formatValue(kind, metricValue, mode, { withUnit: false, digits: kind === "temp" ? 0 : undefined });
+      return;
+    }
     if (kind === "temp") {
       el.textContent = mode === "imperial"
         ? String(Math.round((metricValue * 9 / 5) + 32))
@@ -1435,6 +1446,10 @@ const renderCompactSummaryValues = () => {
   });
   document.querySelectorAll("[data-compact-unit-label]").forEach((el) => {
     const kind = String(el.getAttribute("data-compact-unit-label") || "").trim();
+    if (fieldGuideUnits.unitLabel && ["temp", "snow", "rain"].includes(kind)) {
+      el.textContent = fieldGuideUnits.unitLabel(kind, mode);
+      return;
+    }
     if (kind === "snow") el.textContent = mode === "imperial" ? "in" : "cm";
     if (kind === "temp") el.textContent = mode === "imperial" ? "°F" : "°C";
     if (kind === "rain") el.textContent = mode === "imperial" ? "in" : "mm";
@@ -1471,6 +1486,9 @@ const renderSunTimeValues = () => {
 };
 
 const formatMeasure = (metricValue, kind, mode) => {
+  if (fieldGuideUnits.formatValue) {
+    return fieldGuideUnits.formatValue(kind, metricValue, mode, { withUnit: false });
+  }
   if (mode === "imperial") {
     if (kind === "snow") return (metricValue / 2.54).toFixed(1);
     if (kind === "rain") return (metricValue / 25.4).toFixed(2);
@@ -1510,28 +1528,37 @@ const applyUnitModes = () => {
   syncSunTimeToggle();
 };
 
-const setUnitMode = (kind, mode) => {
-  if (!VALID_UNIT_KINDS.has(kind)) return;
-  appState.unitModes[kind] = mode === "imperial" ? "imperial" : "metric";
-  try {
-    localStorage.setItem(`${UNIT_STORAGE_KEY_PREFIX}${kind}`, appState.unitModes[kind]);
-  } catch (error) {
-    // Ignore storage failures.
-  }
+const applySiteUnitMode = (mode) => {
+  const normalizedMode = mode === "imperial" ? "imperial" : "metric";
+  Object.keys(appState.unitModes).forEach((kind) => {
+    appState.unitModes[kind] = normalizedMode;
+  });
+  appState.compactSummaryUnitMode = normalizedMode;
   applyUnitModes();
   applyLayout();
 };
 
-const setCompactSummaryUnitMode = (mode) => {
-  appState.compactSummaryUnitMode = mode === "imperial" ? "imperial" : "metric";
+const persistSiteUnitMode = (mode) => {
+  const normalizedMode = mode === "imperial" ? "imperial" : "metric";
+  if (fieldGuideUnits.setMode) {
+    fieldGuideUnits.setMode(normalizedMode);
+    return;
+  }
   try {
-    localStorage.setItem(`${UNIT_STORAGE_KEY_PREFIX}${COMPACT_SUMMARY_UNIT_KIND}`, appState.compactSummaryUnitMode);
+    VALID_UNIT_KINDS.forEach((kind) => localStorage.setItem(`${UNIT_STORAGE_KEY_PREFIX}${kind}`, normalizedMode));
+    localStorage.setItem(`${UNIT_STORAGE_KEY_PREFIX}${COMPACT_SUMMARY_UNIT_KIND}`, normalizedMode);
   } catch (error) {
     // Ignore storage failures.
   }
-  renderCompactSummaryValues();
-  syncCompactSummaryToggle();
+  applySiteUnitMode(normalizedMode);
 };
+
+const setUnitMode = (kind, mode) => {
+  if (!VALID_UNIT_KINDS.has(kind)) return;
+  persistSiteUnitMode(mode);
+};
+
+const setCompactSummaryUnitMode = (mode) => persistSiteUnitMode(mode);
 
 const setSunTimeToggleMode = (mode) => {
   appState.sunTimeToggleMode = mode === "imperial" ? "imperial" : "metric";
@@ -1765,6 +1792,9 @@ const applyFiltersImmediately = async () => {
 };
 
 const bindControls = () => {
+  window.addEventListener("closesnow:unitschange", (event) => {
+    applySiteUnitMode(event?.detail?.mode);
+  });
   if (resortSearchInput) {
     resortSearchInput.addEventListener("input", () => {
       scheduleApplyFilters();

--- a/src/web/asset_manifest.py
+++ b/src/web/asset_manifest.py
@@ -36,6 +36,8 @@ class WebAsset:
 
 WEB_ASSET_MANIFEST: Final[tuple[WebAsset, ...]] = (
     WebAsset("assets/css/weather_page.css", "text/css; charset=utf-8"),
+    WebAsset("assets/css/field_guide_foundation.css", "text/css; charset=utf-8"),
+    WebAsset("assets/js/field_guide_foundation.js", "application/javascript; charset=utf-8"),
     WebAsset("assets/js/compact_daily_summary.js", "application/javascript; charset=utf-8"),
     WebAsset("assets/js/weather_code_emoji.js", "application/javascript; charset=utf-8"),
     WebAsset("assets/js/weather_filter_state.js", "application/javascript; charset=utf-8"),

--- a/src/web/templates/resort_hourly_page.html
+++ b/src/web/templates/resort_hourly_page.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Resort Forecast</title>
   <link rel="stylesheet" href="{{asset_prefix}}/css/resort_hourly.css" />
+  <link rel="stylesheet" href="{{asset_prefix}}/css/field_guide_foundation.css" />
 </head>
 <body>
   <header class="site-header">
@@ -15,7 +16,13 @@
         </span>
         <span class="brand-copy"><strong>CloseSnow</strong><span>Mountain weather, made useful</span></span>
       </a>
-      <span class="site-header-note"><span aria-hidden="true"></span> Resort intelligence</span>
+      <div class="site-header-actions">
+        <span class="site-header-note"><span aria-hidden="true"></span> Resort intelligence</span>
+        <button class="field-guide-unit-switch" type="button" data-field-guide-unit-toggle aria-pressed="false">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M8 5h8M8 12h8M8 19h8"></path><path d="M5 3v4M5 10v4M5 17v4M19 3v4M19 10v4M19 17v4"></path></svg>
+          <span data-field-guide-unit-label>Metric</span>
+        </button>
+      </div>
     </div>
   </header>
   <main>
@@ -82,7 +89,7 @@
   <script>
     window.CLOSESNOW_HOURLY_CONTEXT = {{hourly_context_json}};
   </script>
-  <script src="{{asset_prefix}}/js/weather_code_emoji.js"></script>
+  <script src="{{asset_prefix}}/js/field_guide_foundation.js"></script>
   <script src="{{asset_prefix}}/js/compact_daily_summary.js"></script>
   <script src="{{asset_prefix}}/js/resort_hourly_metrics.js"></script>
   <script src="{{asset_prefix}}/js/resort_hourly.js"></script>

--- a/src/web/templates/weather_page.html
+++ b/src/web/templates/weather_page.html
@@ -13,6 +13,7 @@
   </script>
   <title>Ski Resorts Weather Forecast</title>
   <link rel="stylesheet" href="assets/css/weather_page.css" />
+  <link rel="stylesheet" href="assets/css/field_guide_foundation.css" />
 </head>
 <body class="units-pending">
   <header class="site-header">
@@ -29,7 +30,13 @@
           <span>Mountain weather, made useful</span>
         </span>
       </a>
-      <span class="site-header-note"><span aria-hidden="true"></span> Fresh mountain intelligence</span>
+      <div class="site-header-actions">
+        <span class="site-header-note"><span aria-hidden="true"></span> Fresh mountain intelligence</span>
+        <button class="field-guide-unit-switch" type="button" data-field-guide-unit-toggle aria-pressed="false">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M8 5h8M8 12h8M8 19h8"></path><path d="M5 3v4M5 10v4M5 17v4M19 3v4M19 10v4M19 17v4"></path></svg>
+          <span data-field-guide-unit-label>Metric</span>
+        </button>
+      </div>
     </div>
   </header>
   <main>
@@ -147,7 +154,7 @@
     window.CLOSESNOW_PAGE_BOOTSTRAP = {{page_bootstrap_json}};
     window.CLOSESNOW_INITIAL_PAYLOAD = {{initial_payload_json}};
   </script>
-  <script src="assets/js/weather_code_emoji.js"></script>
+  <script src="assets/js/field_guide_foundation.js"></script>
   <script src="assets/js/compact_daily_summary.js"></script>
   <script src="assets/js/weather_filter_state.js"></script>
   <script src="assets/js/sticky_single_table_layout.js"></script>

--- a/tests/frontend/test_renderers.py
+++ b/tests/frontend/test_renderers.py
@@ -249,8 +249,16 @@ def test_build_html_contains_meta_sections():
     assert 'class="skeleton skeleton-table"' in html
     assert "<h2>Daily Summary</h2>" in html
     assert "<h2>Sunrise / Sunset</h2>" in html
+    assert 'href="assets/css/field_guide_foundation.css"' in html
+    assert html.index('href="assets/css/weather_page.css"') < html.index('href="assets/css/field_guide_foundation.css"')
+    assert 'src="assets/js/field_guide_foundation.js"' in html
+    assert html.index('src="assets/js/field_guide_foundation.js"') < html.index(
+        'src="assets/js/compact_daily_summary.js"'
+    )
     assert 'src="assets/js/weather_page_formatters.js"' in html
     assert html.index('src="assets/js/weather_page_formatters.js"') < html.index('src="assets/js/weather_page.js"')
+    assert 'src="assets/js/weather_code_emoji.js"' not in html
+    assert "data-field-guide-unit-toggle" in html
     assert html.index("<h2>Temperature</h2>") < html.index("<h2>Weather</h2>")
     assert 'id="resort-search-input"' in html
     assert 'id="filter-modal"' in html

--- a/tests/frontend/test_static_site_pipeline.py
+++ b/tests/frontend/test_static_site_pipeline.py
@@ -119,8 +119,16 @@ def test_render_hourly_pages(tmp_path):
     ]
     html = outputs[0].read_text(encoding="utf-8")
     assert "../../assets/css/resort_hourly.css" in html
+    assert "../../assets/css/field_guide_foundation.css" in html
+    assert html.index("../../assets/css/resort_hourly.css") < html.index("../../assets/css/field_guide_foundation.css")
+    assert "../../assets/js/field_guide_foundation.js" in html
+    assert html.index("../../assets/js/field_guide_foundation.js") < html.index(
+        "../../assets/js/compact_daily_summary.js"
+    )
     assert "../../assets/js/resort_hourly_metrics.js" in html
     assert html.index("../../assets/js/resort_hourly_metrics.js") < html.index("../../assets/js/resort_hourly.js")
+    assert "../../assets/js/weather_code_emoji.js" not in html
+    assert "data-field-guide-unit-toggle" in html
     assert '<h1 id="hourly-title">Resort Forecast</h1>' in html
     assert 'id="resort-snapshot"' in html
     assert 'id="hourly-charts"' in html

--- a/tests/frontend/test_styles_and_transform.py
+++ b/tests/frontend/test_styles_and_transform.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
 from src.web.weather_report_transform import (
     reports_to_rain_rows,
     reports_to_snow_rows,
@@ -7,6 +13,45 @@ from src.web.weather_report_transform import (
     reports_to_temp_rows,
 )
 from src.web.weather_table_styles import rain_color, render_measure_cell, snow_color, temp_color, to_float
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _node_binary() -> str:
+    bundled_node = Path("/Applications/ChatGPT.app/Contents/Resources/cua_node/bin/node")
+    node = shutil.which("node") or (str(bundled_node) if bundled_node.is_file() else "")
+    if not node:
+        pytest.skip("Node.js is required for shared frontend API tests")
+    return node
+
+
+def _run_field_guide_expression(expression: str):
+    asset_path = REPO_ROOT / "assets" / "js" / "field_guide_foundation.js"
+    runner = f"""
+const fs = require("fs");
+const storageState = {{}};
+const dispatchedEvents = [];
+global.window = {{
+  localStorage: {{
+    getItem: (key) => Object.prototype.hasOwnProperty.call(storageState, key) ? storageState[key] : null,
+    setItem: (key, value) => {{ storageState[key] = String(value); }},
+  }},
+  addEventListener: () => {{}},
+  dispatchEvent: (event) => {{ dispatchedEvents.push({{ type: event.type, detail: event.detail }}); }},
+  CustomEvent: function (type, init) {{ this.type = type; this.detail = init.detail; }},
+}};
+eval(fs.readFileSync({json.dumps(str(asset_path))}, "utf8"));
+const result = (() => ({expression}))();
+process.stdout.write(JSON.stringify(result));
+"""
+    result = subprocess.run(
+        [_node_binary(), "-e", runner],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
 
 
 def test_to_float_and_color_functions():
@@ -139,3 +184,107 @@ def test_sun_rows_fallback_to_iso_strings_when_hhmm_missing():
     assert sun_rows[0]["day_1_sunset"] == "17:55"
     assert sun_rows[0]["day_2_sunrise"] == ""
     assert sun_rows[0]["day_2_sunset"] == ""
+
+
+def test_field_guide_weather_icons_have_plain_labels_and_safe_svg_markup():
+    result = _run_field_guide_expression(
+        """(() => {
+  const weather = window.CloseSnowFieldGuide.weather;
+  return {
+    snowName: weather.conditionName(71),
+    rainName: weather.conditionName(61),
+    unknownName: weather.conditionName(null),
+    snowIcon: weather.iconHtml(71),
+    escapedIcon: weather.iconHtml(0, { label: "Clear <strong>", className: "x\\\" onclick=\\\"bad" }),
+    rainMetricIcon: weather.metricIconHtml("rain"),
+  };
+})()"""
+    )
+
+    assert result["snowName"] == "Snow"
+    assert result["rainName"] == "Rain"
+    assert result["unknownName"] == "Conditions unavailable"
+    assert '<svg viewBox="0 0 24 24" aria-hidden="true"' in result["snowIcon"]
+    assert 'role="img" aria-label="Snow"' in result["snowIcon"]
+    assert 'data-weather-kind="snow"' in result["snowIcon"]
+    assert "&lt;strong&gt;" in result["escapedIcon"]
+    assert "&quot; onclick=&quot;bad" in result["escapedIcon"]
+    assert 'aria-label="Rainfall"' in result["rainMetricIcon"]
+
+
+def test_field_guide_copy_helpers_use_readable_fallbacks_and_existing_daily_values():
+    result = _run_field_guide_expression(
+        """(() => {
+  const copy = window.CloseSnowFieldGuide.copy;
+  const daily = [
+    { weather_code: 71, snowfall_cm: 2.5, rain_mm: 0, temperature_max_c: 3, temperature_min_c: -4 },
+    { weather_code: 3, snowfall_cm: 1.5, rain_mm: 1.2, temperature_max_c: 2, temperature_min_c: -5 },
+  ];
+  return {
+    missing: copy.dailyOutlook([]),
+    missingPrecip: copy.precipitationOutlook([{ weather_code: 3 }]),
+    missingTemp: copy.temperatureOutlook({}),
+    outlook: copy.dailyOutlook(daily, { mode: "metric" }),
+  };
+})()"""
+    )
+
+    assert result["missing"] == "Forecast details are not available yet."
+    assert result["missingPrecip"] == "Snow and rain estimates are not available yet."
+    assert result["missingTemp"] == "Temperature details are not available yet."
+    assert result["outlook"] == (
+        "Snow today. Expect 4.0 cm of snow and 1.2 mm of rain over the next 2 days. High 3 °C, low -4 °C."
+    )
+
+
+def test_field_guide_units_migrate_once_convert_all_supported_values_and_emit_event():
+    result = _run_field_guide_expression(
+        """(() => {
+  const units = window.CloseSnowFieldGuide.units;
+  storageState[units.STORAGE_KEY] = "invalid";
+  storageState[units.LEGACY_STORAGE_KEYS[0]] = "imperial";
+  const migrated = units.readPreference(window.localStorage);
+  const formatted = {
+    temperature: units.formatTemperature(0, migrated),
+    snow: units.formatSnow(2.54, migrated),
+    rain: units.formatRain(25.4, migrated),
+    distance: units.formatDistance(1.609344, migrated),
+    missing: units.formatSnow(null, migrated),
+  };
+  const normalized = units.setMode("not-a-mode");
+  return {
+    migrated,
+    persisted: storageState[units.STORAGE_KEY],
+    formatted,
+    normalized,
+    event: dispatchedEvents.at(-1),
+  };
+})()"""
+    )
+
+    assert result["migrated"] == "imperial"
+    assert result["formatted"] == {
+        "temperature": "32 °F",
+        "snow": "1.0 in",
+        "rain": "1.00 in",
+        "distance": "1 mi",
+        "missing": "—",
+    }
+    assert result["persisted"] == "metric"
+    assert result["normalized"] == "metric"
+    assert result["event"] == {"type": "closesnow:unitschange", "detail": {"mode": "metric"}}
+
+
+def test_field_guide_styles_define_shared_semantics_and_compact_header():
+    css = (REPO_ROOT / "assets" / "css" / "field_guide_foundation.css").read_text(encoding="utf-8")
+
+    assert "--fg-glacier:" in css
+    assert "--fg-pine:" in css
+    assert "--fg-signal:" in css
+    assert "--fg-paper:" in css
+    assert ".site-header-inner" in css
+    assert "height: 56px" in css
+    assert "font-variant-numeric: tabular-nums" in css
+    assert ".fg-card" in css
+    assert "[data-field-guide-tabs]" in css
+    assert "details[data-field-guide-disclosure]" in css


### PR DESCRIPTION
## Summary
- add shared Field Guide visual tokens, compact header, controls, card/tab/disclosure primitives, and accessible semantic SVG icons
- add plain-language condition/outlook helpers plus one persisted Metric/Imperial preference for temperature, snow, rain, and distance
- wire root and nested resort templates, migrate primary renderers off native emoji, and include the new assets in static generation

## Validation
- python3 scripts/lint_assets.py
- python3 -m pytest -q tests/frontend/test_renderers.py tests/frontend/test_styles_and_transform.py tests/frontend/test_static_site_pipeline.py tests/test_lint_assets.py (43 passed)
- python3 -m pytest -q (263 passed)
- python3 -m src.cli static --output-dir /tmp/closesnow-field-guide-foundation --max-workers 8 --include-all-resorts (125 resort pages)
- verified shared asset paths resolve from root and nested resort HTML