### PR TITLE
feat: rebuild homepage forecast decision board

### DIFF
--- a/assets/css/weather_page.css
+++ b/assets/css/weather_page.css
@@ -1,1629 +1,233 @@
-    body {
-      margin: 0;
-      font-family: "Avenir Next", "Segoe UI", sans-serif;
-      color: #1f2937;
-      background: linear-gradient(180deg, #f8fafc 0%, #eef2ff 100%);
-    }
-    main {
-      max-width: 1400px;
-      margin: 0 auto;
-      padding: 20px;
-    }
-    .page-footer {
-      max-width: 1400px;
-      margin: 10px auto 20px;
-      padding: 0 20px;
-      font-size: 13px;
-      color: #475569;
-    }
-    .page-footer a {
-      color: #0f766e;
-      text-decoration: none;
-      font-weight: 600;
-    }
-    .page-footer a:hover {
-      text-decoration: underline;
-    }
-    h1 {
-      margin: 0 0 16px;
-      font-size: 28px;
-    }
-    .report-date {
-      margin: -8px 0 12px;
-    }
-    .report-powered {
-      font-size: 13px;
-      color: #475569;
-      font-weight: 600;
-    }
-    .report-generated {
-      margin-top: 2px;
-      font-size: 12px;
-      font-weight: 500;
-      color: #64748b;
-    }
-    .resort-controls {
-      margin: 10px 0 18px;
-      display: grid;
-      gap: 8px;
-    }
-    .resort-search {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      flex-wrap: wrap;
-    }
-    .resort-search label {
-      font-size: 13px;
-      font-weight: 600;
-      color: #334155;
-    }
-    .resort-search input {
-      min-width: 260px;
-      padding: 7px 10px;
-      border: 1px solid #cbd5e1;
-      border-radius: 8px;
-      background: #fff;
-      font-size: 13px;
-      color: #1f2937;
-    }
-    .resort-search button {
-      border: 1px solid #94a3b8;
-      background: #f8fafc;
-      color: #1f2937;
-      border-radius: 8px;
-      padding: 7px 12px;
-      font-size: 12px;
-      font-weight: 600;
-      cursor: pointer;
-    }
-    .resort-search-toggle {
-      display: inline-flex;
-      align-items: center;
-      gap: 6px;
-      font-size: 12px;
-      font-weight: 600;
-      color: #334155;
-    }
-    .resort-search-options {
-      display: flex;
-      align-items: center;
-      gap: 12px;
-      flex-wrap: wrap;
-      margin-top: -2px;
-    }
-    .resort-filter-bar {
-      display: flex;
-      align-items: center;
-      gap: 10px;
-    }
-    #filter-open-btn {
-      border: 1px solid #0f766e;
-      background: #0f766e;
-      color: #fff;
-      border-radius: 8px;
-      padding: 7px 12px;
-      font-size: 12px;
-      font-weight: 700;
-      cursor: pointer;
-    }
-    .filter-summary {
-      font-size: 12px;
-      color: #475569;
-      font-weight: 600;
-    }
-    .section-loading,
-    .page-load-error {
-      margin: 0;
-      font-size: 13px;
-      color: #64748b;
-      font-weight: 500;
-    }
-    .empty-state-cell {
-      padding: 14px 16px;
-      font-size: 13px;
-      color: #64748b;
-      font-weight: 600;
-      text-align: left;
-    }
-    .filter-modal[hidden] {
-      display: none;
-    }
-    .filter-modal {
-      position: fixed;
-      inset: 0;
-      background: rgba(15, 23, 42, 0.45);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      z-index: 50;
-      padding: 14px;
-    }
-    .filter-panel {
-      width: min(460px, 100%);
-      background: #fff;
-      border-radius: 12px;
-      border: 1px solid #cbd5e1;
-      box-shadow: 0 18px 50px rgba(0,0,0,0.18);
-      padding: 14px;
-    }
-    .filter-panel h3 {
-      margin: 0 0 10px;
-      font-size: 18px;
-      color: #0f172a;
-    }
-    .filter-group {
-      display: grid;
-      gap: 7px;
-      margin-bottom: 12px;
-      font-size: 13px;
-      color: #334155;
-    }
-    .filter-group label {
-      display: flex;
-      align-items: center;
-      gap: 6px;
-    }
-    .filter-option-grid {
-      display: grid;
-      gap: 6px;
-      max-height: 170px;
-      overflow: auto;
-      padding: 6px;
-      border: 1px solid #cbd5e1;
-      border-radius: 8px;
-      background: #fff;
-    }
-    .filter-option-list {
-      padding: 0;
-      border: 0;
-      border-radius: 0;
-      background: transparent;
-    }
-    .filter-option-grid label {
-      align-items: center;
-      justify-content: flex-start;
-      line-height: 1.2;
-    }
-    .filter-option-grid .filter-count {
-      color: #64748b;
-      font-size: 12px;
-      font-weight: 600;
-    }
-    .filter-option-empty {
-      font-size: 12px;
-      color: #64748b;
-      font-weight: 500;
-    }
-    .filter-group select {
-      width: 100%;
-      padding: 7px 10px;
-      border: 1px solid #cbd5e1;
-      border-radius: 8px;
-      background: #fff;
-      font-size: 13px;
-      color: #1f2937;
-    }
-    .filter-group label span[data-pass-count] {
-      color: #64748b;
-      font-size: 12px;
-      font-weight: 600;
-    }
-    .filter-group-title {
-      font-size: 12px;
-      font-weight: 700;
-      color: #0f172a;
-      text-transform: uppercase;
-      letter-spacing: 0.03em;
-    }
-    .filter-include-all-label {
-      font-weight: 600;
-      color: #0f172a;
-    }
-    .filter-actions {
-      display: flex;
-      gap: 8px;
-      justify-content: flex-end;
-      flex-wrap: wrap;
-    }
-    .filter-actions button {
-      border: 1px solid #94a3b8;
-      background: #f8fafc;
-      color: #1f2937;
-      border-radius: 8px;
-      padding: 7px 11px;
-      font-size: 12px;
-      font-weight: 600;
-      cursor: pointer;
-    }
-    .report-powered a {
-      color: #0f766e;
-      text-decoration: none;
-      font-weight: 600;
-    }
-    .report-powered a:hover {
-      text-decoration: underline;
-    }
-    .unit-toggle {
-      position: relative;
-      display: inline-flex;
-      gap: 0;
-      margin: 0;
-      padding: 4px;
-      border: 1px solid #cbd5e1;
-      border-radius: 999px;
-      background: #f8fafc;
-      overflow: hidden;
-    }
-    .section-header {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 12px;
-      margin: 24px 0 8px;
-    }
-    .section-header h2 {
-      margin: 0;
-    }
-    .unit-toggle::before {
-      content: "";
-      position: absolute;
-      top: 4px;
-      left: 4px;
-      width: calc(50% - 4px);
-      height: calc(100% - 8px);
-      border-radius: 999px;
-      background: #0f766e;
-      transform: translateX(0);
-      z-index: 0;
-    }
-    body:not(.units-pending) .unit-toggle::before {
-      transition: transform 240ms ease;
-    }
-    .unit-toggle[data-mode="imperial"]::before {
-      transform: translateX(100%);
-    }
-    .unit-btn {
-      border: 0;
-      background: transparent;
-      color: #334155;
-      padding: 5px 0;
-      border-radius: 999px;
-      font-size: 12px;
-      font-weight: 600;
-      cursor: pointer;
-      transition: color 160ms ease;
-      width: 52px;
-      position: relative;
-      z-index: 1;
-    }
-    .unit-toggle[data-compact-summary-toggle="1"] .unit-btn {
-      width: 58px;
-    }
-    body.units-pending .unit-btn {
-      transition: none;
-    }
-    .unit-btn.is-active {
-      color: #fff;
-    }
-    @keyframes unitCellRefresh {
-      from {
-        opacity: 0.35;
-        transform: translateY(2px);
-      }
-      to {
-        opacity: 1;
-        transform: translateY(0);
-      }
-    }
-    td.unit-changing {
-      animation: unitCellRefresh 240ms cubic-bezier(0.22, 1, 0.36, 1);
-    }
-    h2 {
-      margin: 24px 0 8px;
-      font-size: 20px;
-    }
-    .table-wrap {
-      overflow: auto;
-      border: 1px solid #d1d5db;
-      border-radius: 10px;
-      background: #fff;
-      box-shadow: 0 6px 24px rgba(0,0,0,0.06);
-    }
-    table {
-      border-collapse: separate;
-      border-spacing: 0;
-      width: max-content;
-    }
-    th, td {
-      border-bottom: 1px solid #e5e7eb;
-      border-right: 1px solid #f3f4f6;
-      padding: 7px 9px;
-      line-height: 14px;
-      font-size: 12px;
-      text-align: right;
-      white-space: nowrap;
-    }
-    th {
-      background: #f3f4f6;
-      text-align: center;
-      font-weight: 700;
-    }
-    th .day-label-date,
-    th .day-label-weekday {
-      display: block;
-      line-height: 1.15;
-    }
-    th .day-label-weekday {
-      font-size: 11px;
-      color: #475569;
-      font-weight: 600;
-    }
-    .plain-table thead th {
-      position: sticky;
-      top: 0;
-      z-index: 2;
-    }
-    .plain-table {
-      min-width: 1100px;
-    }
-    .plain-table .query-col {
-      text-align: left;
-      font-weight: 600;
-    }
-    .query-col .resort-link {
-      display: block;
-      color: #0f766e;
-      text-decoration: none;
-      font-weight: 700;
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-    .query-col .resort-link:hover {
-      text-decoration: underline;
-    }
-    .resort-cell {
-      display: block;
-      min-width: 0;
-    }
-    .resort-link-wrap {
-      min-width: 0;
-    }
-    .resort-link-wrap .resort-link,
-    .resort-link-wrap > span,
-    .resort-link-wrap > a {
-      display: block;
-    }
-    .favorite-btn {
-      position: relative;
-      width: 14px;
-      height: 14px;
-      border: 0;
-      border-radius: 0;
-      background: transparent;
-      color: #94a3b8;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      line-height: 1;
-      cursor: pointer;
-      padding: 0;
-      transition:
-        transform 180ms ease,
-        color 180ms ease;
-    }
-    .favorite-col .favorite-btn,
-    .favorite-head .favorite-btn {
-      display: flex;
-      margin: 0 auto;
-    }
-    .favorite-btn-icon {
-      position: absolute;
-      inset: 0;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      width: 12px;
-      height: 12px;
-      margin: auto;
-      line-height: 1;
-      transition: transform 180ms ease, opacity 180ms ease, color 180ms ease;
-    }
-    .favorite-btn-outline {
-      opacity: 1;
-      transform: scale(1);
-      color: #64748b;
-    }
-    .favorite-btn-filled {
-      opacity: 0;
-      transform: scale(0.7);
-      color: #fb7185;
-    }
-    .favorite-btn[data-favorite-active="1"] .favorite-btn-outline {
-      opacity: 0;
-      transform: scale(0.7);
-    }
-    .favorite-btn[data-favorite-active="1"] .favorite-btn-filled {
-      opacity: 1;
-      transform: scale(1);
-    }
-    .favorite-btn:hover {
-      transform: scale(1.08);
-    }
-    .favorite-btn:hover .favorite-btn-outline {
-      color: #fb7185;
-      transform: scale(1.05);
-    }
-    .favorite-btn:hover .favorite-btn-filled {
-      transform: scale(0.82);
-    }
-    .favorite-btn:focus-visible {
-      outline: 2px solid #fb7185;
-      outline-offset: 2px;
-    }
-    .favorite-col,
-    .favorite-head {
-      width: 28px;
-      min-width: 28px;
-      text-align: center;
-      padding-top: 0;
-      padding-bottom: 0;
-      padding-left: 0;
-      padding-right: 0;
-      line-height: 1;
-    }
-    .favorite-col {
-      background: #fff;
-      vertical-align: middle;
-    }
-    .favorite-head {
-      background: #f3f4f6;
-      vertical-align: middle;
-    }
-    .favorite-all-btn {
-      opacity: 0.78;
-    }
-    .favorite-all-btn:hover {
-      opacity: 1;
-    }
-    .compact-grid-wrap {
-      display: flex;
-      border: 1px solid #d1d5db;
-      border-radius: 10px;
-      background: #fff;
-      box-shadow: 0 6px 24px rgba(0,0,0,0.06);
-      overflow: hidden;
-      --compact-header-row1-h: 32px;
-      margin-top: 8px;
-    }
-    .compact-grid-mobile-wrap {
-      margin-top: 8px;
-      border: 1px solid #d1d5db;
-      border-radius: 10px;
-      background: #fff;
-      box-shadow: 0 6px 24px rgba(0,0,0,0.06);
-      overflow: auto;
-      --compact-mobile-query-w: 180px;
-    }
-    .compact-grid-left-wrap {
-      flex: 0 0 auto;
-      background: #fff;
-      overflow-x: hidden;
-      overflow-y: auto;
-      --compact-query-w: 220px;
-    }
-    .compact-grid-right-wrap {
-      flex: 1 1 auto;
-      overflow: auto;
-    }
-    .compact-grid-mobile-wrap,
-    .compact-grid-left-wrap,
-    .compact-grid-right-wrap,
-    .sticky-single-table-wrap,
-    .weather-table-wrap,
-    .snowfall-sticky-wrap,
-    .snowfall-left-wrap,
-    .snowfall-right-wrap,
-    .rain-sticky-wrap,
-    .rain-left-wrap,
-    .rain-right-wrap,
-    .temperature-sticky-wrap,
-    .sun-single-wrap {
-      -webkit-overflow-scrolling: touch;
-    }
-    .sticky-single-table-wrap {
-      overflow: auto;
-    }
-    .sticky-single-table {
-      table-layout: fixed;
-      width: max-content;
-      min-width: 100%;
-    }
-    .sticky-single-table thead th {
-      position: sticky;
-      top: 0;
-      z-index: 5;
-      background: #e5e7eb;
-    }
-    .sticky-single-table[data-sticky-header-rows="2"] thead tr:nth-child(2) th {
-      top: var(--sticky-header-row-2-top, 32px);
-    }
-    .sticky-single-table .sticky-leading-cell {
-      position: sticky;
-      left: var(--sticky-leading-left, 0px);
-      z-index: 6;
-      background: #fff;
-      background-clip: padding-box;
-    }
-    .sticky-single-table thead .sticky-leading-cell {
-      z-index: 8;
-      background: #e5e7eb;
-    }
-    .compact-grid-mobile-table {
-      table-layout: fixed;
-      width: max-content;
-      min-width: 100%;
-    }
-    .compact-grid-mobile-table col.col-favorite {
-      width: 28px;
-    }
-    .compact-grid-mobile-table col.col-query {
-      width: var(--compact-mobile-query-w);
-    }
-    .compact-grid-mobile-table col.col-compact-day {
-      width: 98px;
-    }
-    .compact-grid-left-table,
-    .compact-grid-right-table {
-      table-layout: fixed;
-      width: auto;
-      min-width: 0;
-    }
-    .compact-grid-right-table {
-      width: max-content;
-    }
-    .compact-grid-left-table col.col-favorite {
-      width: 28px;
-    }
-    .compact-grid-left-table col.col-query {
-      width: var(--compact-query-w);
-    }
-    .compact-grid-right-table col.col-compact-day {
-      width: 98px;
-    }
-    .compact-grid-left-table thead th,
-    .compact-grid-right-table thead th,
-    .compact-grid-mobile-table thead th {
-      position: sticky;
-      top: 0;
-      z-index: 5;
-      background: #e5e7eb;
-    }
-    .compact-grid-left-table tbody .query-col {
-      text-align: left;
-      font-weight: 600;
-      background: #fff;
-      max-width: var(--compact-query-w);
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-    .compact-grid-left-table thead .query-col {
-      text-align: left;
-    }
-    .compact-grid-mobile-table .query-col {
-      text-align: left;
-      font-weight: 600;
-      background: #fff;
-      max-width: var(--compact-mobile-query-w);
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-    .compact-grid-mobile-table thead .query-col {
-      background: #e5e7eb;
-      z-index: 8;
-    }
-    .compact-grid-left-table td,
-    .compact-grid-right-table td,
-    .compact-grid-mobile-table td {
-      background-clip: padding-box;
-    }
-    .compact-grid-left-table td,
-    .compact-grid-right-table td,
-    .compact-grid-mobile-table td {
-      padding-top: 4px;
-      padding-bottom: 4px;
-      padding-left: 9px;
-      padding-right: 9px;
-    }
-    .compact-grid-left-table thead th,
-    .compact-grid-right-table thead th,
-    .compact-grid-mobile-table thead th {
-      padding-top: 7px;
-      padding-bottom: 7px;
-    }
-    .compact-grid-left-table .favorite-col,
-    .compact-grid-left-table .favorite-head,
-    .compact-grid-mobile-table .favorite-col,
-    .compact-grid-mobile-table .favorite-head {
-      width: 28px;
-      min-width: 28px;
-      padding-left: 0;
-      padding-right: 0;
-    }
-    .compact-grid-mobile-table .favorite-col,
-    .compact-grid-mobile-table .favorite-head {
-    }
-    .compact-day-cell {
-      padding: 5px 8px;
-      height: 62px;
-      min-height: 62px;
-      vertical-align: top;
-    }
-    .compact-day-card {
-      display: flex;
-      flex-direction: column;
-      justify-content: space-between;
-      gap: 4px;
-      height: 100%;
-    }
-    .compact-row {
-      display: grid;
-      align-items: center;
-    }
-    .compact-row-primary {
-      grid-template-columns: 20px 1fr;
-      gap: 2px;
-      align-items: stretch;
-    }
-    .compact-row-secondary {
-      grid-template-columns: 1fr 1fr;
-      gap: 6px;
-      align-items: center;
-    }
-    .compact-weather {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      align-self: stretch;
-      font-size: 26px;
-      line-height: 1;
-    }
-    .compact-temp-stack {
-      display: grid;
-      justify-items: end;
-      line-height: 1.1;
-      gap: 1px;
-    }
-    .compact-temp-high {
-      font-size: 15px;
-      font-weight: 600;
-      color: #0f172a;
-    }
-    .compact-temp-low {
-      font-size: 12px;
-      font-weight: 500;
-      color: #475569;
-    }
-    .compact-pair {
-      display: inline-flex;
-      align-items: center;
-      gap: 2px;
-      min-width: 0;
-      font-size: 12px;
-      line-height: 1;
-      white-space: nowrap;
-    }
-    .compact-pair-value {
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-    .compact-row-secondary .compact-pair {
-      color: #334155;
-      font-weight: 600;
-    }
-    .compact-rain {
-      justify-self: end;
-      justify-content: flex-end;
-      text-align: right;
-      flex-direction: row-reverse;
-    }
-    .compact-snow .compact-pair-icon {
-      color: #2563eb;
-    }
-    .compact-rain .compact-pair-icon {
-      color: #0f766e;
-    }
-    .desktop-only {
-      display: block;
-    }
-    .mobile-only {
-      display: none;
-    }
-    .weather-table-wrap {
-      margin-top: 8px;
-      border: 1px solid #d1d5db;
-      border-radius: 10px;
-      background: #fff;
-      box-shadow: 0 6px 24px rgba(0,0,0,0.06);
-      overflow: auto;
-      --weather-query-w: 220px;
-    }
-    .weather-table {
-      table-layout: fixed;
-      width: max-content;
-      min-width: 100%;
-    }
-    .weather-table col.col-favorite {
-      width: 28px;
-    }
-    .weather-table col.col-query {
-      width: var(--weather-query-w);
-    }
-    .weather-table col.col-weather {
-      width: 68px;
-    }
-    .weather-table .favorite-col,
-    .weather-table .favorite-head {
-      width: 28px;
-      min-width: 28px;
-      padding-left: 0;
-      padding-right: 0;
-    }
-    .weather-table .query-col {
-      text-align: left;
-      font-weight: 600;
-      background: #fff;
-      max-width: var(--weather-query-w);
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-    .weather-table thead .query-col {
-      background: #e5e7eb;
-    }
-    .weather-table td {
-      background-clip: padding-box;
-    }
-    .weather-table td.weather-emoji-cell {
-      text-align: center;
-      font-size: 18px;
-      line-height: 1;
-    }
-    .snowfall-sticky-wrap,
-    .rain-sticky-wrap {
-      border: 1px solid #d1d5db;
-      border-radius: 10px;
-      background: #fff;
-      box-shadow: 0 6px 24px rgba(0,0,0,0.06);
-      overflow: auto;
-    }
-    .snowfall-sticky-wrap {
-      --snowfall-query-w: 220px;
-      --snowfall-week-w: 110px;
-    }
-    .rain-sticky-wrap {
-      --rain-query-w: 220px;
-      --rain-week-w: 110px;
-    }
-    .snowfall-sticky-table col.col-favorite,
-    .rain-sticky-table col.col-favorite {
-      width: 28px;
-    }
-    .snowfall-sticky-table col.col-query {
-      width: var(--snowfall-query-w);
-    }
-    .rain-sticky-table col.col-query {
-      width: var(--rain-query-w);
-    }
-    .snowfall-sticky-table col.col-week {
-      width: var(--snowfall-week-w);
-    }
-    .rain-sticky-table col.col-week {
-      width: var(--rain-week-w);
-    }
-    .snowfall-sticky-table col.col-day,
-    .rain-sticky-table col.col-day {
-      width: 66px;
-    }
-    .snowfall-sticky-table .query-col,
-    .rain-sticky-table .query-col {
-      text-align: left;
-      font-weight: 600;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-    .mobile-precip-resort-content {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      min-width: 0;
-    }
-    .mobile-precip-resort-content .resort-cell {
-      flex: 1 1 auto;
-      min-width: 0;
-    }
-    .mobile-precip-resort-head {
-      text-align: left;
-    }
-    .mobile-precip-resort-head .favorite-btn,
-    .mobile-precip-resort-cell .favorite-btn {
-      flex: 0 0 auto;
-      margin: 0;
-    }
-    .mobile-precip-resort-label {
-      min-width: 0;
-    }
-    .snowfall-sticky-table .query-col {
-      max-width: var(--snowfall-query-w);
-    }
-    .rain-sticky-table .query-col {
-      max-width: var(--rain-query-w);
-    }
-    .snowfall-sticky-table .week-col-cell,
-    .rain-sticky-table .week-col-cell {
-      text-align: center;
-    }
-    .snowfall-sticky-table td,
-    .rain-sticky-table td {
-      background-clip: padding-box;
-    }
-    .snowfall-split-wrap {
-      display: flex;
-      border: 1px solid #d1d5db;
-      border-radius: 10px;
-      background: #fff;
-      box-shadow: 0 6px 24px rgba(0,0,0,0.06);
-      overflow: hidden;
-      --snow-header-row1-h: 32px;
-    }
-    .snowfall-split-wrap.mobile-only {
-      display: none;
-    }
-    .snowfall-left-wrap {
-      flex: 0 0 auto;
-      background: #fff;
-      overflow: hidden;
-      --query-col-w: 220px;
-      --week-col-w: 110px;
-    }
-    .snowfall-left-table col.col-favorite {
-      width: 28px;
-    }
-    .snowfall-left-table col.col-query {
-      width: var(--query-col-w);
-    }
-    .snowfall-left-table col.col-week {
-      width: var(--week-col-w);
-    }
-    .snowfall-right-wrap {
-      flex: 1 1 auto;
-      overflow: auto;
-    }
-    .snowfall-left-table, .snowfall-right-table {
-      table-layout: fixed;
-    }
-    .snowfall-left-table {
-      min-width: 0;
-      width: auto;
-    }
-    .snowfall-right-table {
-      min-width: 0;
-      width: auto;
-    }
-    .snowfall-right-table col.col-week-right {
-      width: 100px;
-    }
-    .snowfall-right-table col.col-day {
-      width: 66px;
-    }
-    .snowfall-left-table thead tr:first-child th,
-    .snowfall-right-table thead tr:first-child th {
-      top: 0;
-      z-index: 5;
-    }
-    .snowfall-left-table thead tr:nth-child(2) th,
-    .snowfall-right-table thead tr:nth-child(2) th {
-      top: var(--snow-header-row1-h);
-      z-index: 5;
-      text-align: center;
-    }
-    .snowfall-left-table .query-col {
-      text-align: left;
-      font-weight: 600;
-      max-width: var(--query-col-w);
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-    .snowfall-left-table thead th,
-    .snowfall-right-table thead th {
-      position: sticky;
-      background: #e5e7eb;
-    }
-    .snowfall-left-table td,
-    .snowfall-right-table td {
-      background-clip: padding-box;
-    }
-    .rain-split-wrap {
-      display: flex;
-      border: 1px solid #d1d5db;
-      border-radius: 10px;
-      background: #fff;
-      box-shadow: 0 6px 24px rgba(0,0,0,0.06);
-      overflow: hidden;
-      --rain-header-row1-h: 32px;
-    }
-    .rain-split-wrap.mobile-only {
-      display: none;
-    }
-    .rain-left-wrap {
-      flex: 0 0 auto;
-      background: #fff;
-      overflow: hidden;
-      --rain-query-w: 220px;
-      --rain-week-w: 110px;
-    }
-    .rain-right-wrap {
-      flex: 1 1 auto;
-      overflow: auto;
-    }
-    .rain-left-table, .rain-right-table {
-      table-layout: fixed;
-      width: auto;
-      min-width: 0;
-    }
-    .rain-left-table col.col-favorite {
-      width: 28px;
-    }
-    .rain-left-table col.col-query {
-      width: var(--rain-query-w);
-    }
-    .rain-left-table col.col-week {
-      width: var(--rain-week-w);
-    }
-    .rain-right-table col.col-day {
-      width: 66px;
-    }
-    .rain-right-table col.col-week-right {
-      width: 100px;
-    }
-    .rain-left-table thead tr:first-child th,
-    .rain-right-table thead tr:first-child th {
-      position: sticky;
-      top: 0;
-      z-index: 5;
-      background: #e5e7eb;
-    }
-    .rain-left-table thead tr:nth-child(2) th,
-    .rain-right-table thead tr:nth-child(2) th {
-      position: sticky;
-      top: var(--rain-header-row1-h);
-      z-index: 5;
-      background: #e5e7eb;
-    }
-    .rain-left-table .query-col {
-      text-align: left;
-      font-weight: 600;
-      max-width: var(--rain-query-w);
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-    .rain-left-table td, .rain-right-table td {
-      background-clip: padding-box;
-    }
-    .temperature-sticky-wrap {
-      margin-top: 8px;
-      border: 1px solid #d1d5db;
-      border-radius: 10px;
-      background: #fff;
-      box-shadow: 0 6px 24px rgba(0,0,0,0.06);
-      overflow: auto;
-      --temp-query-w: 220px;
-    }
-    .temperature-single-table {
-      table-layout: fixed;
-      width: max-content;
-      min-width: 100%;
-    }
-    .temperature-single-table col.col-favorite {
-      width: 28px;
-    }
-    .temperature-single-table col.col-query {
-      width: var(--temp-query-w);
-    }
-    .temperature-single-table col.col-temp {
-      width: 50px;
-    }
-    .temperature-single-table .query-col {
-      text-align: left;
-      font-weight: 600;
-      background: #fff;
-      max-width: var(--temp-query-w);
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-    .temperature-single-table td {
-      background-clip: padding-box;
-    }
-    .sun-single-wrap {
-      border: 1px solid #d1d5db;
-      border-radius: 10px;
-      background: #fff;
-      box-shadow: 0 6px 24px rgba(0,0,0,0.06);
-      overflow: auto;
-      --sun-query-w: 220px;
-    }
-    .sun-single-table {
-      table-layout: fixed;
-      width: max-content;
-      min-width: 100%;
-    }
-    .sun-single-table col.col-favorite {
-      width: 28px;
-    }
-    .sun-single-table col.col-query {
-      width: var(--sun-query-w);
-    }
-    .sun-single-table col.col-sun {
-      width: 58px;
-    }
-    .sun-single-table .query-col {
-      text-align: left;
-      font-weight: 600;
-      background: #fff;
-      max-width: var(--sun-query-w);
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-    .sun-single-table td {
-      background-clip: padding-box;
-    }
-    .sun-single-table td[data-sun-time-raw] {
-      text-align: center;
-    }
-    body.mobile-simple .desktop-only {
-      display: none;
-    }
-    body.mobile-simple .mobile-only {
-      display: block;
-    }
-    body.mobile-simple .snowfall-split-wrap.mobile-only {
-      display: flex;
-    }
-    body.mobile-simple .rain-split-wrap.mobile-only {
-      display: flex;
-    }
-    body.mobile-simple .snowfall-left-table th,
-    body.mobile-simple .snowfall-left-table td,
-    body.mobile-simple .snowfall-right-table th,
-    body.mobile-simple .snowfall-right-table td,
-    body.mobile-simple .rain-left-table th,
-    body.mobile-simple .rain-left-table td,
-    body.mobile-simple .rain-right-table th,
-    body.mobile-simple .rain-right-table td {
-      box-sizing: border-box;
-    }
-    body.mobile-simple {
-      --mobile-leading-col-max: max(0px, calc(50vw - 28px));
-      --mobile-single-leading-col-max: 50vw;
-    }
-    body.mobile-simple .plain-table {
-      min-width: 0;
-    }
-    body.mobile-simple .compact-grid-mobile-table col.col-query {
-      width: min(var(--compact-mobile-query-w), var(--mobile-leading-col-max));
-    }
-    body.mobile-simple .compact-grid-mobile-table .query-col {
-      max-width: min(var(--compact-mobile-query-w), var(--mobile-leading-col-max));
-    }
-    body.mobile-simple .snowfall-left-table col.col-query {
-      width: min(var(--query-col-w), var(--mobile-leading-col-max));
-    }
-    body.mobile-simple .snowfall-left-table .query-col {
-      max-width: min(var(--query-col-w), var(--mobile-leading-col-max));
-    }
-    body.mobile-simple .snowfall-sticky-wrap.mobile-only .snowfall-sticky-table col.col-query {
-      width: min(var(--snowfall-query-w), var(--mobile-single-leading-col-max));
-    }
-    body.mobile-simple .snowfall-sticky-wrap.mobile-only .snowfall-sticky-table .query-col {
-      max-width: min(var(--snowfall-query-w), var(--mobile-single-leading-col-max));
-    }
-    body.mobile-simple .snowfall-sticky-wrap.mobile-only .snowfall-sticky-table col.col-week {
-      width: 92px;
-    }
-    body.mobile-simple .snowfall-sticky-wrap.mobile-only .snowfall-sticky-table col.col-day {
-      width: 62px;
-    }
-    body.mobile-simple .rain-left-table col.col-query {
-      width: min(var(--rain-query-w), var(--mobile-leading-col-max));
-    }
-    body.mobile-simple .rain-left-table .query-col {
-      max-width: min(var(--rain-query-w), var(--mobile-leading-col-max));
-    }
-    body.mobile-simple .rain-sticky-wrap.mobile-only .rain-sticky-table col.col-query {
-      width: min(var(--rain-query-w), var(--mobile-single-leading-col-max));
-    }
-    body.mobile-simple .rain-sticky-wrap.mobile-only .rain-sticky-table .query-col {
-      max-width: min(var(--rain-query-w), var(--mobile-single-leading-col-max));
-    }
-    body.mobile-simple .rain-sticky-wrap.mobile-only .rain-sticky-table col.col-week {
-      width: 92px;
-    }
-    body.mobile-simple .rain-sticky-wrap.mobile-only .rain-sticky-table col.col-day {
-      width: 62px;
-    }
-    body.mobile-simple .temperature-single-table col.col-query {
-      width: min(var(--temp-query-w), var(--mobile-leading-col-max));
-    }
-    body.mobile-simple .temperature-single-table .query-col {
-      max-width: min(var(--temp-query-w), var(--mobile-leading-col-max));
-    }
-    body.mobile-simple .weather-table col.col-query {
-      width: min(var(--weather-query-w), var(--mobile-leading-col-max));
-    }
-    body.mobile-simple .weather-table .query-col {
-      max-width: min(var(--weather-query-w), var(--mobile-leading-col-max));
-    }
-    body.mobile-simple .sun-single-table col.col-query {
-      width: min(var(--sun-query-w), var(--mobile-leading-col-max));
-    }
-    body.mobile-simple .sun-single-table .query-col {
-      max-width: min(var(--sun-query-w), var(--mobile-leading-col-max));
-    }
-
-/* Alpine product shell */
-:root {
-  --ink-950: #081a29;
-  --ink-900: #10283a;
-  --ink-800: #1c3a4d;
-  --ink-700: #37566a;
-  --ink-500: #6a8291;
-  --snow-50: #f8fbfc;
-  --snow-100: #eef4f6;
-  --snow-200: #dce7eb;
-  --glacier-300: #8fd8e8;
-  --glacier-500: #28a9c2;
-  --glacier-600: #148ca8;
-  --sun-400: #f7c969;
-  --surface: #ffffff;
-  --surface-soft: #f4f8f9;
-  --border: #d8e3e7;
-  --shadow-soft: 0 18px 50px rgba(8, 26, 41, 0.08);
-  --shadow-card: 0 10px 28px rgba(8, 26, 41, 0.07);
-  --radius-lg: 24px;
-  --radius-md: 16px;
-  --radius-sm: 11px;
-}
-
-* {
-  box-sizing: border-box;
-}
-
-html {
-  background: var(--snow-100);
-}
+/* Homepage composition for the CloseSnow Alpine Field Guide. */
 
 body {
   min-width: 0;
-  overflow-x: clip;
-  color: var(--ink-900);
   background:
-    radial-gradient(circle at 12% -10%, rgba(143, 216, 232, 0.32), transparent 34rem),
-    linear-gradient(180deg, #f7fbfc 0%, var(--snow-100) 42%, #f5f8f7 100%);
-  font-family: "Avenir Next", "Segoe UI", sans-serif;
-  -webkit-font-smoothing: antialiased;
+    linear-gradient(180deg, #eef5f2 0, #fbfcfa 18rem, #fbfcfa 100%);
 }
 
-button,
-input,
-select {
-  font: inherit;
-}
-
-button,
-a,
-input,
-select {
-  transition: border-color 160ms ease, box-shadow 160ms ease, color 160ms ease, background-color 160ms ease, transform 160ms ease;
-}
-
-button:focus-visible,
-a:focus-visible,
-input:focus-visible,
-select:focus-visible {
-  outline: 3px solid rgba(40, 169, 194, 0.28);
-  outline-offset: 2px;
-}
-
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
+body.filter-sheet-open {
   overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
 }
 
-.site-header {
-  position: relative;
-  z-index: 30;
-  color: #fff;
-  background: var(--ink-950);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.09);
-}
-
-.site-header-inner {
-  width: min(1440px, 100%);
-  min-height: 72px;
-  margin: 0 auto;
-  padding: 0 28px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 24px;
-}
-
-.brand {
-  display: inline-flex;
-  align-items: center;
-  gap: 11px;
-  color: #fff;
-  text-decoration: none;
-}
-
-.brand:hover {
-  color: var(--glacier-300);
-}
-
-.brand-mark {
-  width: 40px;
-  height: 40px;
-  border-radius: 13px;
-  display: grid;
-  place-items: center;
-  color: var(--ink-950);
-  background: linear-gradient(145deg, #d9f5fa, var(--glacier-300));
-  box-shadow: 0 8px 22px rgba(40, 169, 194, 0.22);
-}
-
-.brand-mark svg {
-  width: 30px;
-  height: 30px;
-  fill: currentColor;
-}
-
-.brand-mark svg path + path {
-  fill: none;
-  stroke: #eefdff;
-  stroke-width: 2.8;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-}
-
-.brand-copy {
-  display: grid;
-  gap: 1px;
-}
-
-.brand-copy strong {
-  font-size: 18px;
-  line-height: 1.05;
-  letter-spacing: -0.02em;
-}
-
-.brand-copy span {
-  color: #a9bfca;
-  font-size: 10px;
-  font-weight: 600;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-}
-
-.site-header-note {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  color: #c7d5dc;
-  font-size: 12px;
-  font-weight: 650;
-}
-
-.site-header-note > span {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: #65d6aa;
-  box-shadow: 0 0 0 5px rgba(101, 214, 170, 0.1);
-}
-
-main {
-  width: min(1440px, 100%);
-  max-width: none;
+.field-guide-home {
+  width: min(90rem, 100%);
   min-width: 0;
-  padding: 28px;
+  margin-inline: auto;
+  padding: 1.25rem var(--fg-page-gutter) 3.5rem;
 }
 
-.forecast-hero {
-  position: relative;
-  min-height: 320px;
-  padding: clamp(34px, 5vw, 66px);
-  overflow: hidden;
-  display: flex;
-  align-items: center;
-  border-radius: var(--radius-lg);
-  color: #fff;
-  background:
-    radial-gradient(circle at 82% 20%, rgba(143, 216, 232, 0.22), transparent 24rem),
-    linear-gradient(128deg, #0a1e2e 0%, #13364b 55%, #155268 100%);
-  box-shadow: 0 28px 70px rgba(8, 26, 41, 0.16);
-}
-
-.forecast-hero::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  opacity: 0.3;
-  background-image: radial-gradient(circle, rgba(255, 255, 255, 0.65) 0 1px, transparent 1.3px);
-  background-size: 42px 42px;
-  mask-image: linear-gradient(90deg, transparent 0%, #000 55%);
-}
-
-.forecast-hero-copy {
-  position: relative;
-  z-index: 3;
-  max-width: 650px;
-}
-
-.eyebrow {
-  margin: 0 0 10px;
-  color: var(--glacier-600);
-  font-size: 11px;
+.section-kicker {
+  margin: 0 0 0.3rem;
+  color: var(--fg-pine);
+  font-size: 0.7rem;
+  font-weight: 850;
+  letter-spacing: 0.12em;
   line-height: 1.2;
-  font-weight: 800;
-  letter-spacing: 0.13em;
   text-transform: uppercase;
 }
 
-.forecast-hero .eyebrow {
-  color: var(--glacier-300);
+.morning-masthead {
+  min-width: 0;
+  padding: clamp(1.25rem, 2.8vw, 2.25rem);
+  border: 1px solid var(--fg-line);
+  border-radius: var(--fg-radius-lg);
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(22rem, 0.8fr);
+  align-items: stretch;
+  gap: clamp(1.25rem, 3vw, 3rem);
+  background: var(--fg-surface);
 }
 
-.forecast-hero h1 {
-  max-width: 620px;
+.morning-masthead__copy {
+  min-width: 0;
+  align-self: center;
+}
+
+.morning-masthead h1 {
+  max-width: 16ch;
   margin: 0;
-  font-size: clamp(42px, 6.2vw, 78px);
-  line-height: 0.98;
+  color: var(--fg-header);
+  font-size: clamp(2rem, 4.2vw, 4rem);
+  font-weight: 790;
   letter-spacing: -0.055em;
+  line-height: 0.98;
 }
 
-.forecast-hero h1 span {
-  color: var(--glacier-300);
-}
-
-.hero-lede {
-  max-width: 580px;
-  margin: 22px 0 0;
-  color: #d6e5eb;
-  font-size: clamp(15px, 1.6vw, 18px);
+.morning-masthead__copy > p:last-child {
+  max-width: 44rem;
+  margin: 0.9rem 0 0;
+  color: var(--fg-ink-muted);
+  font-size: clamp(0.92rem, 1.35vw, 1.08rem);
   line-height: 1.55;
-  font-weight: 500;
 }
 
-.report-date {
-  margin: 26px 0 0;
-  padding-top: 18px;
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  flex-wrap: wrap;
-  border-top: 1px solid rgba(255, 255, 255, 0.14);
-}
-
-.report-powered,
-.report-generated {
+.morning-meta {
+  min-width: 0;
   margin: 0;
-  color: #b9ccd5;
-  font-size: 11px;
-  font-weight: 650;
+  padding: 0.35rem;
+  border-radius: var(--fg-radius-md);
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  color: var(--fg-header-copy);
+  background: var(--fg-header);
 }
 
-.report-powered a {
-  color: #fff;
+.morning-meta > div {
+  min-width: 0;
+  padding: 0.85rem 1rem;
+  border-right: 1px solid rgba(255, 255, 255, 0.12);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
 }
 
-.report-generated {
-  padding-left: 16px;
-  border-left: 1px solid rgba(255, 255, 255, 0.2);
+.morning-meta > div:nth-child(2n) {
+  border-right: 0;
 }
 
-.hero-landscape {
-  position: absolute;
-  z-index: 1;
-  right: -2%;
-  bottom: -6px;
-  width: min(56%, 760px);
-  height: 92%;
-  pointer-events: none;
+.morning-meta > div:nth-last-child(-n + 2) {
+  border-bottom: 0;
 }
 
-.hero-landscape svg {
-  position: absolute;
-  right: 0;
-  bottom: 0;
-  width: 100%;
-  height: 82%;
+.morning-meta dt {
+  margin-bottom: 0.18rem;
+  color: #a9c1c9;
+  font-size: 0.64rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
 }
 
-.mountain-back {
-  fill: rgba(103, 170, 190, 0.22);
+.morning-meta dd {
+  min-width: 0;
+  margin: 0;
+  overflow-wrap: anywhere;
+  color: #ffffff;
+  font-size: 0.83rem;
+  font-weight: 700;
+  line-height: 1.3;
 }
 
-.mountain-front {
-  fill: rgba(4, 22, 34, 0.7);
-}
-
-.snow-line {
-  fill: none;
-  stroke: rgba(214, 245, 250, 0.55);
-  stroke-width: 5;
-  stroke-linejoin: round;
-}
-
-.snow-line-front {
-  stroke: rgba(240, 253, 255, 0.72);
-}
-
-.hero-sun {
-  position: absolute;
-  top: 22%;
-  right: 20%;
-  width: 56px;
-  height: 56px;
-  border-radius: 50%;
-  background: var(--sun-400);
-  box-shadow: 0 0 50px rgba(247, 201, 105, 0.28);
-}
-
-.hero-contour {
-  position: absolute;
-  border: 1px solid rgba(143, 216, 232, 0.13);
-  border-radius: 48% 52% 42% 58%;
-  transform: rotate(-10deg);
-}
-
-.hero-contour-one {
-  width: 360px;
-  height: 128px;
-  right: 2%;
-  top: 5%;
-}
-
-.hero-contour-two {
-  width: 290px;
-  height: 96px;
-  right: 9%;
-  top: 13%;
-}
-
-.control-panel {
+.forecast-toolbar {
   position: sticky;
-  top: 12px;
-  z-index: 24;
-  margin: 18px 0 24px;
-  padding: 18px 20px;
-  border: 1px solid rgba(216, 227, 231, 0.88);
-  border-radius: var(--radius-md);
-  background: rgba(255, 255, 255, 0.94);
-  box-shadow: var(--shadow-soft);
-  backdrop-filter: blur(16px);
+  z-index: 20;
+  top: 0.75rem;
+  min-width: 0;
+  margin: 1rem 0 1.4rem;
+  padding: 1rem;
+  border: 1px solid var(--fg-line);
+  border-radius: var(--fg-radius-lg);
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: var(--fg-shadow-raised);
+  backdrop-filter: blur(14px);
 }
 
-.control-panel-heading {
+.forecast-toolbar__heading {
+  min-width: 0;
+  margin-bottom: 0.75rem;
   display: flex;
-  align-items: center;
+  align-items: end;
   justify-content: space-between;
-  gap: 18px;
-  margin-bottom: 14px;
+  gap: 1rem;
 }
 
-.control-panel-heading .eyebrow {
-  margin-bottom: 3px;
-}
-
-.control-panel-heading h2 {
+.forecast-toolbar__heading h2 {
   margin: 0;
-  color: var(--ink-950);
-  font-size: 19px;
-  letter-spacing: -0.02em;
+  color: var(--fg-ink);
+  font-size: 1rem;
+  letter-spacing: -0.015em;
+  line-height: 1.2;
 }
 
 .filter-summary {
-  max-width: 55%;
-  padding: 7px 11px;
+  min-width: 0;
+  max-width: 62%;
   overflow: hidden;
-  border-radius: 999px;
-  color: var(--ink-700);
-  background: var(--snow-100);
-  font-size: 11px;
+  color: var(--fg-ink-muted);
+  font-size: 0.72rem;
+  font-weight: 650;
+  text-align: right;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .resort-controls {
-  margin: 0;
+  min-width: 0;
   display: grid;
-  grid-template-columns: minmax(260px, 1fr) auto auto;
+  grid-template-columns: minmax(18rem, 1fr) auto auto;
   align-items: center;
-  gap: 12px;
+  gap: 0.65rem;
 }
 
 .resort-search {
   min-width: 0;
-  flex-wrap: nowrap;
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
 }
 
 .search-field {
+  position: relative;
   min-width: 0;
   flex: 1;
-  position: relative;
   display: flex;
   align-items: center;
 }
 
 .search-field svg {
   position: absolute;
-  left: 14px;
-  width: 18px;
-  height: 18px;
+  left: 0.8rem;
+  width: 1rem;
+  height: 1rem;
   fill: none;
-  stroke: var(--ink-500);
+  stroke: var(--fg-ink-subtle);
+  stroke-linecap: round;
   stroke-width: 1.8;
 }
 
 .resort-search input {
   width: 100%;
   min-width: 0;
-  height: 44px;
-  padding: 0 16px 0 42px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  color: var(--ink-950);
-  background: var(--surface-soft);
-  font-size: 13px;
+  height: 42px;
+  padding: 0 0.8rem 0 2.35rem;
+  border: 1px solid var(--fg-line-strong);
+  border-radius: var(--fg-radius-md);
+  background: var(--fg-surface-muted);
+  font-size: 0.85rem;
 }
 
 .resort-search input:focus {
-  border-color: var(--glacier-500);
-  background: #fff;
-  box-shadow: 0 0 0 4px rgba(40, 169, 194, 0.1);
-  outline: none;
+  border-color: var(--fg-glacier);
+  background: var(--fg-surface);
+  outline: 3px solid rgba(22, 122, 155, 0.16);
+  outline-offset: 0;
 }
 
-.resort-search button {
-  height: 40px;
-  padding: 0 12px;
-  border-color: transparent;
-  color: var(--ink-700);
+.resort-search > button {
+  min-height: 40px;
+  padding-inline: 0.7rem;
+  border: 0;
+  border-radius: var(--fg-radius-sm);
+  color: var(--fg-ink-muted);
   background: transparent;
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 750;
 }
 
-.resort-search button:hover {
-  color: var(--ink-950);
-  background: var(--snow-100);
+.resort-search > button:hover {
+  color: var(--fg-ink);
+  background: var(--fg-surface-muted);
 }
 
 .resort-search-options {
-  margin: 0;
-  gap: 8px;
-  flex-wrap: nowrap;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
 }
 
 .resort-search-toggle {
   position: relative;
-  gap: 0;
   cursor: pointer;
 }
 
@@ -1634,343 +238,791 @@ main {
 }
 
 .resort-search-toggle span {
-  padding: 10px 12px;
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  color: var(--ink-700);
-  background: #fff;
-  font-size: 11px;
+  min-height: 40px;
+  padding: 0.55rem 0.7rem;
+  border: 1px solid var(--fg-line);
+  border-radius: var(--fg-radius-md);
+  display: inline-flex;
+  align-items: center;
+  color: var(--fg-ink-muted);
+  background: var(--fg-surface);
+  font-size: 0.72rem;
+  font-weight: 720;
+  line-height: 1;
   white-space: nowrap;
 }
 
 .resort-search-toggle input:checked + span {
-  border-color: #b9e4ec;
-  color: #08748b;
-  background: #eaf8fa;
+  border-color: #91c8b9;
+  color: #0f5b4c;
+  background: var(--fg-pine-soft);
 }
 
 .resort-search-toggle input:focus-visible + span {
-  outline: 3px solid rgba(40, 169, 194, 0.25);
+  outline: 3px solid rgba(22, 122, 155, 0.25);
   outline-offset: 2px;
 }
 
 #filter-open-btn {
-  height: 42px;
-  padding: 0 16px;
+  position: relative;
+  min-height: 42px;
+  padding: 0.55rem 0.8rem;
+  border: 1px solid var(--fg-header);
+  border-radius: var(--fg-radius-md);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 7px;
-  border: 0;
-  border-radius: var(--radius-sm);
-  background: var(--ink-950);
-  box-shadow: 0 8px 18px rgba(8, 26, 41, 0.16);
+  gap: 0.45rem;
+  color: #ffffff;
+  background: var(--fg-header);
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 760;
+  white-space: nowrap;
 }
 
 #filter-open-btn:hover {
-  background: var(--ink-800);
-  transform: translateY(-1px);
+  border-color: #1f4b5b;
+  background: #1f4b5b;
 }
 
-#filter-open-btn svg {
-  width: 17px;
-  height: 17px;
+#filter-open-btn svg,
+.filter-close-btn svg {
+  width: 1rem;
+  height: 1rem;
   fill: none;
   stroke: currentColor;
-  stroke-width: 1.8;
   stroke-linecap: round;
+  stroke-width: 1.8;
+}
+
+.active-filter-count {
+  min-width: 1.25rem;
+  min-height: 1.25rem;
+  padding: 0.12rem 0.32rem;
+  border-radius: 999px;
+  display: inline-grid;
+  place-items: center;
+  color: var(--fg-header);
+  background: #ffffff;
+  font-size: 0.66rem;
+  line-height: 1;
+}
+
+.filter-modal[hidden] {
+  display: none;
 }
 
 .filter-modal {
-  background: rgba(5, 18, 28, 0.64);
-  backdrop-filter: blur(8px);
+  position: fixed;
+  z-index: 100;
+  inset: 0;
+  padding: 1rem;
+  display: grid;
+  place-items: center;
+  background: rgba(9, 30, 39, 0.58);
+  backdrop-filter: blur(5px);
 }
 
 .filter-panel {
-  padding: 22px;
-  border: 1px solid rgba(255, 255, 255, 0.5);
-  border-radius: var(--radius-md);
-  box-shadow: 0 28px 80px rgba(5, 18, 28, 0.3);
-}
-
-.filter-actions button:last-child {
-  border-color: var(--ink-950);
-  color: #fff;
-  background: var(--ink-950);
-}
-
-.forecast-overview {
-  margin: 0 0 24px;
-  padding: 24px;
-  border: 1px solid #cfe4e9;
-  border-radius: var(--radius-lg);
-  background:
-    radial-gradient(circle at 96% 10%, rgba(143, 216, 232, 0.2), transparent 22rem),
-    linear-gradient(145deg, #edf8fa 0%, #f9fcfd 62%);
-  box-shadow: var(--shadow-card);
-}
-
-.overview-heading {
-  margin-bottom: 17px;
-  display: flex;
-  align-items: end;
-  justify-content: space-between;
-  gap: 20px;
-}
-
-.overview-heading .eyebrow {
-  margin-bottom: 4px;
-}
-
-.overview-heading h2 {
-  margin: 0;
-  color: var(--ink-950);
-  font-size: clamp(23px, 2.4vw, 31px);
-  letter-spacing: -0.035em;
-}
-
-.overview-heading > span {
-  color: var(--ink-500);
-  font-size: 11px;
-  font-weight: 650;
-}
-
-.snow-pick-grid,
-.loading-card-grid {
+  width: min(42rem, 100%);
+  max-height: min(90vh, 46rem);
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  border-radius: var(--fg-radius-lg);
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 13px;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  overflow: hidden;
+  background: var(--fg-surface);
+  box-shadow: var(--fg-shadow-overlay);
 }
 
-.snow-pick-card {
-  min-width: 0;
-  padding: 18px;
-  border: 1px solid rgba(207, 228, 233, 0.9);
-  border-radius: var(--radius-md);
-  background: rgba(255, 255, 255, 0.88);
-  box-shadow: 0 6px 18px rgba(8, 26, 41, 0.04);
-}
-
-.snow-pick-card:hover {
-  border-color: #a8d8e2;
-  transform: translateY(-2px);
-  box-shadow: 0 14px 28px rgba(8, 26, 41, 0.08);
-}
-
-.snow-pick-card-topline {
+.filter-panel__header,
+.filter-actions {
+  padding: 1rem 1.15rem;
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 1rem;
 }
 
-.snow-pick-rank {
-  color: var(--glacier-600);
-  font-size: 10px;
-  font-weight: 800;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+.filter-panel__header {
+  border-bottom: 1px solid var(--fg-line);
 }
 
-.snow-pick-weather {
-  font-size: 26px;
-  line-height: 1;
-}
-
-.snow-pick-card h3 {
-  margin: 12px 0 3px;
-  overflow: hidden;
-  font-size: 17px;
-  line-height: 1.2;
-  letter-spacing: -0.02em;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.snow-pick-card h3 a {
-  color: var(--ink-950);
-  text-decoration: none;
-}
-
-.snow-pick-card h3 a:hover {
-  color: var(--glacier-600);
-}
-
-.snow-pick-card > p {
-  margin: 0 0 16px;
-  overflow: hidden;
-  color: var(--ink-500);
-  font-size: 11px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.snow-pick-metrics {
-  padding-top: 13px;
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 10px;
-  border-top: 1px solid var(--snow-200);
-}
-
-.snow-pick-metrics > span {
-  display: grid;
-  gap: 3px;
-}
-
-.snow-pick-metrics small {
-  color: var(--ink-500);
-  font-size: 10px;
-  font-weight: 650;
-}
-
-.snow-pick-metrics strong {
-  display: flex;
-  align-items: baseline;
-  gap: 3px;
-  color: var(--ink-950);
-  font-size: 20px;
-  line-height: 1;
+.filter-panel__header h2 {
+  margin: 0;
+  font-size: 1.25rem;
   letter-spacing: -0.025em;
 }
 
-.snow-pick-metrics em {
-  color: var(--ink-500);
-  font-size: 10px;
-  font-style: normal;
-  letter-spacing: 0;
-}
-
-.overview-empty {
-  grid-column: 1 / -1;
-  padding: 26px;
+.filter-close-btn {
+  width: 42px;
+  height: 42px;
+  padding: 0;
+  border: 1px solid var(--fg-line);
+  border-radius: var(--fg-radius-md);
   display: grid;
-  gap: 4px;
-  text-align: center;
-  color: var(--ink-500);
+  place-items: center;
+  background: var(--fg-surface-muted);
+  cursor: pointer;
 }
 
-.overview-empty strong {
-  color: var(--ink-900);
+.filter-panel__body {
+  min-height: 0;
+  padding: 1.1rem;
+  overflow-y: auto;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  align-items: start;
+  gap: 0.85rem;
+}
+
+.filter-group {
+  min-width: 0;
+  margin: 0;
+  padding: 0.9rem;
+  border: 1px solid var(--fg-line);
+  border-radius: var(--fg-radius-md);
+  background: var(--fg-paper);
+}
+
+.filter-group-title {
+  display: block;
+  margin: 0 0 0.6rem;
+  color: var(--fg-ink);
+  font-size: 0.76rem;
+  font-weight: 820;
+}
+
+.filter-group select {
+  width: 100%;
+  min-height: 42px;
+  padding: 0.5rem 2rem 0.5rem 0.65rem;
+  border: 1px solid var(--fg-line-strong);
+  border-radius: var(--fg-radius-sm);
+  background: var(--fg-surface);
+  font-size: 0.82rem;
+}
+
+.filter-check-list,
+.filter-option-grid {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.filter-check-list label,
+.filter-option-grid label {
+  min-height: 40px;
+  padding: 0.5rem 0.6rem;
+  border-radius: var(--fg-radius-sm);
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  color: var(--fg-ink-muted);
+  background: var(--fg-surface);
+  cursor: pointer;
+  font-size: 0.78rem;
+  font-weight: 650;
+}
+
+.filter-check-list label:hover,
+.filter-option-grid label:hover {
+  color: var(--fg-ink);
+  background: var(--fg-pine-soft);
+}
+
+.filter-check-list input,
+.filter-option-grid input {
+  width: 1rem;
+  height: 1rem;
+  margin: 0;
+  accent-color: var(--fg-pine);
+}
+
+.filter-option-grid label span {
+  min-width: 0;
+  flex: 1;
+}
+
+.filter-option-grid small {
+  color: var(--fg-ink-subtle);
+}
+
+.filter-option-empty {
+  margin: 0;
+  color: var(--fg-ink-muted);
+  font-size: 0.78rem;
+}
+
+.filter-actions {
+  border-top: 1px solid var(--fg-line);
+  justify-content: flex-end;
+  background: var(--fg-surface-muted);
 }
 
 #page-content-root {
   min-width: 0;
 }
 
-.forecast-section {
+.insight-board,
+.forecast-results {
   min-width: 0;
-  margin: 0 0 18px;
-  padding: 20px;
-  overflow: hidden;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  background: rgba(255, 255, 255, 0.94);
-  box-shadow: var(--shadow-card);
 }
 
-.forecast-section > h2,
-.forecast-section .section-header {
-  margin: 0 0 14px;
+.insight-board {
+  margin-bottom: 2rem;
+  padding: clamp(1rem, 2vw, 1.5rem);
+  border: 1px solid #bed8d0;
+  border-radius: var(--fg-radius-lg);
+  background: #edf6f2;
 }
 
-.forecast-section h2 {
+.section-heading {
+  min-width: 0;
+  margin-bottom: 1rem;
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 1.25rem;
+}
+
+.section-heading h2 {
   margin: 0;
-  color: var(--ink-950);
-  font-size: 18px;
-  letter-spacing: -0.02em;
+  color: var(--fg-header);
+  font-size: clamp(1.35rem, 2.2vw, 2rem);
+  letter-spacing: -0.035em;
+  line-height: 1.1;
 }
 
-.section-note {
-  color: var(--ink-500);
-  font-size: 11px;
+.section-heading > p {
+  max-width: 32rem;
+  margin: 0;
+  color: var(--fg-ink-muted);
+  font-size: 0.75rem;
+  font-weight: 650;
+  text-align: right;
+}
+
+.insight-grid,
+.loading-card-grid {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.insight-card {
+  min-width: 0;
+  padding: 1rem;
+  border: 1px solid #c9ded7;
+  border-radius: var(--fg-radius-md);
+  background: rgba(255, 255, 255, 0.92);
+}
+
+.insight-card__topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.insight-rank {
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  color: #ffffff;
+  background: var(--fg-pine);
+  font-size: 0.72rem;
+  font-weight: 850;
+}
+
+.insight-weather-icon.field-guide-weather-icon {
+  width: 2rem;
+  height: 2rem;
+}
+
+.insight-kicker {
+  margin: 0.85rem 0 0.2rem;
+  color: var(--fg-pine);
+  font-size: 0.65rem;
+  font-weight: 850;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.insight-card h3 {
+  margin: 0;
+  overflow-wrap: anywhere;
+  font-size: 1.08rem;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+}
+
+.insight-resort-link,
+.resort-card-link {
+  color: var(--fg-ink);
+  text-decoration: none;
+}
+
+.insight-resort-link:hover,
+.resort-card-link:hover {
+  color: var(--fg-glacier);
+  text-decoration: underline;
+}
+
+.insight-location {
+  margin: 0.25rem 0 0;
+  color: var(--fg-ink-subtle);
+  font-size: 0.72rem;
+}
+
+.insight-explanation {
+  margin: 0.75rem 0 0;
+  color: var(--fg-ink-muted);
+  font-size: 0.8rem;
+  line-height: 1.55;
+}
+
+.insight-board--empty {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.insight-board--empty h2,
+.results-empty-state h2 {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.insight-board--empty > p {
+  margin: 0;
+  color: var(--fg-ink-muted);
+}
+
+.results-heading {
+  padding-inline: 0.2rem;
+}
+
+.resort-card-grid {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 34rem), 1fr));
+  align-items: start;
+  gap: 1rem;
+}
+
+.resort-forecast-card {
+  min-width: 0;
+  border: 1px solid var(--fg-line);
+  border-radius: var(--fg-radius-lg);
+  overflow: hidden;
+  background: var(--fg-surface);
+}
+
+.resort-card-heading {
+  min-width: 0;
+  padding: 1.1rem 1.1rem 0;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.8rem;
+}
+
+.resort-card-title {
+  min-width: 0;
+}
+
+.resort-card-title > p {
+  margin: 0 0 0.16rem;
+  color: var(--fg-ink-subtle);
+  font-size: 0.7rem;
   font-weight: 650;
 }
 
-.unit-toggle {
-  padding: 3px;
-  border-color: var(--border);
-  background: var(--surface-soft);
+.resort-card-title h3 {
+  margin: 0;
+  overflow-wrap: anywhere;
+  color: var(--fg-ink);
+  font-size: 1.25rem;
+  letter-spacing: -0.03em;
+  line-height: 1.15;
 }
 
-.unit-toggle::before {
-  top: 3px;
-  left: 3px;
-  width: calc(50% - 3px);
-  height: calc(100% - 6px);
-  background: var(--ink-950);
+.resort-tags {
+  min-height: 1.3rem;
+  margin-top: 0.45rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
 }
 
-.unit-btn {
-  font-size: 11px;
-}
-
-.compact-grid-mobile-wrap,
-.snowfall-sticky-wrap,
-.rain-sticky-wrap,
-.temperature-sticky-wrap,
-.weather-table-wrap,
-.sun-single-wrap {
-  max-width: 100%;
-  border-color: var(--border);
-  border-radius: var(--radius-sm);
-  box-shadow: none;
-  scrollbar-color: #a9bdc7 var(--snow-100);
-  scrollbar-width: thin;
-}
-
-.compact-grid-mobile-wrap::-webkit-scrollbar,
-.snowfall-sticky-wrap::-webkit-scrollbar,
-.rain-sticky-wrap::-webkit-scrollbar,
-.temperature-sticky-wrap::-webkit-scrollbar,
-.weather-table-wrap::-webkit-scrollbar,
-.sun-single-wrap::-webkit-scrollbar {
-  width: 9px;
-  height: 9px;
-}
-
-.compact-grid-mobile-wrap::-webkit-scrollbar-thumb,
-.snowfall-sticky-wrap::-webkit-scrollbar-thumb,
-.rain-sticky-wrap::-webkit-scrollbar-thumb,
-.temperature-sticky-wrap::-webkit-scrollbar-thumb,
-.weather-table-wrap::-webkit-scrollbar-thumb,
-.sun-single-wrap::-webkit-scrollbar-thumb {
-  border: 2px solid var(--snow-100);
-  border-radius: 999px;
-  background: #a9bdc7;
-}
-
-th {
-  color: var(--ink-800);
-  background: #e9f0f2;
-  border-color: #d7e2e6;
-}
-
-td {
-  color: var(--ink-800);
-  border-color: #e7eef0;
-}
-
-tbody tr:hover td {
-  box-shadow: inset 0 1px rgba(40, 169, 194, 0.18), inset 0 -1px rgba(40, 169, 194, 0.18);
-}
-
-.query-col .resort-link {
-  color: #0c7890;
+.resort-tag {
+  padding: 0.22rem 0.4rem;
+  border-radius: var(--fg-radius-sm);
+  color: var(--fg-pine);
+  background: var(--fg-pine-soft);
+  font-size: 0.6rem;
+  font-weight: 850;
+  letter-spacing: 0.05em;
 }
 
 .favorite-btn {
-  color: #9eafb8;
+  width: 44px;
+  height: 44px;
+  flex: 0 0 44px;
+  padding: 0;
+  border: 1px solid var(--fg-line);
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  color: var(--fg-ink-subtle);
+  background: var(--fg-surface-muted);
+  cursor: pointer;
+}
+
+.favorite-btn:hover {
+  border-color: #d8a6a2;
+  color: var(--fg-danger);
+  background: #fff5f4;
+}
+
+.favorite-btn svg {
+  width: 1.25rem;
+  height: 1.25rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-linejoin: round;
+  stroke-width: 1.8;
 }
 
 .favorite-btn[data-favorite-active="1"] {
-  color: #e35769;
+  border-color: #e2b4b0;
+  color: var(--fg-danger);
+  background: #fff2f1;
+}
+
+.favorite-btn[data-favorite-active="1"] svg {
+  fill: currentColor;
+}
+
+.resort-outlook {
+  min-height: 3.7rem;
+  margin: 0.8rem 1.1rem;
+  color: var(--fg-ink-muted);
+  font-size: 0.82rem;
+  line-height: 1.55;
+}
+
+.today-brief {
+  min-width: 0;
+  margin-inline: 1.1rem;
+  padding: 0.7rem 0.8rem;
+  border: 1px solid #cbdfe6;
+  border-radius: var(--fg-radius-md);
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.65rem;
+  background: #edf6f9;
+}
+
+.today-brief-icon.field-guide-weather-icon {
+  width: 2rem;
+  height: 2rem;
+}
+
+.today-brief > div {
+  min-width: 0;
+  display: grid;
+}
+
+.today-brief > div span {
+  color: var(--fg-ink-subtle);
+  font-size: 0.64rem;
+  font-weight: 750;
+  text-transform: uppercase;
+}
+
+.today-brief > div strong {
+  overflow: hidden;
+  color: var(--fg-ink);
+  font-size: 0.86rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.today-temperature {
+  color: var(--fg-header);
+  font-size: 0.82rem;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.resort-metric-grid {
+  min-width: 0;
+  margin: 0.8rem 1.1rem;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.45rem;
+}
+
+.resort-metric {
+  min-width: 0;
+  padding: 0.62rem;
+  border: 1px solid var(--fg-line);
+  border-radius: var(--fg-radius-sm);
+  background: var(--fg-paper);
+}
+
+.resort-metric dt {
+  color: var(--fg-ink-subtle);
+  font-size: 0.62rem;
+  font-weight: 720;
+}
+
+.resort-metric dd {
+  margin: 0.18rem 0 0;
+  overflow-wrap: anywhere;
+  color: var(--fg-ink);
+  font-size: 0.78rem;
+  font-weight: 820;
+  line-height: 1.25;
+}
+
+.near-term-list {
+  min-width: 0;
+  margin: 0 1.1rem 1rem;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.4rem;
+  list-style: none;
+}
+
+.near-day {
+  min-width: 0;
+  padding: 0.6rem;
+  border-left: 2px solid var(--fg-line-strong);
+  display: grid;
+  gap: 0.2rem;
+}
+
+.near-day__date,
+.near-day__snow {
+  color: var(--fg-ink-subtle);
+  font-size: 0.62rem;
+  font-weight: 680;
+}
+
+.near-day__condition {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  color: var(--fg-ink-muted);
+  font-size: 0.7rem;
+}
+
+.near-day__condition .field-guide-weather-icon {
+  width: 1.1rem;
+  height: 1.1rem;
+  flex: 0 0 1.1rem;
+}
+
+.near-day__condition span:last-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.near-day__temp {
+  color: var(--fg-ink);
+  font-size: 0.77rem;
+  font-weight: 800;
+}
+
+.resort-day-disclosure {
+  border: 0 !important;
+  border-top: 1px solid var(--fg-line) !important;
+  border-radius: 0 !important;
+}
+
+.resort-day-disclosure > summary {
+  min-height: 54px;
+  padding: 0.75rem 1.1rem !important;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
+  color: var(--fg-glacier);
+  background: var(--fg-paper);
+  cursor: pointer;
+  font-size: 0.78rem;
+  font-weight: 800;
+  list-style: none;
+}
+
+.resort-day-disclosure > summary::-webkit-details-marker {
+  display: none;
+}
+
+.resort-day-disclosure > summary::after {
+  content: "+";
+  width: 1.5rem;
+  height: 1.5rem;
+  flex: 0 0 1.5rem;
+  border: 1px solid var(--fg-line-strong);
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  color: var(--fg-ink);
+  background: var(--fg-surface);
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.resort-day-disclosure[open] > summary::after {
+  content: "−";
+}
+
+.disclosure-hint {
+  min-width: 0;
+  margin-left: auto;
+  color: var(--fg-ink-subtle);
+  font-size: 0.66rem;
+  font-weight: 620;
+  text-align: right;
+}
+
+.daily-detail-grid {
+  min-width: 0;
+  padding: 1rem;
+  border-top: 1px solid var(--fg-line);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 13rem), 1fr));
+  gap: 0.65rem;
+  background: var(--fg-surface-muted);
+}
+
+.daily-detail-card {
+  min-width: 0;
+  padding: 0.8rem;
+  border: 1px solid var(--fg-line);
+  border-radius: var(--fg-radius-md);
+  background: var(--fg-surface);
+}
+
+.daily-detail-card header {
+  min-width: 0;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.daily-detail-card header > div {
+  min-width: 0;
+}
+
+.daily-detail-card header p {
+  margin: 0;
+  color: var(--fg-ink-subtle);
+  font-size: 0.64rem;
+  font-weight: 700;
+}
+
+.daily-detail-card h4 {
+  margin: 0.15rem 0 0;
+  overflow-wrap: anywhere;
+  font-size: 0.83rem;
+  line-height: 1.2;
+}
+
+.daily-detail-icon.field-guide-weather-icon {
+  width: 1.65rem;
+  height: 1.65rem;
+  flex: 0 0 1.65rem;
+}
+
+.daily-detail-metrics {
+  margin: 0.7rem 0 0;
+  display: grid;
+  gap: 0.36rem;
+}
+
+.daily-detail-metrics > div {
+  min-width: 0;
+  padding-top: 0.36rem;
+  border-top: 1px solid var(--fg-line);
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.55rem;
+}
+
+.daily-detail-metrics dt {
+  color: var(--fg-ink-subtle);
+  font-size: 0.62rem;
+}
+
+.daily-detail-metrics dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+  color: var(--fg-ink);
+  font-size: 0.68rem;
+  font-weight: 760;
+  text-align: right;
+}
+
+.resort-detail-link {
+  width: max-content;
+  max-width: calc(100% - 2rem);
+  margin: 0 1rem 1rem auto;
+}
+
+.forecast-missing-state {
+  margin: 0;
+  color: var(--fg-ink-muted);
+  font-size: 0.75rem;
+}
+
+.results-empty-state {
+  grid-column: 1 / -1;
+  padding: 3rem 1.25rem;
+  border: 1px dashed var(--fg-line-strong);
+  border-radius: var(--fg-radius-lg);
+  display: grid;
+  justify-items: center;
+  gap: 0.5rem;
+  color: var(--fg-ink-muted);
+  background: var(--fg-surface-muted);
+  text-align: center;
+}
+
+.results-empty-icon {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  color: var(--fg-ink-muted);
+  background: var(--fg-line);
+  font-size: 1.25rem;
+}
+
+.results-empty-state p {
+  max-width: 32rem;
+  margin: 0;
 }
 
 .skeleton {
   position: relative;
   overflow: hidden;
-  border-radius: 10px;
-  background: #e6eef1;
+  border-radius: var(--fg-radius-md);
+  background: #e3ebe7;
 }
 
 .skeleton::after {
@@ -1979,170 +1031,147 @@ tbody tr:hover td {
   inset: 0;
   transform: translateX(-100%);
   background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.72), transparent);
-  animation: skeleton-shimmer 1.4s infinite;
+  animation: skeleton-shimmer 1.3s infinite;
 }
 
 .skeleton-heading {
-  width: 210px;
-  height: 28px;
-  margin-bottom: 18px;
+  width: min(20rem, 65%);
+  height: 2rem;
+  margin-bottom: 1rem;
 }
 
 .skeleton-card {
-  height: 160px;
+  height: 12rem;
 }
 
-.skeleton-table {
-  height: 220px;
-  margin-top: 14px;
+.skeleton-resort-card {
+  height: 28rem;
 }
 
 @keyframes skeleton-shimmer {
-  to {
-    transform: translateX(100%);
-  }
+  to { transform: translateX(100%); }
 }
 
 .page-load-error {
-  padding: 20px;
-  border: 1px solid #f2c6c3;
-  border-radius: var(--radius-md);
-  color: #8f2722;
-  background: #fff3f2;
+  padding: 1.5rem;
+  border: 1px solid #e1b8b5;
+  border-radius: var(--fg-radius-lg);
+  color: var(--fg-danger);
+  background: #fff4f3;
+}
+
+.page-load-error h2 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.page-load-error p {
+  margin: 0.5rem 0 0;
 }
 
 .page-footer {
-  width: min(1440px, 100%);
-  max-width: none;
-  margin: 0 auto;
-  padding: 8px 28px 28px;
+  width: min(90rem, 100%);
+  margin-inline: auto;
+  padding: 1rem var(--fg-page-gutter) 2rem;
+  border-top: 1px solid var(--fg-line);
   display: flex;
   justify-content: space-between;
-  gap: 18px;
-  color: var(--ink-500);
-  font-size: 11px;
+  gap: 1rem;
+  color: var(--fg-ink-subtle);
+  font-size: 0.7rem;
 }
 
 .page-footer strong {
-  color: var(--ink-800);
+  color: var(--fg-ink);
 }
 
-.page-footer a {
-  color: #0c7890;
+.units-pending [data-field-guide-number] {
+  opacity: 0.58;
 }
 
-@media (max-width: 960px) {
-  .hero-landscape {
-    right: -12%;
-    width: 66%;
-    opacity: 0.68;
+@media (max-width: 1040px) {
+  .morning-masthead {
+    grid-template-columns: minmax(0, 1.1fr) minmax(19rem, 0.9fr);
   }
 
   .resort-controls {
-    grid-template-columns: minmax(240px, 1fr) auto;
-  }
-
-  .resort-filter-bar {
-    grid-column: 2;
-    grid-row: 1;
+    grid-template-columns: minmax(16rem, 1fr) auto;
   }
 
   .resort-search-options {
-    grid-column: 1 / -1;
+    grid-column: 1;
+  }
+
+  #filter-open-btn {
+    grid-column: 2;
+    grid-row: 1 / span 2;
   }
 }
 
-@media (max-width: 700px) {
-  .site-header-inner {
-    min-height: 64px;
-    padding: 0 16px;
+@media (max-width: 760px) {
+  .field-guide-home {
+    padding-top: 0.75rem;
+    padding-bottom: 2.5rem;
   }
 
-  .site-header-note,
-  .brand-copy span {
+  .morning-masthead {
+    padding: 1rem;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0.9rem;
+  }
+
+  .morning-masthead h1 {
+    max-width: 19ch;
+    font-size: clamp(1.85rem, 9vw, 2.8rem);
+    line-height: 1;
+  }
+
+  .morning-masthead__copy > p:last-child {
+    margin-top: 0.6rem;
+    font-size: 0.82rem;
+    line-height: 1.45;
+  }
+
+  .morning-meta > div {
+    padding: 0.62rem 0.7rem;
+  }
+
+  .morning-meta dd {
+    font-size: 0.72rem;
+  }
+
+  .forecast-toolbar {
+    position: relative;
+    top: auto;
+    margin: 0.7rem 0 1rem;
+    padding: 0.8rem;
+    box-shadow: none;
+  }
+
+  .forecast-toolbar__heading {
+    margin-bottom: 0.6rem;
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.2rem;
+  }
+
+  .forecast-toolbar__heading .section-kicker {
     display: none;
   }
 
-  .brand-mark {
-    width: 36px;
-    height: 36px;
-  }
-
-  main {
-    padding: 14px;
-  }
-
-  .forecast-hero {
-    min-height: 360px;
-    padding: 30px 24px 180px;
-    align-items: flex-start;
-    border-radius: 20px;
-  }
-
-  .forecast-hero h1 {
-    font-size: clamp(42px, 13vw, 58px);
-  }
-
-  .hero-lede {
-    margin-top: 16px;
-    font-size: 14px;
-  }
-
-  .report-date {
-    margin-top: 18px;
-    padding-top: 14px;
-    display: grid;
-    gap: 5px;
-  }
-
-  .report-generated {
-    padding-left: 0;
-    border-left: 0;
-  }
-
-  .hero-landscape {
-    right: -9%;
-    width: 112%;
-    height: 56%;
-    opacity: 0.85;
-  }
-
-  .hero-sun {
-    top: 10%;
-    right: 23%;
-    width: 44px;
-    height: 44px;
-  }
-
-  .control-panel {
-    position: static;
-    top: 8px;
-    margin: 12px 0 16px;
-    padding: 15px;
-    border-radius: 14px;
-  }
-
-  .control-panel-heading {
-    align-items: flex-start;
-    margin-bottom: 12px;
-  }
-
-  .control-panel-heading .eyebrow {
-    display: none;
-  }
-
-  .control-panel-heading h2 {
-    font-size: 16px;
+  .forecast-toolbar__heading h2 {
+    font-size: 0.9rem;
   }
 
   .filter-summary {
-    max-width: 56%;
-    padding: 5px 8px;
+    max-width: 100%;
+    width: 100%;
+    text-align: left;
   }
 
   .resort-controls {
-    grid-template-columns: 1fr auto;
-    gap: 9px;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 0.5rem;
   }
 
   .resort-search {
@@ -2150,115 +1179,192 @@ tbody tr:hover td {
   }
 
   .resort-search input {
-    height: 42px;
+    font-size: 1rem;
   }
 
   .resort-search-options {
     grid-column: 1;
     min-width: 0;
     overflow-x: auto;
-    padding: 2px 0;
-  }
-
-  .resort-search-toggle span {
-    padding: 8px 10px;
-  }
-
-  .resort-filter-bar {
-    grid-column: 2;
-    grid-row: 2;
-  }
-
-  #filter-open-btn {
-    width: 42px;
-    padding: 0;
-    font-size: 0;
-  }
-
-  #filter-open-btn svg {
-    width: 19px;
-    height: 19px;
-  }
-
-  .forecast-overview {
-    margin-bottom: 16px;
-    padding: 18px 0 18px 18px;
-    border-radius: 18px;
-  }
-
-  .overview-heading {
-    padding-right: 18px;
-    align-items: flex-start;
-    flex-direction: column;
-    gap: 5px;
-  }
-
-  .overview-heading h2 {
-    font-size: 24px;
-  }
-
-  .snow-pick-grid,
-  .loading-card-grid {
-    padding-right: 18px;
-    display: flex;
-    gap: 10px;
-    overflow-x: auto;
-    scroll-snap-type: x mandatory;
     scrollbar-width: none;
   }
 
-  .snow-pick-grid::-webkit-scrollbar,
-  .loading-card-grid::-webkit-scrollbar {
+  .resort-search-options::-webkit-scrollbar {
     display: none;
   }
 
-  .snow-pick-card,
+  #filter-open-btn {
+    grid-column: 2;
+    grid-row: 2;
+    width: 42px;
+    padding: 0;
+  }
+
+  #filter-open-btn > span:not(.active-filter-count) {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+  }
+
+  .active-filter-count {
+    position: absolute;
+    margin: -2rem -2rem 0 0;
+  }
+
+  .filter-modal {
+    padding: 0;
+    place-items: end stretch;
+  }
+
+  .filter-panel {
+    width: 100%;
+    max-height: min(88vh, 48rem);
+    border-width: 1px 0 0;
+    border-radius: var(--fg-radius-lg) var(--fg-radius-lg) 0 0;
+  }
+
+  .filter-panel__body {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .filter-actions {
+    padding-bottom: max(1rem, env(safe-area-inset-bottom));
+  }
+
+  .filter-actions .fg-button {
+    flex: 1;
+  }
+
+  .section-heading {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+
+  .section-heading > p {
+    text-align: left;
+  }
+
+  .insight-board {
+    margin-bottom: 1.5rem;
+    padding: 1rem 0 1rem 1rem;
+    overflow: hidden;
+  }
+
+  .insight-board > .section-heading {
+    padding-right: 1rem;
+  }
+
+  .insight-grid,
+  .loading-card-grid {
+    padding-right: 1rem;
+    grid-template-columns: none;
+    grid-auto-flow: column;
+    grid-auto-columns: min(82vw, 20rem);
+    overflow-x: auto;
+    scroll-padding-left: 1rem;
+    scroll-snap-type: x mandatory;
+    scrollbar-width: thin;
+  }
+
+  .insight-card,
   .skeleton-card {
-    width: min(78vw, 290px);
-    min-width: min(78vw, 290px);
     scroll-snap-align: start;
   }
 
-  .overview-empty {
-    width: calc(100vw - 64px);
-    min-width: calc(100vw - 64px);
+  .insight-board--empty {
+    margin-right: 0;
+    padding-right: 1rem;
+    align-items: flex-start;
+    flex-direction: column;
   }
 
-  .forecast-section {
-    margin-bottom: 12px;
-    padding: 16px 12px;
-    border-radius: 15px;
+  .resort-card-grid {
+    grid-template-columns: minmax(0, 1fr);
   }
 
-  .forecast-section > h2,
-  .forecast-section .section-header {
-    padding: 0 3px;
+  .resort-outlook {
+    min-height: 0;
   }
 
-  .forecast-section h2 {
-    font-size: 17px;
+  .today-brief {
+    grid-template-columns: auto minmax(0, 1fr);
   }
 
-  body.mobile-simple {
-    --mobile-leading-col-max: max(0px, calc(42vw - 28px));
-    --mobile-single-leading-col-max: 42vw;
+  .today-temperature {
+    grid-column: 2;
   }
 
-  .compact-grid-mobile-wrap,
-  .snowfall-sticky-wrap,
-  .rain-sticky-wrap,
-  .temperature-sticky-wrap,
-  .weather-table-wrap,
-  .sun-single-wrap {
-    position: relative;
-    border-radius: 9px;
-    box-shadow: 12px 0 18px -18px rgba(8, 26, 41, 0.55) inset;
+  .resort-metric-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .resort-metric:last-child {
+    grid-column: 1 / -1;
+  }
+
+  .near-term-list {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .near-day {
+    grid-template-columns: minmax(5.5rem, auto) minmax(0, 1fr) auto;
+    align-items: center;
+  }
+
+  .near-day__snow {
+    grid-column: 2;
+  }
+
+  .near-day__temp {
+    grid-column: 3;
+    grid-row: 1 / span 2;
+  }
+
+  .disclosure-hint {
+    display: none;
+  }
+
+  .daily-detail-grid {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .page-footer {
-    padding: 8px 16px 24px;
     flex-direction: column;
-    gap: 4px;
+    gap: 0.25rem;
+  }
+}
+
+@media (max-width: 390px) {
+  .brand-copy span,
+  .site-header-note {
+    display: none;
+  }
+
+  .morning-meta {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  }
+
+  .resort-search > button {
+    padding-inline: 0.45rem;
+  }
+
+  .resort-search-toggle span {
+    padding-inline: 0.6rem;
+  }
+
+  .resort-card-heading,
+  .today-brief,
+  .resort-metric-grid,
+  .near-term-list,
+  .resort-outlook {
+    margin-inline: 0.85rem;
+  }
+
+  .resort-card-heading {
+    padding-inline: 0;
   }
 }
 
@@ -2272,4 +1378,3 @@ tbody tr:hover td {
     animation-iteration-count: 1 !important;
   }
 }
-  

--- a/assets/js/field_guide_homepage.js
+++ b/assets/js/field_guide_homepage.js
@@ -1,0 +1,375 @@
+(function () {
+  "use strict";
+
+  const foundation = window.CloseSnowFieldGuide || {};
+  const weather = foundation.weather || {};
+  const units = foundation.units || {};
+
+  const asFiniteNumber = (value) => {
+    if (value === null || value === undefined || typeof value === "boolean") return null;
+    if (typeof value === "string" && !value.trim()) return null;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  };
+
+  const escapeHtml = (value) => String(value === null || value === undefined ? "" : value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll("\"", "&quot;")
+    .replaceAll("'", "&#39;");
+
+  const normalizeMode = (value) => (value === "imperial" ? "imperial" : "metric");
+
+  const formatFallback = (kind, value, mode) => {
+    const numeric = asFiniteNumber(value);
+    if (numeric === null) return "Not available";
+    if (kind === "temperature") return `${Math.round(numeric)} °C`;
+    if (kind === "rain") return `${numeric.toFixed(1)} mm`;
+    return `${numeric.toFixed(1)} cm`;
+  };
+
+  const formatMeasure = (kind, value, mode) => {
+    const normalizedMode = normalizeMode(mode);
+    const formatters = {
+      temperature: units.formatTemperature,
+      snow: units.formatSnow,
+      rain: units.formatRain,
+    };
+    const formatter = formatters[kind];
+    if (typeof formatter === "function") {
+      const rendered = formatter(value, normalizedMode, { fallback: "Not available" });
+      return String(rendered);
+    }
+    return formatFallback(kind, value, normalizedMode);
+  };
+
+  const safeDaily = (report) => (Array.isArray(report?.daily) ? report.daily : [])
+    .filter((day) => day && typeof day === "object");
+
+  const dailyAt = (report, index) => safeDaily(report)[index] || {};
+
+  const displayName = (report) => String(report?.display_name || report?.query || "Unnamed resort").trim();
+
+  const locationLabel = (report) => {
+    const parts = [report?.city, report?.admin1 || report?.state_name, report?.country_code]
+      .map((value) => String(value || "").trim())
+      .filter(Boolean);
+    return Array.from(new Set(parts)).join(", ") || String(report?.region || "Mountain location").trim();
+  };
+
+  const dateParts = (rawValue, index) => {
+    const raw = String(rawValue || "").trim();
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(raw)) {
+      return { compact: index === 0 ? "Today" : `Day ${index + 1}`, full: index === 0 ? "Today" : `Forecast day ${index + 1}` };
+    }
+    const date = new Date(`${raw}T00:00:00Z`);
+    if (Number.isNaN(date.getTime())) return { compact: raw, full: raw };
+    const weekday = new Intl.DateTimeFormat(undefined, { weekday: "short", timeZone: "UTC" }).format(date);
+    const monthDay = new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric", timeZone: "UTC" }).format(date);
+    return {
+      compact: index === 0 ? `Today · ${monthDay}` : `${weekday} · ${monthDay}`,
+      full: index === 0 ? `Today, ${weekday}, ${monthDay}` : `${weekday}, ${monthDay}`,
+    };
+  };
+
+  const conditionName = (code) => (typeof weather.conditionName === "function"
+    ? weather.conditionName(code)
+    : "Conditions unavailable");
+
+  const conditionIcon = (code, className = "") => (typeof weather.iconHtml === "function"
+    ? weather.iconHtml(code, { className })
+    : `<span class="condition-icon-fallback" aria-hidden="true">—</span>`);
+
+  const sumDays = (report, key, count = 7) => {
+    const values = safeDaily(report).slice(0, count)
+      .map((day) => asFiniteNumber(day[key]))
+      .filter((value) => value !== null);
+    if (!values.length) return null;
+    return values.reduce((total, value) => total + value, 0);
+  };
+
+  const reportTotal = (report, key, dailyKey, start, end) => {
+    const direct = asFiniteNumber(report?.[key]);
+    if (direct !== null) return direct;
+    const values = safeDaily(report).slice(start, end)
+      .map((day) => asFiniteNumber(day[dailyKey]))
+      .filter((value) => value !== null);
+    return values.length ? values.reduce((total, value) => total + value, 0) : null;
+  };
+
+  const weekOneSnow = (report) => reportTotal(report, "week1_total_snowfall_cm", "snowfall_cm", 0, 7);
+  const weekTwoSnow = (report) => reportTotal(report, "week2_total_snowfall_cm", "snowfall_cm", 7, 14);
+  const weekOneRain = (report) => reportTotal(report, "week1_total_rain_mm", "rain_mm", 0, 7);
+
+  const strongestDay = (report, key, count = 7) => {
+    let winner = null;
+    safeDaily(report).slice(0, count).forEach((day, index) => {
+      const value = asFiniteNumber(day[key]);
+      if (value === null) return;
+      if (!winner || value > winner.value) winner = { day, index, value };
+    });
+    return winner;
+  };
+
+  const rankCandidates = (reports, limit = 3) => {
+    const safeReports = (Array.isArray(reports) ? reports : []).filter((report) => report && typeof report === "object");
+    const snowLed = safeReports.some((report) => (weekOneSnow(report) || 0) > 0);
+    return [...safeReports]
+      .sort((a, b) => {
+        const primaryA = snowLed ? (weekOneSnow(a) || 0) : (weekOneRain(a) || 0);
+        const primaryB = snowLed ? (weekOneSnow(b) || 0) : (weekOneRain(b) || 0);
+        if (primaryB !== primaryA) return primaryB - primaryA;
+        const secondaryDelta = (weekOneSnow(b) || 0) - (weekOneSnow(a) || 0);
+        if (secondaryDelta !== 0) return secondaryDelta;
+        return displayName(a).localeCompare(displayName(b));
+      })
+      .slice(0, Math.max(0, Number(limit) || 0))
+      .map((report) => ({ report, signal: snowLed ? "snow" : "rain" }));
+  };
+
+  const temperatureSentence = (day, mode) => {
+    const high = asFiniteNumber(day?.temperature_max_c);
+    const low = asFiniteNumber(day?.temperature_min_c);
+    if (high === null && low === null) return "Temperature guidance is not available.";
+    if (high === null) return `Today's low is near ${formatMeasure("temperature", low, mode)}.`;
+    if (low === null) return `Today's high is near ${formatMeasure("temperature", high, mode)}.`;
+    return `Today ranges from ${formatMeasure("temperature", low, mode)} to ${formatMeasure("temperature", high, mode)}.`;
+  };
+
+  const rankingExplanation = (report, signal, mode) => {
+    const snow = weekOneSnow(report);
+    const rain = weekOneRain(report);
+    const key = signal === "snow" ? "snowfall_cm" : "rain_mm";
+    const strongest = strongestDay(report, key);
+    const signalText = signal === "snow"
+      ? (snow === null ? "Seven-day snow guidance is not available." : `${formatMeasure("snow", snow, mode)} of snow is forecast over seven days.`)
+      : (rain === null ? "Seven-day rain guidance is not available." : `${formatMeasure("rain", rain, mode)} of rain is forecast over seven days.`);
+    let bestDayText = "No accumulating snow or rain is currently forecast.";
+    if (strongest && strongest.value > 0) {
+      const label = dateParts(strongest.day.date, strongest.index).compact;
+      const measure = formatMeasure(signal === "snow" ? "snow" : "rain", strongest.value, mode);
+      bestDayText = `${label} has the strongest ${signal} signal at ${measure}.`;
+    }
+    return `${signalText} ${bestDayText} ${temperatureSentence(dailyAt(report, 0), mode)}`;
+  };
+
+  const resortHref = (report) => {
+    const id = String(report?.resort_id || "").trim();
+    return id ? `resort/${encodeURIComponent(id)}` : "";
+  };
+
+  const resortLink = (report, className = "") => {
+    const name = escapeHtml(displayName(report));
+    const href = resortHref(report);
+    return href ? `<a class="${escapeHtml(className)}" href="${escapeHtml(href)}">${name}</a>` : `<span class="${escapeHtml(className)}">${name}</span>`;
+  };
+
+  const renderInsightCard = (entry, index, mode) => {
+    const { report, signal } = entry;
+    const today = dailyAt(report, 0);
+    return `
+      <article class="insight-card">
+        <div class="insight-card__topline">
+          <span class="insight-rank">${index + 1}</span>
+          ${conditionIcon(today.weather_code, "insight-weather-icon")}
+        </div>
+        <p class="insight-kicker">${signal === "snow" ? "Snow signal" : "Storm signal"}</p>
+        <h3>${resortLink(report, "insight-resort-link")}</h3>
+        <p class="insight-location">${escapeHtml(locationLabel(report))}</p>
+        <p class="insight-explanation">${escapeHtml(rankingExplanation(report, signal, mode))}</p>
+      </article>`;
+  };
+
+  const renderInsightBoard = (reports, mode) => {
+    const entries = rankCandidates(reports, 3);
+    if (!entries.length) {
+      return `
+        <section class="insight-board insight-board--empty" aria-labelledby="insight-title">
+          <div><p class="section-kicker">Morning picks</p><h2 id="insight-title">Nothing to rank yet</h2></div>
+          <p>Change the search or filters to bring mountain guidance back into view.</p>
+        </section>`;
+    }
+    const signal = entries[0].signal;
+    return `
+      <section class="insight-board" aria-labelledby="insight-title">
+        <div class="section-heading">
+          <div>
+            <p class="section-kicker">Morning picks</p>
+            <h2 id="insight-title">${signal === "snow" ? "Where the snow signal is strongest" : "Where weather is most active"}</h2>
+          </div>
+          <p>${signal === "snow" ? "Ranked by seven-day snowfall" : "No accumulating snow in view; ranked by seven-day rain"}</p>
+        </div>
+        <div class="insight-grid">${entries.map((entry, index) => renderInsightCard(entry, index, mode)).join("")}</div>
+      </section>`;
+  };
+
+  const favoriteButton = (report, active) => {
+    const resortId = String(report?.resort_id || "").trim();
+    if (!resortId) return "";
+    const label = active ? "Remove resort from favorites" : "Add resort to favorites";
+    return `
+      <button type="button" class="favorite-btn" data-resort-id="${escapeHtml(resortId)}" data-favorite-active="${active ? "1" : "0"}" aria-pressed="${active ? "true" : "false"}" aria-label="${label}">
+        <svg aria-hidden="true" viewBox="0 0 24 24"><path d="M12 20.4S3.4 15.7 3.4 9.1A4.7 4.7 0 0 1 12 6.5a4.7 4.7 0 0 1 8.6 2.6c0 6.6-8.6 11.3-8.6 11.3Z"></path></svg>
+      </button>`;
+  };
+
+  const passesHtml = (report) => {
+    const passes = Array.isArray(report?.pass_types) ? report.pass_types : [];
+    return passes.slice(0, 3)
+      .map((pass) => `<span class="resort-tag">${escapeHtml(String(pass).toUpperCase())}</span>`)
+      .join("");
+  };
+
+  const metricBlock = (label, value, kind, mode, options = {}) => {
+    const numeric = asFiniteNumber(value);
+    const noSnow = kind === "snow" && numeric === 0 && options.zeroCopy;
+    const rendered = noSnow ? options.zeroCopy : formatMeasure(kind, value, mode);
+    return `<div class="resort-metric"><dt>${escapeHtml(label)}</dt><dd data-field-guide-number>${escapeHtml(rendered)}</dd></div>`;
+  };
+
+  const renderNearTermDay = (day, index, mode) => {
+    const label = dateParts(day?.date, index).compact;
+    const condition = conditionName(day?.weather_code);
+    return `
+      <li class="near-day">
+        <span class="near-day__date">${escapeHtml(label)}</span>
+        <span class="near-day__condition">${conditionIcon(day?.weather_code)}<span>${escapeHtml(condition)}</span></span>
+        <span class="near-day__temp" data-field-guide-number>${escapeHtml(formatMeasure("temperature", day?.temperature_max_c, mode))}</span>
+        <span class="near-day__snow" data-field-guide-number>${escapeHtml(formatMeasure("snow", day?.snowfall_cm, mode))} snow</span>
+      </li>`;
+  };
+
+  const localTime = (day, kind) => {
+    const localKey = `${kind}_local_hhmm`;
+    const isoKey = `${kind}_iso`;
+    const local = String(day?.[localKey] || "").trim();
+    if (/^\d{2}:\d{2}$/.test(local)) return local;
+    const iso = String(day?.[isoKey] || "").trim();
+    const match = /T(\d{2}:\d{2})/.exec(iso);
+    return match ? match[1] : "Not available";
+  };
+
+  const renderDailyDetail = (day, index, mode) => {
+    const date = dateParts(day?.date, index).full;
+    const condition = conditionName(day?.weather_code);
+    return `
+      <article class="daily-detail-card">
+        <header>
+          <div><p>${escapeHtml(date)}</p><h4>${escapeHtml(condition)}</h4></div>
+          ${conditionIcon(day?.weather_code, "daily-detail-icon")}
+        </header>
+        <dl class="daily-detail-metrics">
+          <div><dt>High / low</dt><dd data-field-guide-number>${escapeHtml(formatMeasure("temperature", day?.temperature_max_c, mode))} / ${escapeHtml(formatMeasure("temperature", day?.temperature_min_c, mode))}</dd></div>
+          <div><dt>Snow</dt><dd data-field-guide-number>${escapeHtml(formatMeasure("snow", day?.snowfall_cm, mode))}</dd></div>
+          <div><dt>Rain</dt><dd data-field-guide-number>${escapeHtml(formatMeasure("rain", day?.rain_mm, mode))}</dd></div>
+          <div><dt>Daylight</dt><dd data-field-guide-number>${escapeHtml(localTime(day, "sunrise"))}–${escapeHtml(localTime(day, "sunset"))}</dd></div>
+        </dl>
+      </article>`;
+  };
+
+  const outlookText = (report, mode) => {
+    const days = safeDaily(report).slice(0, 3);
+    if (!days.length) return "Forecast details are not available for this resort yet.";
+    const today = days[0];
+    const condition = conditionName(today.weather_code);
+    const snow = sumDays({ daily: days }, "snowfall_cm", 3);
+    const rain = sumDays({ daily: days }, "rain_mm", 3);
+    const precipitation = [];
+    if (snow !== null && snow > 0) precipitation.push(`${formatMeasure("snow", snow, mode)} snow`);
+    if (rain !== null && rain > 0) precipitation.push(`${formatMeasure("rain", rain, mode)} rain`);
+    const precipText = precipitation.length
+      ? `${precipitation.join(" and ")} over the next three days.`
+      : "Little to no snow or rain is expected over the next three days.";
+    return `${condition} today. ${precipText} ${temperatureSentence(today, mode)}`;
+  };
+
+  const renderResortCard = (report, options = {}) => {
+    const mode = normalizeMode(options.mode);
+    const active = Boolean(options.favorite);
+    const today = dailyAt(report, 0);
+    const days = safeDaily(report);
+    const resortId = String(report?.resort_id || "").trim();
+    const detailsId = `forecast-${resortId || options.index || "resort"}`.replace(/[^a-zA-Z0-9_-]/g, "-");
+    const weekOne = weekOneSnow(report);
+    const weekTwo = weekTwoSnow(report);
+    const rain = weekOneRain(report);
+    const dailyHtml = days.length
+      ? days.map((day, index) => renderDailyDetail(day, index, mode)).join("")
+      : `<p class="forecast-missing-state">Daily guidance is not available yet. Check back after the next model update.</p>`;
+    return `
+      <article class="resort-forecast-card" data-resort-card="${escapeHtml(resortId)}">
+        <header class="resort-card-heading">
+          <div class="resort-card-title">
+            <p>${escapeHtml(locationLabel(report))}</p>
+            <h3>${resortLink(report, "resort-card-link")}</h3>
+            <div class="resort-tags">${passesHtml(report)}</div>
+          </div>
+          ${favoriteButton(report, active)}
+        </header>
+        <p class="resort-outlook">${escapeHtml(outlookText(report, mode))}</p>
+        <div class="today-brief">
+          ${conditionIcon(today.weather_code, "today-brief-icon")}
+          <div><span>Today</span><strong>${escapeHtml(conditionName(today.weather_code))}</strong></div>
+          <span class="today-temperature" data-field-guide-number>${escapeHtml(formatMeasure("temperature", today.temperature_max_c, mode))} / ${escapeHtml(formatMeasure("temperature", today.temperature_min_c, mode))}</span>
+        </div>
+        <dl class="resort-metric-grid">
+          ${metricBlock("Week 1 snow", weekOne, "snow", mode, { zeroCopy: "No snow forecast" })}
+          ${metricBlock("Week 2 snow", weekTwo, "snow", mode, { zeroCopy: "No snow forecast" })}
+          ${metricBlock("7-day rain", rain, "rain", mode)}
+        </dl>
+        <ol class="near-term-list" aria-label="Three-day preview">
+          ${days.slice(0, 3).map((day, index) => renderNearTermDay(day, index, mode)).join("") || `<li class="forecast-missing-state">Near-term guidance is not available.</li>`}
+        </ol>
+        <details class="resort-day-disclosure" data-field-guide-disclosure data-resort-disclosure="${escapeHtml(resortId)}">
+          <summary aria-controls="${escapeHtml(detailsId)}">
+            <span>Full ${days.length || 14}-day forecast</span>
+            <span class="disclosure-hint">Weather, temperatures, snow, rain &amp; daylight</span>
+          </summary>
+          <div class="daily-detail-grid" id="${escapeHtml(detailsId)}">${dailyHtml}</div>
+          ${resortHref(report) ? `<a class="resort-detail-link fg-button" href="${escapeHtml(resortHref(report))}">Open resort forecast</a>` : ""}
+        </details>
+      </article>`;
+  };
+
+  const renderResults = (reports, options = {}) => {
+    const mode = normalizeMode(options.mode);
+    const favorites = options.favorites instanceof Set ? options.favorites : new Set(options.favorites || []);
+    const cards = reports.map((report, index) => renderResortCard(report, {
+      mode,
+      index,
+      favorite: favorites.has(String(report?.resort_id || "").trim()),
+    })).join("");
+    const empty = `
+      <div class="results-empty-state">
+        <span class="results-empty-icon" aria-hidden="true">×</span>
+        <h2>No resorts match this view</h2>
+        <p>${escapeHtml(options.emptyMessage || "Try clearing the search or changing a filter.")}</p>
+      </div>`;
+    return `
+      <section class="forecast-results" aria-labelledby="results-title">
+        <div class="section-heading results-heading">
+          <div><p class="section-kicker">Forecast directory</p><h2 id="results-title">Mountain-by-mountain outlook</h2></div>
+          <p>${reports.length} resort${reports.length === 1 ? "" : "s"} in this view · Select a resort to reveal every forecast day.</p>
+        </div>
+        <div class="resort-card-grid">${cards || empty}</div>
+      </section>`;
+  };
+
+  const render = (reports, options = {}) => {
+    const safeReports = (Array.isArray(reports) ? reports : []).filter((report) => report && typeof report === "object");
+    return `${renderInsightBoard(safeReports, options.mode)}${renderResults(safeReports, options)}`;
+  };
+
+  window.CloseSnowFieldGuideHomepage = Object.freeze({
+    escapeHtml,
+    rankCandidates,
+    rankingExplanation,
+    render,
+    renderDailyDetail,
+    renderResortCard,
+    weekOneRain,
+    weekOneSnow,
+    weekTwoSnow,
+  });
+}());

--- a/assets/js/weather_page.js
+++ b/assets/js/weather_page.js
@@ -1,1917 +1,637 @@
-const pageBootstrapRaw = window.CLOSESNOW_PAGE_BOOTSTRAP;
-const pageBootstrap =
-  pageBootstrapRaw && typeof pageBootstrapRaw === "object" && !Array.isArray(pageBootstrapRaw) ? pageBootstrapRaw : {};
-const filterMetaRaw = window.CLOSESNOW_FILTER_META;
-const filterMeta =
-  filterMetaRaw && typeof filterMetaRaw === "object" && !Array.isArray(filterMetaRaw) ? filterMetaRaw : {};
-const filterMetaAvailable =
-  filterMeta.available_filters && typeof filterMeta.available_filters === "object"
+(function () {
+  "use strict";
+
+  const pageBootstrap = window.CLOSESNOW_PAGE_BOOTSTRAP && typeof window.CLOSESNOW_PAGE_BOOTSTRAP === "object"
+    ? window.CLOSESNOW_PAGE_BOOTSTRAP
+    : {};
+  const filterMeta = window.CLOSESNOW_FILTER_META && typeof window.CLOSESNOW_FILTER_META === "object"
+    ? window.CLOSESNOW_FILTER_META
+    : {};
+  const filterMetaAvailable = filterMeta.available_filters && typeof filterMeta.available_filters === "object"
     ? filterMeta.available_filters
     : {};
-const filterMetaApplied =
-  filterMeta.applied_filters && typeof filterMeta.applied_filters === "object"
+  const filterMetaApplied = filterMeta.applied_filters && typeof filterMeta.applied_filters === "object"
     ? filterMeta.applied_filters
     : {};
-const initialPayloadRaw = window.CLOSESNOW_INITIAL_PAYLOAD;
-const initialPayload =
-  initialPayloadRaw && typeof initialPayloadRaw === "object" && !Array.isArray(initialPayloadRaw)
-    ? initialPayloadRaw
+  const initialPayload = window.CLOSESNOW_INITIAL_PAYLOAD && typeof window.CLOSESNOW_INITIAL_PAYLOAD === "object"
+    ? window.CLOSESNOW_INITIAL_PAYLOAD
     : null;
 
-const pageContentRoot = document.getElementById("page-content-root");
-const reportDateEl = document.getElementById("report-date");
-const resortSearchInput = document.getElementById("resort-search-input");
-const resortSearchClear = document.getElementById("resort-search-clear");
-const filterOpenBtn = document.getElementById("filter-open-btn");
-const filterModal = document.getElementById("filter-modal");
-const filterResetBtn = document.getElementById("filter-reset-btn");
-const filterCloseBtn = document.getElementById("filter-close-btn");
-const filterSummary = document.getElementById("filter-summary");
-const filterRegionOptions = document.getElementById("filter-region-options");
-const filterSortSelect = document.getElementById("filter-sort-select");
-const filterIncludeAllInput = document.getElementById("filter-include-all");
-const filterSearchAllInput = document.getElementById("filter-search-all");
-const favoritesOnlyToggle = document.getElementById("favorites-only-toggle");
-const filterFavoritesOnlyInput = document.getElementById("filter-favorites-only");
-const filterPassTypeInputs = Array.from(document.querySelectorAll("input[name='filter-pass-type']"));
+  const pageContentRoot = document.getElementById("page-content-root");
+  const reportDateEl = document.getElementById("report-date");
+  const reportModelEl = document.getElementById("report-model");
+  const visibleResortCountEl = document.getElementById("visible-resort-count");
+  const unitStatusEls = Array.from(document.querySelectorAll("[data-field-guide-unit-status]"));
+  const resortSearchInput = document.getElementById("resort-search-input");
+  const resortSearchClear = document.getElementById("resort-search-clear");
+  const filterOpenBtn = document.getElementById("filter-open-btn");
+  const filterModal = document.getElementById("filter-modal");
+  const filterResetBtn = document.getElementById("filter-reset-btn");
+  const filterCloseBtn = document.getElementById("filter-close-btn");
+  const filterDoneBtn = document.getElementById("filter-done-btn");
+  const filterSummary = document.getElementById("filter-summary");
+  const activeFilterCount = document.getElementById("active-filter-count");
+  const filterRegionOptions = document.getElementById("filter-region-options");
+  const filterSortSelect = document.getElementById("filter-sort-select");
+  const filterIncludeAllInput = document.getElementById("filter-include-all");
+  const filterSearchAllInput = document.getElementById("filter-search-all");
+  const favoritesOnlyToggle = document.getElementById("favorites-only-toggle");
+  const filterFavoritesOnlyInput = document.getElementById("filter-favorites-only");
+  const filterPassTypeInputs = Array.from(document.querySelectorAll("input[name='filter-pass-type']"));
 
-const UNIT_STORAGE_KEY_PREFIX = "closesnow_unit_mode_";
-const FILTER_STORAGE_KEY = "closesnow_filter_state_v1";
-const FAVORITES_STORAGE_KEY = "closesnow_favorite_resorts_v1";
-const VALID_UNIT_KINDS = new Set(["snow", "rain", "temp"]);
-const DEFAULT_AVAILABLE_FILTERS = { pass_type: {}, region: {}, subregion: {} };
-const SUBREGION_OPTIONS = [
-  { value: "rockies", label: "Rockies" },
-  { value: "west-coast", label: "West Coast" },
-  { value: "midwest", label: "Midwest" },
-  { value: "mid-atlantic", label: "Mid-Atlantic" },
-  { value: "northeast", label: "Northeast" },
-  { value: "europe", label: "Europe" },
-  { value: "asia", label: "Asia" },
-  { value: "australia-new-zealand", label: "Australia / New Zealand" },
-  { value: "south-america", label: "South America" },
-];
-const MAX_DISPLAY_DAYS = 14;
-const MIN_DESKTOP_SNOW_3DAY_PX = 554;
-const LEADING_FAVORITE_COL_PX = 28;
-const compactDailySummary = window.CloseSnowCompactDailySummary || {};
-const filterStateHelpers = window.CloseSnowFilterState || {};
-const stickySingleTableLayout = window.CloseSnowStickySingleTableLayout || {};
-const fieldGuide = window.CloseSnowFieldGuide || {};
-const fieldGuideUnits = fieldGuide.units || {};
-const fieldGuideWeather = fieldGuide.weather || {};
-const COMPACT_SUMMARY_UNIT_KIND = "compact_summary";
-const SUN_TIME_TOGGLE_KIND = "sun_time";
-// Reserve section keys so later workers can move one section at a time to shared single-table layout.
-const STICKY_SINGLE_TABLE_SECTION_KEYS = Object.freeze({
-  dailySummary: "daily-summary",
-  snowfall: "snowfall",
-  rainfall: "rainfall",
-  temperature: "temperature",
-  weather: "weather",
-  sun: "sunrise-sunset",
-});
+  const FILTER_STORAGE_KEY = "closesnow_filter_state_v1";
+  const FAVORITES_STORAGE_KEY = "closesnow_favorite_resorts_v1";
+  const DEFAULT_AVAILABLE_FILTERS = { pass_type: {}, region: {}, subregion: {} };
+  const SUBREGION_OPTIONS = [
+    { value: "rockies", label: "Rockies" },
+    { value: "west-coast", label: "West Coast" },
+    { value: "midwest", label: "Midwest" },
+    { value: "mid-atlantic", label: "Mid-Atlantic" },
+    { value: "northeast", label: "Northeast" },
+    { value: "europe", label: "Europe" },
+    { value: "asia", label: "Asia" },
+    { value: "australia-new-zealand", label: "Australia / New Zealand" },
+    { value: "south-america", label: "South America" },
+  ];
 
-const appState = {
-  payload: null,
-  reports: [],
-  availableFilters: DEFAULT_AVAILABLE_FILTERS,
-  favoriteResortIds: new Set(),
-  filterState: {
-    passTypes: new Set(),
-    subregions: new Set(),
-    sortBy: "week_snow",
-    includeDefault: true,
-    searchAll: true,
-    search: "",
-    favoritesOnly: false,
-  },
-  unitModes: {
-    snow: "metric",
-    rain: "metric",
-    temp: "metric",
-  },
-  compactSummaryUnitMode: "metric",
-  sunTimeToggleMode: "metric",
-  layoutMode: "desktop",
-};
+  const formatters = window.CloseSnowWeatherPageFormatters || {};
+  const normalizeSearch = formatters.normalizeSearch || ((value) => String(value || "").trim().toLowerCase());
+  const isTruthyParam = formatters.isTruthyParam || ((value) => ["1", "true", "yes", "on"].includes(normalizeSearch(value)));
+  const filterHelpers = window.CloseSnowFilterState || {};
+  const parsePassTypeValues = filterHelpers.parsePassTypeValues || ((values) => values);
+  const parseSubregionValues = filterHelpers.parseSubregionValues || ((values) => values);
+  const normalizeSortBy = filterHelpers.normalizeSortBy || ((value) => value || "state");
+  const sortLabel = filterHelpers.sortLabel || ((value) => value);
+  const fieldGuide = window.CloseSnowFieldGuide || {};
+  const fieldGuideUnits = fieldGuide.units || {};
+  const homepage = window.CloseSnowFieldGuideHomepage || {};
 
-const weatherPageFormatters = window.CloseSnowWeatherPageFormatters || {};
-const {
-  asFiniteNumber: _asFiniteNumber,
-  dayLabelHtml: _dayLabelHtml,
-  escapeHtml: _escapeHtml,
-  formatDayLabel: _formatDayLabel,
-  formatMetric: _formatMetric,
-  formatTemp: _formatTemp,
-  isTruthyParam: _isTruthyParam,
-  metricCellHtml: _metricCellHtml,
-  normalizeSearch: _normalizeSearch,
-  rainColor: _rainColor,
-  snowColor: _snowColor,
-  tempColor: _tempColor,
-} = weatherPageFormatters;
-
-const _errorMessage = (error) => (error instanceof Error ? error.message : String(error));
-
-const renderPageLoadError = (error) => {
-  if (!pageContentRoot) return;
-  const el = document.createElement("div");
-  el.className = "page-load-error";
-  el.textContent = _errorMessage(error);
-  pageContentRoot.replaceChildren(el);
-};
-
-const measureTextWidth = (text, font) => {
-  const cache = measureTextWidth.cache || (measureTextWidth.cache = new Map());
-  const cacheKey = `${font}\u0000${text || ""}`;
-  if (cache.has(cacheKey)) return cache.get(cacheKey);
-  const canvas = measureTextWidth.canvas || (measureTextWidth.canvas = document.createElement("canvas"));
-  const context = canvas.getContext("2d");
-  context.font = font;
-  const width = context.measureText(text || "").width;
-  cache.set(cacheKey, width);
-  if (cache.size > 4000) cache.clear();
-  return width;
-};
-
-const _resolveBootstrapUrl = (rawUrl) => {
-  const text = String(rawUrl || "").trim();
-  if (!text) throw new Error("Missing dataUrl bootstrap.");
-  if (/^[a-z][a-z0-9+.-]*:/i.test(text) || text.startsWith("//")) {
-    return new URL(text, window.location.href).toString();
-  }
-  const pathname = window.location.pathname || "/";
-  const normalizedPath = pathname.endsWith("/")
-    ? pathname
-    : (pathname.includes(".") ? pathname.replace(/[^/]+$/, "") : `${pathname}/`);
-  return new URL(text, `${window.location.origin}${normalizedPath}`).toString();
-};
-
-const _resolvedDataUrl = () => _resolveBootstrapUrl(pageBootstrap.dataUrl);
-
-const _isDynamicApiDataUrl = () => {
-  try {
-    const resolved = new URL(_resolvedDataUrl());
-    return resolved.pathname.endsWith("/api/data");
-  } catch (error) {
-    return false;
-  }
-};
-
-const _weatherIcon = (rawCode, className = "") => (fieldGuideWeather.iconHtml
-  ? fieldGuideWeather.iconHtml(rawCode, { className })
-  : '<span class="field-guide-weather-icon" role="img" aria-label="Conditions unavailable">?</span>');
-
-const _filterAttrs = (report) => {
-  const passTypes = Array.isArray(report.pass_types) ? report.pass_types.join(",").toLowerCase() : "";
-  const region = String(report.region || "").trim().toLowerCase();
-  const country = String(report.country_code || report.country || "").trim().toUpperCase();
-  const state = String(report.admin1 || "").trim().toUpperCase();
-  const defaultResort = report.default_resort || report.ljcc_favorite ? "1" : "";
-  return ` data-pass-types='${_escapeHtml(passTypes)}' data-region='${_escapeHtml(region)}' data-country='${_escapeHtml(country)}' data-state='${_escapeHtml(state)}' data-default-resort='${_escapeHtml(defaultResort)}'`;
-};
-
-const _isFavoriteResortId = (resortId) => appState.favoriteResortIds.has(String(resortId || "").trim());
-
-const _favoriteButtonHtml = (report) => {
-  const resortId = String(report.resort_id || "").trim();
-  if (!resortId) return "";
-  const active = _isFavoriteResortId(resortId);
-  const label = active ? "Remove resort from favorites" : "Add resort to favorites";
-  return `<button type='button' class='favorite-btn' data-resort-id='${_escapeHtml(resortId)}' data-favorite-active='${active ? "1" : "0"}' aria-pressed='${active ? "true" : "false"}' aria-label='${label}'><svg class='favorite-btn-icon favorite-btn-outline' aria-hidden='true' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round'><path d='M12 21s-6.9-4.35-9.2-8.45C.9 9.18 2.03 5.5 5.58 4.6c2.12-.54 4.4.24 5.82 1.98 1.42-1.74 3.7-2.52 5.82-1.98 3.55.9 4.68 4.58 2.78 7.95C18.9 16.65 12 21 12 21Z'/></svg><svg class='favorite-btn-icon favorite-btn-filled' aria-hidden='true' viewBox='0 0 24 24' fill='currentColor'><path d='M12 21s-6.9-4.35-9.2-8.45C.9 9.18 2.03 5.5 5.58 4.6c2.12-.54 4.4.24 5.82 1.98 1.42-1.74 3.7-2.52 5.82-1.98 3.55.9 4.68 4.58 2.78 7.95C18.9 16.65 12 21 12 21Z'/></svg></button>`;
-};
-
-const _favoriteAllButtonHtml = (reports) => {
-  const visibleIds = Array.from(new Set((reports || []).map((report) => String(report?.resort_id || "").trim()).filter(Boolean)));
-  if (!visibleIds.length) return "";
-  const allFavorited = visibleIds.every((resortId) => _isFavoriteResortId(resortId));
-  const label = allFavorited ? "Remove all visible resorts from favorites" : "Favorite all visible resorts";
-  return `<button type='button' class='favorite-btn favorite-all-btn' data-favorite-all='1' data-favorite-active='${allFavorited ? "1" : "0"}' aria-pressed='${allFavorited ? "true" : "false"}' aria-label='${label}'><svg class='favorite-btn-icon favorite-btn-outline' aria-hidden='true' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round'><path d='M12 21s-6.9-4.35-9.2-8.45C.9 9.18 2.03 5.5 5.58 4.6c2.12-.54 4.4.24 5.82 1.98 1.42-1.74 3.7-2.52 5.82-1.98 3.55.9 4.68 4.58 2.78 7.95C18.9 16.65 12 21 12 21Z'/></svg><svg class='favorite-btn-icon favorite-btn-filled' aria-hidden='true' viewBox='0 0 24 24' fill='currentColor'><path d='M12 21s-6.9-4.35-9.2-8.45C.9 9.18 2.03 5.5 5.58 4.6c2.12-.54 4.4.24 5.82 1.98 1.42-1.74 3.7-2.52 5.82-1.98 3.55.9 4.68 4.58 2.78 7.95C18.9 16.65 12 21 12 21Z'/></svg></button>`;
-};
-
-const _displayName = (report) => String(report?.display_name || report?.query || "").trim();
-
-const _resortLinkHtml = (report) => {
-  const text = _escapeHtml(_displayName(report));
-  const resortId = String(report.resort_id || "").trim();
-  return resortId
-    ? `<a class='resort-link' href='resort/${encodeURIComponent(resortId)}'>${text}</a>`
-    : text;
-};
-
-const _resortCellHtml = (report) => {
-  const linkHtml = _resortLinkHtml(report);
-  return `<td class='favorite-col'>${_favoriteButtonHtml(report)}</td><td class='query-col'><div class='resort-cell'><div class='resort-link-wrap'>${linkHtml}</div></div></td>`;
-};
-
-const _mobilePrecipResortHeadHtml = (favoriteAllButton) => `
-  <th rowspan='2' class='query-col mobile-precip-resort-head'>
-    <div class='mobile-precip-resort-content'>${favoriteAllButton}<span class='mobile-precip-resort-label'>Resort</span></div>
-  </th>`;
-
-const _mobilePrecipResortCellHtml = (report) => `
-  <td class='query-col mobile-precip-resort-cell'>
-    <div class='mobile-precip-resort-content'>${_favoriteButtonHtml(report)}<div class='resort-cell'><div class='resort-link-wrap'>${_resortLinkHtml(report)}</div></div></div>
-  </td>`;
-
-const _displayDays = () => {
-  const raw = appState.payload && Number(appState.payload.forecast_days);
-  if (Number.isFinite(raw) && raw > 0) return Math.max(0, Math.min(MAX_DISPLAY_DAYS, raw - 1));
-  return MAX_DISPLAY_DAYS;
-};
-
-const _dailyAt = (report, index) => {
-  const daily = Array.isArray(report.daily) ? report.daily : [];
-  return daily[index] && typeof daily[index] === "object" ? daily[index] : {};
-};
-
-const _dayLabelFor = (report, index) => {
-  if (index === 0) return "Today";
-  const label = _formatDayLabel(_dailyAt(report, index).date);
-  if (label) return label;
-  return `day ${index + 1}`;
-};
-
-const _fallbackDayLabels = (count) => Array.from({ length: count }, (_, idx) => (idx === 0 ? "Today" : `day ${idx + 1}`));
-
-const _emptyStateRow = (colspan, message) => `<tr><td class="empty-state-cell" colspan="${colspan}">${_escapeHtml(message)}</td></tr>`;
-
-const _overviewLocation = (report) => {
-  const parts = [report?.city, report?.admin1 || report?.country_code]
-    .map((value) => String(value || "").trim())
-    .filter(Boolean);
-  return parts.join(", ") || String(report?.region || "Mountain forecast").trim();
-};
-
-const _overviewValue = (kind, value, fallback = "--") => {
-  const numeric = _asFiniteNumber(value);
-  if (numeric === null) return `<span class="overview-value">${fallback}</span>`;
-  const display = kind === "temp" ? String(Math.round(numeric)) : numeric.toFixed(1);
-  return `<span class="overview-value" data-compact-unit-kind="${kind}" data-compact-metric-value="${numeric.toFixed(6)}">${display}</span>`;
-};
-
-const _renderForecastOverview = (reports) => {
-  const snowSorted = [...reports].sort((a, b) => (_weeklySnowfall(b) || 0) - (_weeklySnowfall(a) || 0));
-  const hasSnow = snowSorted.some((report) => (_weeklySnowfall(report) || 0) > 0);
-  const candidates = (hasSnow
-    ? snowSorted
-    : [...reports].sort((a, b) => (Number(b?.week1_total_rain_mm) || 0) - (Number(a?.week1_total_rain_mm) || 0)))
-    .slice(0, 3);
-  const outlookKind = hasSnow ? "snow" : "rain";
-  const outlookLabel = hasSnow ? "7-day snow" : "7-day rain";
-  const outlookUnit = hasSnow ? "cm" : "mm";
-  const cards = candidates.map((report, index) => {
-    const today = _dailyAt(report, 0);
-    const weatherCode = today.weather_code;
-    const weatherTitle = fieldGuideWeather.conditionName
-      ? fieldGuideWeather.conditionName(weatherCode)
-      : "Conditions unavailable";
-    return `
-      <article class="snow-pick-card">
-        <div class="snow-pick-card-topline">
-          <span class="snow-pick-rank">#${index + 1} ${hasSnow ? "snow" : "storm"} pick</span>
-          <span class="snow-pick-weather" title="${_escapeHtml(weatherTitle)}">${_weatherIcon(weatherCode)}</span>
-        </div>
-        <h3>${_resortLinkHtml(report)}</h3>
-        <p>${_escapeHtml(_overviewLocation(report))}</p>
-        <div class="snow-pick-metrics">
-          <span><small>${outlookLabel}</small><strong>${_overviewValue(outlookKind, hasSnow ? _weeklySnowfall(report) : report?.week1_total_rain_mm)}<em data-compact-unit-label="${outlookKind}">${outlookUnit}</em></strong></span>
-          <span><small>Today high</small><strong>${_overviewValue("temp", today.temperature_max_c)}<em data-compact-unit-label="temp">°C</em></strong></span>
-        </div>
-      </article>`;
-  }).join("");
-  const empty = `
-    <div class="overview-empty">
-      <strong>No mountains in view</strong>
-      <span>Adjust your search or filters to bring forecast candidates back.</span>
-    </div>`;
-  return `
-    <section class="forecast-overview" aria-labelledby="forecast-overview-title">
-      <div class="overview-heading">
-        <div><p class="eyebrow">At a glance</p><h2 id="forecast-overview-title">${hasSnow ? "Best bets this week" : "Storm watch this week"}</h2></div>
-        <span>${hasSnow ? "Ranked by forecast snowfall" : "No accumulating snow · ranked by forecast rain"} across ${reports.length} visible resort${reports.length === 1 ? "" : "s"}</span>
-      </div>
-      <div class="snow-pick-grid">${cards || empty}</div>
-    </section>`;
-};
-
-const _renderCompactGridSection = (reports, emptyMessage = "No resorts match the current filters.") => {
-  const displayDays = _displayDays();
-  const labels = reports.length
-    ? Array.from({ length: displayDays }, (_, idx) => compactDailySummary.dayLabelFor(_dailyAt(reports[0], idx), idx))
-    : _fallbackDayLabels(displayDays);
-  const rows = reports.length ? reports.map((report) => {
-    const attrs = _filterAttrs(report);
-    const cells = Array.from({ length: displayDays }, (_, idx) => {
-      const day = _dailyAt(report, idx);
-      const style = compactDailySummary.dayStyle(day);
-      const styleAttr = style ? ` style='${style}'` : "";
-      return `<td class='compact-day-cell'${styleAttr}>${compactDailySummary.dayCellHtml(day, { unitMode: appState.compactSummaryUnitMode })}</td>`;
-    }).join("");
-    return `<tr${attrs}>${_resortCellHtml(report)}${cells}</tr>`;
-  }).join("") : _emptyStateRow(2 + Math.max(1, displayDays), emptyMessage);
-  return `
-    <section class="forecast-section forecast-section-daily">
-      <div class="section-header">
-        <h2>Daily Summary</h2>
-        <div class="unit-toggle" role="group" aria-label="Daily Summary unit system" data-compact-summary-toggle="1" data-mode="${appState.compactSummaryUnitMode}">
-          <button type="button" class="unit-btn" data-unit-mode="metric">Metric</button>
-          <button type="button" class="unit-btn" data-unit-mode="imperial">Imperial</button>
-        </div>
-      </div>
-      <div
-        class="compact-grid-mobile-wrap"
-        id="compact-grid-mobile-wrap"
-        data-sticky-single-table-section="${STICKY_SINGLE_TABLE_SECTION_KEYS.dailySummary}"
-        data-sticky-leading-cols="2"
-        data-sticky-header-rows="1"
-        data-sticky-max-visible-rows="5"
-      >
-        <table class="compact-grid-mobile-table" id="compact-grid-mobile-table">
-          <colgroup><col class='col-favorite'><col class='col-query'>${Array.from({ length: displayDays }, () => "<col class='col-compact-day'>").join("")}</colgroup>
-          <thead><tr><th class='favorite-col favorite-head'>${_favoriteAllButtonHtml(reports)}</th><th class='query-col'>Resort</th>${labels.map((label) => `<th>${_dayLabelHtml(label)}</th>`).join("")}</tr></thead>
-          <tbody>${rows}</tbody>
-        </table>
-      </div>
-    </section>`;
-};
-
-const _renderPrecipSection = (title, kind, metricUnit, imperialUnit, reports, options, emptyMessage = "No resorts match the current filters.") => {
-  const displayDays = _displayDays();
-  const dayLabels = reports.length
-    ? Array.from({ length: displayDays }, (_, idx) => _dayLabelFor(reports[0], idx))
-    : _fallbackDayLabels(displayDays);
-  const weeklyHeaders = ["week 1", "week 2"];
-  const favoriteAllButton = _favoriteAllButtonHtml(reports);
-  const stickySectionKey = options.sectionKey || options.prefix;
-  if (appState.layoutMode === "compact") {
-    const mobileRows = reports.length ? reports.map((report) => {
-      const attrs = _filterAttrs(report);
-      const weeklyValues = [
-        options.week1(report),
-        options.week2(report),
-      ].map((value) => _metricCellHtml(_formatMetric(value), kind, options.color(value), "week-col-cell"));
-      const dailyValues = Array.from({ length: displayDays }, (_, idx) => {
-        const value = options.daily(_dailyAt(report, idx));
-        return _metricCellHtml(_formatMetric(value), kind, options.color(value), "day-col-cell");
-      });
-      return `<tr${attrs}>${_mobilePrecipResortCellHtml(report)}${weeklyValues.join("")}${dailyValues.join("")}</tr>`;
-    }).join("") : _emptyStateRow(3 + Math.max(1, displayDays), emptyMessage);
-    return `
-      <section class="forecast-section forecast-section-precip">
-        <div class="section-header">
-          <h2>${title}</h2>
-          <div class="unit-toggle" role="group" aria-label="${title} unit system" data-target-kind="${kind}">
-            <button type="button" class="unit-btn" data-unit-mode="metric">${metricUnit}</button>
-            <button type="button" class="unit-btn" data-unit-mode="imperial">${imperialUnit}</button>
-          </div>
-        </div>
-        <div
-          class="${options.prefix}-sticky-wrap mobile-only"
-          id="${options.prefix}-sticky-wrap-mobile"
-          data-sticky-single-table-section="${_escapeHtml(stickySectionKey)}"
-          data-sticky-leading-cols="1"
-          data-sticky-header-rows="2"
-          data-sticky-max-visible-rows="10"
-        >
-          <table class="${options.prefix}-sticky-table ${options.prefix}-mobile-sticky-table">
-            <colgroup><col class='col-query'><col class='col-week'><col class='col-week'>${Array.from({ length: displayDays }, () => "<col class='col-day'>").join("")}</colgroup>
-            <thead><tr>${_mobilePrecipResortHeadHtml(favoriteAllButton)}<th colspan='2' class='week-group'>Weekly</th><th colspan='${displayDays}'>Daily</th></tr><tr><th class='week-col-cell'>${weeklyHeaders[0]}</th><th class='week-col-cell'>${weeklyHeaders[1]}</th>${dayLabels.map((label) => `<th class='day-col-cell'>${_dayLabelHtml(label)}</th>`).join("")}</tr></thead>
-            <tbody>${mobileRows}</tbody>
-          </table>
-        </div>
-      </section>`;
-  }
-  const desktopRows = reports.length ? reports.map((report) => {
-    const attrs = _filterAttrs(report);
-    const weeklyValues = [
-      options.week1(report),
-      options.week2(report),
-    ].map((value) => _metricCellHtml(_formatMetric(value), kind, options.color(value), "week-col-cell"));
-    const dailyValues = Array.from({ length: displayDays }, (_, idx) => {
-      const value = options.daily(_dailyAt(report, idx));
-      return _metricCellHtml(_formatMetric(value), kind, options.color(value), "day-col-cell");
-    }).join("");
-    return `<tr${attrs}>${_resortCellHtml(report)}${weeklyValues.join("")}${dailyValues}</tr>`;
-  }).join("") : _emptyStateRow(4 + Math.max(1, displayDays), emptyMessage);
-  return `
-    <section class="forecast-section forecast-section-precip">
-      <div class="section-header">
-        <h2>${title}</h2>
-        <div class="unit-toggle" role="group" aria-label="${title} unit system" data-target-kind="${kind}">
-          <button type="button" class="unit-btn" data-unit-mode="metric">${metricUnit}</button>
-          <button type="button" class="unit-btn" data-unit-mode="imperial">${imperialUnit}</button>
-        </div>
-      </div>
-      <div
-        class="${options.prefix}-sticky-wrap desktop-only"
-        id="${options.prefix}-sticky-wrap"
-        data-sticky-single-table-section="${_escapeHtml(stickySectionKey)}"
-        data-sticky-leading-cols="4"
-        data-sticky-header-rows="2"
-        data-sticky-max-visible-rows="10"
-      >
-        <table class="${options.prefix}-sticky-table">
-          <colgroup><col class='col-favorite'><col class='col-query'><col class='col-week'><col class='col-week'>${Array.from({ length: displayDays }, () => "<col class='col-day'>").join("")}</colgroup>
-          <thead><tr><th rowspan='2' class='favorite-col favorite-head'>${favoriteAllButton}</th><th rowspan='2' class='query-col'>Resort</th><th colspan='2' class='week-group'>Weekly</th><th colspan='${displayDays}'>Daily</th></tr><tr><th class='week-col-cell'>${weeklyHeaders[0]}</th><th class='week-col-cell'>${weeklyHeaders[1]}</th>${dayLabels.map((label) => `<th class='day-col-cell'>${_dayLabelHtml(label)}</th>`).join("")}</tr></thead>
-          <tbody>${desktopRows}</tbody>
-        </table>
-      </div>
-    </section>`;
-};
-
-const _renderTemperatureSection = (reports, emptyMessage = "No resorts match the current filters.") => {
-  const displayDays = _displayDays();
-  const labels = reports.length
-    ? Array.from({ length: displayDays }, (_, idx) => _dayLabelFor(reports[0], idx))
-    : _fallbackDayLabels(displayDays);
-  const rows = reports.length ? reports.map((report) => {
-    const attrs = _filterAttrs(report);
-    const cells = Array.from({ length: displayDays }, (_, idx) => {
-      const day = _dailyAt(report, idx);
-      return [
-        _metricCellHtml(_formatTemp(day.temperature_min_c), "temp", _tempColor(day.temperature_min_c)),
-        _metricCellHtml(_formatTemp(day.temperature_max_c), "temp", _tempColor(day.temperature_max_c)),
-      ].join("");
-    }).join("");
-    return `<tr${attrs}>${_resortCellHtml(report)}${cells}</tr>`;
-  }).join("") : _emptyStateRow(2 + Math.max(1, displayDays * 2), emptyMessage);
-  return `
-    <section class="forecast-section forecast-section-temperature">
-      <div class="section-header">
-        <h2>Temperature</h2>
-        <div class="unit-toggle" role="group" aria-label="Temperature unit system" data-target-kind="temp">
-          <button type="button" class="unit-btn" data-unit-mode="metric">°C</button>
-          <button type="button" class="unit-btn" data-unit-mode="imperial">°F</button>
-        </div>
-      </div>
-      <div
-        class="temperature-sticky-wrap"
-        id="temperature-sticky-wrap"
-        data-sticky-single-table-section="${STICKY_SINGLE_TABLE_SECTION_KEYS.temperature}"
-        data-sticky-leading-cols="2"
-        data-sticky-header-rows="2"
-        data-sticky-max-visible-rows="10"
-      >
-        <table class="temperature-single-table" id="temperature-single-table">
-          <colgroup><col class="col-favorite"><col class="col-query">${Array.from({ length: displayDays * 2 }, () => "<col class='col-temp'>").join("")}</colgroup>
-          <thead><tr><th rowspan='2' class='favorite-col favorite-head'>${_favoriteAllButtonHtml(reports)}</th><th rowspan='2' class='query-col'>Resort</th>${labels.map((label) => `<th colspan='2'>${_dayLabelHtml(label)}</th>`).join("")}</tr><tr>${Array.from({ length: displayDays }, () => "<th>min</th><th>max</th>").join("")}</tr></thead>
-          <tbody>${rows}</tbody>
-        </table>
-      </div>
-    </section>`;
-};
-
-const _renderWeatherSection = (reports, emptyMessage = "No resorts match the current filters.") => {
-  const displayDays = _displayDays();
-  const labels = reports.length
-    ? Array.from({ length: displayDays }, (_, idx) => _dayLabelFor(reports[0], idx))
-    : _fallbackDayLabels(displayDays);
-  const weatherCells = (report) => Array.from({ length: displayDays }, (_, idx) => {
-    const code = _dailyAt(report, idx).weather_code;
-    const title = fieldGuideWeather.conditionName
-      ? fieldGuideWeather.conditionName(code)
-      : "Conditions unavailable";
-    return `<td class='weather-emoji-cell' title='${_escapeHtml(title)}'>${_weatherIcon(code)}</td>`;
-  }).join("");
-  const rows = reports.length ? reports.map((report) => `<tr${_filterAttrs(report)}>${_resortCellHtml(report)}${weatherCells(report)}</tr>`).join("") : _emptyStateRow(2 + Math.max(1, displayDays), emptyMessage);
-  return `
-    <section class="forecast-section forecast-section-weather">
-      <div class="section-header">
-        <h2>Weather</h2>
-        <span class="section-note">Daily conditions</span>
-      </div>
-      <div
-        class='weather-table-wrap'
-        id='weather-table-wrap'
-        data-sticky-single-table-section='${STICKY_SINGLE_TABLE_SECTION_KEYS.weather}'
-        data-sticky-leading-cols='2'
-        data-sticky-header-rows='1'
-        data-sticky-max-visible-rows='10'
-      >
-        <table class='weather-table' id='weather-table'>
-          <colgroup><col class='col-favorite'><col class='col-query'>${Array.from({ length: displayDays }, () => "<col class='col-weather'>").join("")}</colgroup>
-          <thead><tr><th class='favorite-col favorite-head'>${_favoriteAllButtonHtml(reports)}</th><th class='query-col'>Resort</th>${labels.map((label) => `<th>${_dayLabelHtml(label)}</th>`).join("")}</tr></thead>
-          <tbody>${rows}</tbody>
-        </table>
-      </div>
-    </section>`;
-};
-
-const _renderSunSection = (reports, emptyMessage = "No resorts match the current filters.") => {
-  const displayDays = _displayDays();
-  const labels = reports.length
-    ? Array.from({ length: displayDays }, (_, idx) => _dayLabelFor(reports[0], idx))
-    : _fallbackDayLabels(displayDays);
-  const hhmm = (raw, mode = "metric") => {
-    const text = String(raw || "").trim();
-    if (!text) return "";
-    const value = text.includes("T") ? text.split("T", 2)[1].slice(0, 5) : text.slice(0, 5);
-    if (mode !== "imperial") return value;
-    const match = /^(\d{2}):(\d{2})$/.exec(value);
-    if (!match) return value;
-    const hour24 = Number(match[1]);
-    if (!Number.isFinite(hour24)) return value;
-    const minute = match[2];
-    const suffix = hour24 >= 12 ? "PM" : "AM";
-    const hour12 = hour24 % 12 || 12;
-    return `${hour12}:${minute} ${suffix}`;
+  const appState = {
+    payload: null,
+    availableFilters: DEFAULT_AVAILABLE_FILTERS,
+    favoriteResortIds: new Set(),
+    unitMode: "metric",
+    filterState: {
+      passTypes: new Set(),
+      subregions: new Set(),
+      sortBy: "week_snow",
+      includeDefault: true,
+      searchAll: true,
+      search: "",
+      favoritesOnly: false,
+    },
   };
-  const totalColumns = 2 + (displayDays * 2);
-  const rows = reports.length ? reports.map((report) => {
-    const attrs = _filterAttrs(report);
-    const cells = Array.from({ length: displayDays }, (_, idx) => {
-      const day = _dailyAt(report, idx);
-      const sunriseRaw = hhmm(day.sunrise_local_hhmm || day.sunrise_iso);
-      const sunsetRaw = hhmm(day.sunset_local_hhmm || day.sunset_iso);
-      const sunrise = hhmm(sunriseRaw, appState.sunTimeToggleMode);
-      const sunset = hhmm(sunsetRaw, appState.sunTimeToggleMode);
-      return `<td data-sun-time-raw="${_escapeHtml(sunriseRaw)}">${_escapeHtml(sunrise)}</td><td data-sun-time-raw="${_escapeHtml(sunsetRaw)}">${_escapeHtml(sunset)}</td>`;
-    }).join("");
-    return `<tr${attrs}>${_resortCellHtml(report)}${cells}</tr>`;
-  }).join("") : _emptyStateRow(totalColumns, emptyMessage);
-  return `
-    <section class="forecast-section forecast-section-sun">
-      <div class="section-header">
-        <h2>Sunrise / Sunset</h2>
-        <div class="unit-toggle" role="group" aria-label="Sunrise and sunset time format" data-sun-time-toggle="1" data-mode="${appState.sunTimeToggleMode}">
-          <button type="button" class="unit-btn" data-unit-mode="metric">24h</button>
-          <button type="button" class="unit-btn" data-unit-mode="imperial">12h</button>
-        </div>
-      </div>
-      <div
-        class="sun-single-wrap"
-        id="sun-single-wrap"
-        data-sticky-single-table-section="${STICKY_SINGLE_TABLE_SECTION_KEYS.sun}"
-        data-sticky-leading-cols="2"
-        data-sticky-header-rows="2"
-        data-sticky-max-visible-rows="10"
-      >
-        <table class="sun-single-table" id="sun-single-table">
-          <colgroup><col class="col-favorite"><col class="col-query">${Array.from({ length: displayDays * 2 }, () => "<col class='col-sun'>").join("")}</colgroup>
-          <thead><tr><th rowspan='2' class='favorite-col favorite-head'>${_favoriteAllButtonHtml(reports)}</th><th rowspan='2' class='query-col'>Resort</th>${labels.map((label) => `<th colspan='2'>${_dayLabelHtml(label)}</th>`).join("")}</tr><tr>${Array.from({ length: displayDays }, () => "<th>sunrise</th><th>sunset</th>").join("")}</tr></thead>
-          <tbody>${rows}</tbody>
-        </table>
-      </div>
-    </section>`;
-};
 
-const _renderSections = (reports, emptyMessage = "No resorts match the current filters.") => [
-  _renderForecastOverview(reports),
-  _renderCompactGridSection(reports, emptyMessage),
-  _renderPrecipSection("Snowfall", "snow", "cm", "in", reports, {
-    prefix: "snowfall",
-    sectionKey: STICKY_SINGLE_TABLE_SECTION_KEYS.snowfall,
-    week1: (report) => report.week1_total_snowfall_cm,
-    week2: (report) => report.week2_total_snowfall_cm,
-    daily: (day) => day.snowfall_cm,
-    color: _snowColor,
-  }, emptyMessage),
-  _renderPrecipSection("Rainfall", "rain", "mm", "in", reports, {
-    prefix: "rain",
-    sectionKey: STICKY_SINGLE_TABLE_SECTION_KEYS.rainfall,
-    week1: (report) => report.week1_total_rain_mm,
-    week2: (report) => report.week2_total_rain_mm,
-    daily: (day) => day.rain_mm,
-    color: _rainColor,
-  }, emptyMessage),
-  _renderTemperatureSection(reports, emptyMessage),
-  _renderWeatherSection(reports, emptyMessage),
-  _renderSunSection(reports, emptyMessage),
-].join("");
-
-const _payloadReports = () => {
-  const reports = appState.payload && Array.isArray(appState.payload.reports) ? appState.payload.reports : [];
-  return reports.filter((report) => report && typeof report === "object");
-};
-
-const _deriveAvailableFiltersFromReports = (reports) => {
-  const out = { pass_type: {}, region: {}, subregion: {} };
-  reports.forEach((report) => {
-    const region = _normalizeSearch(report.region);
-    if (region) out.region[region] = (out.region[region] || 0) + 1;
-    const subregion = _normalizeSearch(report.subregion);
-    if (subregion) out.subregion[subregion] = (out.subregion[subregion] || 0) + 1;
-    const passTypes = Array.isArray(report.pass_types) ? report.pass_types : [];
-    passTypes.forEach((passType) => {
-      const key = _normalizeSearch(passType);
-      if (key) out.pass_type[key] = (out.pass_type[key] || 0) + 1;
-    });
-  });
-  return out;
-};
-
-const _availableFilters = () => {
-  const meta = filterMetaAvailable;
-  if (meta && typeof meta === "object" && Object.keys(meta).length > 0) {
-    return {
-      pass_type: meta.pass_type && typeof meta.pass_type === "object" ? meta.pass_type : {},
-      region: meta.region && typeof meta.region === "object" ? meta.region : {},
-      subregion: meta.subregion && typeof meta.subregion === "object" ? meta.subregion : {},
-    };
-  }
-  return _deriveAvailableFiltersFromReports(_payloadReports());
-};
-
-const parsePassTypeValues = filterStateHelpers.parsePassTypeValues;
-const parseSubregionValues = filterStateHelpers.parseSubregionValues;
-const normalizeSortBy = filterStateHelpers.normalizeSortBy;
-
-const _dailySnowfall = (report, index = 0) => _asFiniteNumber(_dailyAt(report, index).snowfall_cm);
-const _weeklySnowfall = (report) => _asFiniteNumber(report && report.week1_total_snowfall_cm);
-const _nextWeekSnowfall = (report) => _asFiniteNumber(report && report.week2_total_snowfall_cm);
-const _twoWeekSnowfall = (report) => {
-  const week1 = _weeklySnowfall(report);
-  const week2 = _nextWeekSnowfall(report);
-  if (week1 === null && week2 === null) return null;
-  return (week1 || 0) + (week2 || 0);
-};
-
-const _sortLabel = filterStateHelpers.sortLabel;
-
-const _subregionLabel = (value) => {
-  const hit = SUBREGION_OPTIONS.find((option) => option.value === _normalizeSearch(value));
-  return hit ? hit.label : String(value || "");
-};
-
-const _compareBySnowDesc = (a, b, valueFn) => {
-  const aValue = valueFn(a);
-  const bValue = valueFn(b);
-  const aSortable = aValue === null ? Number.NEGATIVE_INFINITY : aValue;
-  const bSortable = bValue === null ? Number.NEGATIVE_INFINITY : bValue;
-  return bSortable - aSortable;
-};
-
-const loadFavoriteResortIds = () => {
-  try {
-    const raw = localStorage.getItem(FAVORITES_STORAGE_KEY);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
-    return Array.from(new Set(parsed.map((value) => String(value || "").trim()).filter(Boolean)));
-  } catch (error) {
-    return [];
-  }
-};
-
-const persistFavoriteResortIds = () => {
-  try {
-    localStorage.setItem(FAVORITES_STORAGE_KEY, JSON.stringify(Array.from(appState.favoriteResortIds).sort()));
-  } catch (error) {
-    // Ignore storage failures.
-  }
-};
-
-const toggleFavoriteResortId = (resortId) => {
-  const id = String(resortId || "").trim();
-  if (!id) return;
-  if (appState.favoriteResortIds.has(id)) {
-    appState.favoriteResortIds.delete(id);
-  } else {
-    appState.favoriteResortIds.add(id);
-  }
-  persistFavoriteResortIds();
-};
-
-const toggleFavoriteVisibleReports = (reports) => {
-  const visibleIds = Array.from(new Set((reports || []).map((report) => String(report?.resort_id || "").trim()).filter(Boolean)));
-  if (!visibleIds.length) return;
-  const allFavorited = visibleIds.every((resortId) => appState.favoriteResortIds.has(resortId));
-  visibleIds.forEach((resortId) => {
-    if (allFavorited) {
-      appState.favoriteResortIds.delete(resortId);
-    } else {
-      appState.favoriteResortIds.add(resortId);
-    }
-  });
-  persistFavoriteResortIds();
-};
-
-const _favoriteButtonLabel = (active) => (active ? "Remove resort from favorites" : "Add resort to favorites");
-
-const _favoriteAllButtonLabel = (active) => (
-  active ? "Remove all visible resorts from favorites" : "Favorite all visible resorts"
-);
-
-const _syncFavoriteButtonState = (button, active) => {
-  if (!button) return;
-  button.setAttribute("data-favorite-active", active ? "1" : "0");
-  button.setAttribute("aria-pressed", active ? "true" : "false");
-  button.setAttribute("aria-label", _favoriteButtonLabel(active));
-};
-
-const _syncFavoriteAllButtonState = (button, active) => {
-  if (!button) return;
-  button.setAttribute("data-favorite-active", active ? "1" : "0");
-  button.setAttribute("aria-pressed", active ? "true" : "false");
-  button.setAttribute("aria-label", _favoriteAllButtonLabel(active));
-};
-
-const syncFavoriteButtons = () => {
-  document.querySelectorAll(".favorite-btn[data-resort-id]").forEach((button) => {
-    const resortId = String(button.getAttribute("data-resort-id") || "").trim();
-    _syncFavoriteButtonState(button, _isFavoriteResortId(resortId));
-  });
-};
-
-const syncFavoriteAllButtons = (reports) => {
-  const visibleIds = Array.from(new Set((reports || []).map((report) => String(report?.resort_id || "").trim()).filter(Boolean)));
-  const allFavorited = visibleIds.length > 0 && visibleIds.every((resortId) => _isFavoriteResortId(resortId));
-  document.querySelectorAll(".favorite-all-btn[data-favorite-all='1']").forEach((button) => {
-    _syncFavoriteAllButtonState(button, allFavorited);
-  });
-};
-
-const syncFavoriteUiInPlace = (reports) => {
-  syncFavoriteButtons();
-  syncFavoriteAllButtons(reports);
-};
-
-const favoriteInteractionNeedsFullRender = () => (
-  appState.filterState.favoritesOnly || appState.filterState.sortBy === "favorites"
-);
-
-const setFavoritesOnlyControls = (checked) => {
-  const value = Boolean(checked);
-  if (favoritesOnlyToggle) favoritesOnlyToggle.checked = value;
-  if (filterFavoritesOnlyInput) filterFavoritesOnlyInput.checked = value;
-};
-
-const loadStoredFilterState = () => filterStateHelpers.loadStoredFilterState(localStorage, FILTER_STORAGE_KEY);
-
-const persistFilterState = () => {
-  filterStateHelpers.persistFilterState(localStorage, FILTER_STORAGE_KEY, appState.filterState);
-};
-
-const applyControlsFromQueryOrMeta = () => {
-  const params = new URLSearchParams(window.location.search);
-  const urlPassTypes = parsePassTypeValues(params.getAll("pass_type"));
-  const urlSubregions = parseSubregionValues(params.getAll("subregion"));
-  const hasUrlSortBy = params.has("sort_by");
-  const urlSortBy = normalizeSortBy(params.get("sort_by") || "");
-  const urlSearch = params.get("search");
-  const hasUrlIncludeDefault = params.has("include_default");
-  const urlIncludeDefault = _isTruthyParam(params.get("include_default") || "");
-  const hasUrlSearchAll = params.has("search_all");
-  const urlSearchAll = _isTruthyParam(params.get("search_all") || "");
-  const hasUrlIncludeAll = params.has("include_all");
-  const urlIncludeAll = _isTruthyParam(params.get("include_all") || "");
-
-  const metaPassTypes = parsePassTypeValues(Array.isArray(filterMetaApplied.pass_type) ? filterMetaApplied.pass_type : []);
-  const metaSubregions = parseSubregionValues(
-    Array.isArray(filterMetaApplied.subregion)
-      ? filterMetaApplied.subregion
-      : (filterMetaApplied.subregion ? [filterMetaApplied.subregion] : [])
-  );
-  const metaSortBy = normalizeSortBy(filterMetaApplied.sort_by || "");
-  const metaSearch = String(filterMetaApplied.search || "");
-  const hasMetaSearchAll = Object.prototype.hasOwnProperty.call(filterMetaApplied, "search_all");
-  const metaSearchAll = Boolean(filterMetaApplied.search_all);
-  const hasMetaIncludeDefault = Object.prototype.hasOwnProperty.call(filterMetaApplied, "include_default");
-  const metaIncludeDefault = Boolean(filterMetaApplied.include_default);
-  const metaIncludeAll = Boolean(filterMetaApplied.include_all);
-  const stored = loadStoredFilterState();
-
-  const passTypes = urlPassTypes.length > 0 ? urlPassTypes : (stored ? stored.passTypes : metaPassTypes);
-  const subregions = urlSubregions.length > 0 ? urlSubregions : (stored ? stored.subregions : metaSubregions);
-  const sortBy = hasUrlSortBy ? urlSortBy : (stored ? stored.sortBy : metaSortBy);
-  const search = urlSearch !== null ? urlSearch : (stored ? stored.search : metaSearch);
-  const searchAll = hasUrlSearchAll ? urlSearchAll : (stored ? stored.searchAll : (hasMetaSearchAll ? metaSearchAll : true));
-  const includeDefault = hasUrlIncludeDefault
-    ? urlIncludeDefault
-    : (hasUrlIncludeAll ? !urlIncludeAll : (stored ? stored.includeDefault : (hasMetaIncludeDefault ? metaIncludeDefault : !metaIncludeAll)));
-  const favoritesOnly = stored ? stored.favoritesOnly : false;
-
-  appState.filterState.passTypes = new Set(passTypes);
-  appState.filterState.subregions = new Set(subregions);
-  appState.filterState.sortBy = sortBy;
-  appState.filterState.includeDefault = includeDefault;
-  appState.filterState.searchAll = searchAll;
-  appState.filterState.search = String(search || "");
-  appState.filterState.favoritesOnly = favoritesOnly;
-
-  filterPassTypeInputs.forEach((input) => {
-    input.checked = appState.filterState.passTypes.has(_normalizeSearch(input.value));
-  });
-  if (filterRegionOptions) {
-    filterRegionOptions.querySelectorAll("input[name='filter-subregion']").forEach((input) => {
-      input.checked = appState.filterState.subregions.has(_normalizeSearch(input.value));
-    });
-  }
-  if (filterSortSelect) filterSortSelect.value = sortBy;
-  if (filterIncludeAllInput) filterIncludeAllInput.checked = includeDefault;
-  if (filterSearchAllInput) filterSearchAllInput.checked = searchAll;
-  setFavoritesOnlyControls(favoritesOnly);
-  if (resortSearchInput) resortSearchInput.value = appState.filterState.search;
-};
-
-const applyFilterStateFromControls = () => {
-  appState.filterState.passTypes = new Set(
-    filterPassTypeInputs.map((input) => _normalizeSearch(input.value)).filter((value, index) => filterPassTypeInputs[index].checked)
-  );
-  const selectedSubregions = filterRegionOptions
-    ? Array.from(filterRegionOptions.querySelectorAll("input[name='filter-subregion']:checked")).map((input) => _normalizeSearch(input.value))
-    : [];
-  appState.filterState.subregions = new Set(selectedSubregions);
-  appState.filterState.sortBy = normalizeSortBy(filterSortSelect ? filterSortSelect.value : "week_snow");
-  appState.filterState.includeDefault = filterIncludeAllInput ? Boolean(filterIncludeAllInput.checked) : true;
-  appState.filterState.searchAll = filterSearchAllInput ? Boolean(filterSearchAllInput.checked) : true;
-  appState.filterState.search = resortSearchInput ? String(resortSearchInput.value || "") : "";
-  appState.filterState.favoritesOnly = favoritesOnlyToggle
-    ? Boolean(favoritesOnlyToggle.checked)
-    : Boolean(filterFavoritesOnlyInput && filterFavoritesOnlyInput.checked);
-  setFavoritesOnlyControls(appState.filterState.favoritesOnly);
-  persistFilterState();
-};
-
-const syncUrlFromFilterState = () => {
-  return false;
-};
-
-const buildServerQueryParams = () => {
-  const params = new URLSearchParams();
-  Array.from(appState.filterState.passTypes).sort().forEach((passType) => {
-    if (passType) params.append("pass_type", passType);
-  });
-  Array.from(appState.filterState.subregions).sort().forEach((subregion) => {
-    if (subregion) params.append("subregion", subregion);
-  });
-  if (appState.filterState.search) params.set("search", appState.filterState.search);
-  params.set("search_all", appState.filterState.searchAll ? "1" : "0");
-  if (appState.filterState.includeDefault) {
-    params.set("include_default", "1");
-  } else {
-    params.set("include_all", "1");
-  }
-  return params;
-};
-
-const _rowSearchText = (report) => {
-  const passTypes = Array.isArray(report.pass_types) ? report.pass_types.join(" ") : "";
-  const state = String(report.admin1 || "").trim();
-  const stateName = String(report.state_name || "").trim();
-  const countryCode = String(report.country_code || report.country || "").trim();
-  const countryName = String(report.country_name || "").trim();
-  const city = String(report.city || "").trim();
-  const address = String(report.address || "").trim();
-  const searchTerms = Array.isArray(report.search_terms) ? report.search_terms.join(" ") : "";
-  return _normalizeSearch(
-    `${_displayName(report)} ${report.query || ""} ${state} ${stateName} ${countryCode} ${countryName} ${city} ${address} ${passTypes} ${searchTerms}`
-  );
-};
-
-const _isDefaultResort = (report) => Boolean(report.default_resort || report.ljcc_favorite);
-const _isFavoriteReport = (report) => _isFavoriteResortId(report && report.resort_id);
-
-const _filteredReports = () => {
-  const keyword = _normalizeSearch(appState.filterState.search);
-  const reports = _payloadReports();
-  const searchAllActive = Boolean(keyword) && appState.filterState.searchAll;
-  const filtered = reports.filter((report) => {
-    if (keyword && !_rowSearchText(report).includes(keyword)) return false;
-    if (searchAllActive) return true;
-    if (appState.filterState.favoritesOnly && !_isFavoriteReport(report)) return false;
-    if (appState.filterState.includeDefault && !_isDefaultResort(report)) return false;
-    if (appState.filterState.passTypes.size > 0) {
-      const reportPassTypes = new Set((Array.isArray(report.pass_types) ? report.pass_types : []).map(_normalizeSearch));
-      let matchesPass = false;
-      for (const passType of appState.filterState.passTypes) {
-        if (reportPassTypes.has(passType)) {
-          matchesPass = true;
-          break;
-        }
-      }
-      if (!matchesPass) return false;
-    }
-    if (appState.filterState.subregions.size > 0) {
-      const reportSubregion = _normalizeSearch(report.subregion || report.region);
-      if (!appState.filterState.subregions.has(reportSubregion)) return false;
-    }
-    return true;
-  });
-  const sortBy = appState.filterState.sortBy;
-  filtered.sort((a, b) => {
-    if (sortBy === "favorites") {
-      const favoriteDelta = Number(_isFavoriteReport(b)) - Number(_isFavoriteReport(a));
-      if (favoriteDelta !== 0) return favoriteDelta;
-    }
-    if (sortBy === "today_snow") {
-      const snowDelta = _compareBySnowDesc(a, b, (report) => _dailySnowfall(report, 0));
-      if (snowDelta !== 0) return snowDelta;
-    }
-    if (sortBy === "week_snow") {
-      const snowDelta = _compareBySnowDesc(a, b, _weeklySnowfall);
-      if (snowDelta !== 0) return snowDelta;
-    }
-    if (sortBy === "next_week_snow") {
-      const snowDelta = _compareBySnowDesc(a, b, _nextWeekSnowfall);
-      if (snowDelta !== 0) return snowDelta;
-    }
-    if (sortBy === "two_week_snow") {
-      const snowDelta = _compareBySnowDesc(a, b, _twoWeekSnowfall);
-      if (snowDelta !== 0) return snowDelta;
-    }
-    if (sortBy === "name") return _displayName(a).localeCompare(_displayName(b));
-    const stateCmp = String(a.admin1 || "").localeCompare(String(b.admin1 || ""));
-    if (stateCmp !== 0) return stateCmp;
-    return String(a.query || "").localeCompare(String(b.query || ""));
-  });
-  return filtered;
-};
-
-const syncFilterSummary = (visibleReports, totalReports) => {
-  if (!filterSummary) return;
-  const scope = totalReports > 0 ? (visibleReports === totalReports ? `${visibleReports}` : `${visibleReports}/${totalReports}`) : "0";
-  const keyword = _normalizeSearch(appState.filterState.search);
-  const searchAllActive = Boolean(keyword) && appState.filterState.searchAll;
-  const parts = [];
-  if (!searchAllActive) {
-    if (appState.filterState.favoritesOnly) parts.push("favorites only");
-    if (appState.filterState.passTypes.size > 0) parts.push(`pass: ${Array.from(appState.filterState.passTypes).join(", ")}`);
-    if (appState.filterState.subregions.size > 0) {
-      parts.push(`region: ${Array.from(appState.filterState.subregions).map((value) => _subregionLabel(value)).join(", ")}`);
-    }
-    if (appState.filterState.sortBy !== "state") parts.push(`sort: ${_sortLabel(appState.filterState.sortBy)}`);
-    if (appState.filterState.includeDefault && parts.length > 0) parts.push("scope: default");
-    if (!appState.filterState.searchAll) parts.push("search: filtered");
-  } else {
-    parts.push("search: all resorts");
-  }
-  filterSummary.textContent = parts.length > 0
-    ? `${parts.join(" | ")} | visible: ${scope}`
-    : (appState.filterState.includeDefault ? `Default resorts (${scope})` : `All supported resorts (${scope})`);
-};
-
-const getLayoutModeForWidth = (width = window.innerWidth) => (width < MIN_DESKTOP_SNOW_3DAY_PX ? "compact" : "desktop");
-
-const updateLayoutMode = () => {
-  const layoutMode = getLayoutModeForWidth();
-  appState.layoutMode = layoutMode;
-  document.body.classList.toggle("mobile-simple", layoutMode === "compact");
-  return layoutMode;
-};
-
-const isCompactLayout = () => appState.layoutMode === "compact";
-
-const _mobileLeadingQueryCap = (offset = LEADING_FAVORITE_COL_PX) => {
-  const viewportWidth = Math.max(
-    document.documentElement?.clientWidth || 0,
-    window.innerWidth || 0,
-  );
-  return Math.max(0, Math.floor((viewportWidth / 2) - Math.max(0, offset)));
-};
-
-const _mobileHalfScreenCap = () => _mobileLeadingQueryCap(0);
-
-const _stickySingleTableWidthContext = ({
-  wrapSelector,
-  queryVarName,
-  leadingWidth = LEADING_FAVORITE_COL_PX,
-}) => {
-  const wrap = document.querySelector(wrapSelector);
-  if (!wrap) return { availableWidth: 0, reservedWidth: leadingWidth };
-  const queryWidth = parseFloat(window.getComputedStyle(wrap).getPropertyValue(queryVarName)) || 0;
-  const reservedWidth = leadingWidth + queryWidth;
-  return {
-    availableWidth: Math.max(0, wrap.clientWidth - reservedWidth),
-    reservedWidth,
+  const displayName = (report) => String(report?.display_name || report?.query || "").trim();
+  const asFiniteNumber = (value) => {
+    if (value === null || value === undefined || typeof value === "boolean") return null;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
   };
-};
 
-const _compactMobileDailyWidthContext = () => {
-  return _stickySingleTableWidthContext({
-    wrapSelector: ".compact-grid-mobile-wrap",
-    queryVarName: "--compact-mobile-query-w",
-  });
-};
-
-const _resolveQueryColumnBounds = ({
-  minWidth,
-  maxWidth,
-  capToMobileHalfScreen = false,
-  mobileCapOffset = LEADING_FAVORITE_COL_PX,
-}) => {
-  let resolvedMax = maxWidth;
-  if (capToMobileHalfScreen && isCompactLayout()) {
-    resolvedMax = Math.min(resolvedMax, _mobileLeadingQueryCap(mobileCapOffset));
-  }
-  return {
-    minWidth: Math.min(minWidth, resolvedMax),
-    maxWidth: resolvedMax,
+  const payloadReports = () => {
+    const reports = Array.isArray(appState.payload?.reports) ? appState.payload.reports : [];
+    return reports.filter((report) => report && typeof report === "object");
   };
-};
 
-const _autoSizeDesktopLeftColumns = ({
-  tableSelector,
-  wrapSelector,
-  queryVarName,
-  weekVarName,
-}) => {
-  const table = document.querySelector(tableSelector);
-  const wrap = document.querySelector(wrapSelector);
-  if (!table || !wrap) return;
-  const rows = Array.from(table.querySelectorAll("tbody tr"));
-  const headerCells = Array.from(table.querySelectorAll("thead tr:last-child th"));
-  if (headerCells.length < 2) return;
-  const sampleCell = table.querySelector("tbody td") || headerCells[0];
-  if (!sampleCell) return;
-  const font = window.getComputedStyle(sampleCell).font;
+  const dailyAt = (report, index) => {
+    const daily = Array.isArray(report?.daily) ? report.daily : [];
+    return daily[index] && typeof daily[index] === "object" ? daily[index] : {};
+  };
 
-  const queryIndex = headerCells.length >= 2 ? 1 : 0;
-  const queryValues = rows.map((row) => row.children[queryIndex]?.textContent?.trim() || "");
-  const queryHeader = table.querySelector("thead .query-col")?.textContent?.trim() || "query";
-  const queryMax = Math.max(
-    measureTextWidth(queryHeader, font),
-    ...queryValues.map((value) => measureTextWidth(value, font)),
-  );
+  const weeklySnowfall = (report) => asFiniteNumber(report?.week1_total_snowfall_cm);
+  const nextWeekSnowfall = (report) => asFiniteNumber(report?.week2_total_snowfall_cm);
+  const twoWeekSnowfall = (report) => {
+    const weekOne = weeklySnowfall(report);
+    const weekTwo = nextWeekSnowfall(report);
+    return weekOne === null && weekTwo === null ? null : (weekOne || 0) + (weekTwo || 0);
+  };
 
-  const weekHeaders = headerCells.map((cell) => cell.textContent?.trim() || "");
-  const weekValues = rows.flatMap((row) =>
-    Array.from(row.children)
-      .slice(queryIndex + 1)
-      .map((cell) => cell.textContent?.trim() || ""),
-  );
-  const weekMax = Math.max(
-    ...weekHeaders.map((value) => measureTextWidth(value, font)),
-    ...weekValues.map((value) => measureTextWidth(value, font)),
-  );
+  const compareDescending = (a, b, valueFn) => {
+    const aValue = valueFn(a);
+    const bValue = valueFn(b);
+    const safeA = aValue === null ? Number.NEGATIVE_INFINITY : aValue;
+    const safeB = bValue === null ? Number.NEGATIVE_INFINITY : bValue;
+    return safeB - safeA;
+  };
 
-  wrap.style.setProperty(queryVarName, `${Math.max(150, Math.min(240, Math.ceil(queryMax + 28)))}px`);
-  wrap.style.setProperty(weekVarName, `${Math.max(90, Math.min(130, Math.ceil(weekMax + 24)))}px`);
-};
-
-const _autoSizeQueryOnly = ({
-  tableSelector,
-  wrapSelector,
-  queryVarName,
-  minWidth = 150,
-  maxWidth = 240,
-  padding = 28,
-  capToMobileHalfScreen = false,
-  mobileCapOffset = LEADING_FAVORITE_COL_PX,
-}) => {
-  const table = document.querySelector(tableSelector);
-  const wrap = document.querySelector(wrapSelector);
-  if (!table || !wrap) return;
-  const rows = Array.from(table.querySelectorAll("tbody tr"));
-  const header = table.querySelector("thead .query-col") || table.querySelector("thead th");
-  const sampleCell = table.querySelector("tbody td") || header;
-  if (!sampleCell || !header) return;
-  const font = window.getComputedStyle(sampleCell).font;
-  const queryIndex = header && header.cellIndex >= 0 ? header.cellIndex : 0;
-  const values = rows.map((row) => row.children[queryIndex]?.textContent?.trim() || "");
-  const headerText = header.textContent?.trim() || "query";
-  const queryMax = Math.max(
-    measureTextWidth(headerText, font),
-    ...values.map((value) => measureTextWidth(value, font)),
-  );
-  const bounds = _resolveQueryColumnBounds({ minWidth, maxWidth, capToMobileHalfScreen, mobileCapOffset });
-  wrap.style.setProperty(
-    queryVarName,
-    `${Math.max(bounds.minWidth, Math.min(bounds.maxWidth, Math.ceil(queryMax + padding)))}px`,
-  );
-};
-
-const _autoSizeMobileQueryColumn = ({
-  tableSelector,
-  wrapSelector,
-  minWidth,
-  maxWidth,
-  padding,
-  capToMobileHalfScreen = false,
-}) => {
-  const table = document.querySelector(tableSelector);
-  const wrap = document.querySelector(wrapSelector);
-  if (!table || !wrap) return;
-  const rows = Array.from(table.querySelectorAll("tbody tr"));
-  const header = table.querySelector("thead .query-col");
-  const sampleCell = table.querySelector("tbody td") || header;
-  if (!sampleCell || !header) return;
-  const font = window.getComputedStyle(sampleCell).font;
-  const queryIndex = header && header.cellIndex >= 0 ? header.cellIndex : 0;
-  const values = rows.map((row) => row.children[queryIndex]?.textContent?.trim() || "");
-  const headerText = header.textContent?.trim() || "Resort";
-  const bounds = _resolveQueryColumnBounds({ minWidth, maxWidth, capToMobileHalfScreen });
-  const width = Math.max(
-    bounds.minWidth,
-    Math.min(
-      bounds.maxWidth,
-      Math.ceil(Math.max(measureTextWidth(headerText, font), ...values.map((value) => measureTextWidth(value, font))) + padding),
-    ),
-  );
-  wrap.style.setProperty("--query-col-w", `${width}px`);
-  wrap.style.setProperty("--rain-query-w", `${width}px`);
-};
-
-const _autoSizeMobileRightColumns = ({
-  tableSelector,
-  wrapSelector,
-  weekSelector,
-  daySelector,
-  minWeekWidth,
-  minDayWidth,
-  maxWeekWidth = Number.POSITIVE_INFINITY,
-  maxDayWidth = Number.POSITIVE_INFINITY,
-}) => {
-  const table = document.querySelector(tableSelector);
-  const wrap = document.querySelector(wrapSelector);
-  if (!table || !wrap) return;
-  const weekCols = Array.from(table.querySelectorAll(weekSelector));
-  const dayCols = Array.from(table.querySelectorAll(daySelector));
-  const totalCols = weekCols.length + dayCols.length;
-  if (!totalCols) return;
-
-  const effectiveMinWeekWidth = Math.min(minWeekWidth, maxWeekWidth);
-  const effectiveMinDayWidth = Math.min(minDayWidth, maxDayWidth);
-  const minTotal = (effectiveMinWeekWidth * weekCols.length) + (effectiveMinDayWidth * dayCols.length);
-  const wrapWidth = wrap.clientWidth;
-  if (wrapWidth >= minTotal) {
-    const base = Math.floor(wrapWidth / totalCols);
-    const remainder = wrapWidth - (base * totalCols);
-    let totalWidth = 0;
-    [...weekCols, ...dayCols].forEach((col, index) => {
-      const isWeekCol = index < weekCols.length;
-      const minWidth = isWeekCol ? effectiveMinWeekWidth : effectiveMinDayWidth;
-      const maxWidth = isWeekCol ? maxWeekWidth : maxDayWidth;
-      const width = Math.max(minWidth, Math.min(maxWidth, base + (index < remainder ? 1 : 0)));
-      col.style.width = `${width}px`;
-      totalWidth += width;
-    });
-    table.style.width = `${totalWidth}px`;
-    return;
-  }
-
-  weekCols.forEach((col) => {
-    col.style.width = `${effectiveMinWeekWidth}px`;
-  });
-  dayCols.forEach((col) => {
-    col.style.width = `${effectiveMinDayWidth}px`;
-  });
-  table.style.width = `${minTotal}px`;
-};
-
-const _setFixedMobileHeights = (leftSelector, rightSelector, wrapSelector, stickyVar) => {
-  const leftTable = document.querySelector(leftSelector);
-  const rightTable = document.querySelector(rightSelector);
-  const splitWrap = document.querySelector(wrapSelector);
-  if (!leftTable || !rightTable) return;
-
-  const leftHeadRows = Array.from(leftTable.tHead?.rows || []);
-  const rightHeadRows = Array.from(rightTable.tHead?.rows || []);
-  const leftBodyRows = Array.from(leftTable.tBodies[0]?.rows || []);
-  const rightBodyRows = Array.from(rightTable.tBodies[0]?.rows || []);
-
-  const headRowHeights = [30, 30];
-  leftHeadRows.forEach((row, index) => { row.style.height = `${headRowHeights[index] || 30}px`; });
-  rightHeadRows.forEach((row, index) => { row.style.height = `${headRowHeights[index] || 30}px`; });
-  leftBodyRows.forEach((row) => { row.style.height = "30px"; });
-  rightBodyRows.forEach((row) => { row.style.height = "30px"; });
-
-  if (splitWrap) {
-    splitWrap.style.setProperty(stickyVar, `${headRowHeights[0]}px`);
-  }
-};
-
-const _stretchColumnsToWrap = ({
-  wrapSelector,
-  tableSelector,
-  colSelector,
-  minWidth,
-  maxWidth = Number.POSITIVE_INFINITY,
-  availableWidth = null,
-  tableWidthOffset = 0,
-}) => {
-  const wrap = document.querySelector(wrapSelector);
-  const table = document.querySelector(tableSelector);
-  if (!wrap || !table) return;
-  const cols = Array.from(table.querySelectorAll(colSelector));
-  const count = cols.length;
-  if (!count) return;
-
-  const effectiveMinWidth = Math.min(minWidth, maxWidth);
-  const stretchWidth = Math.max(0, availableWidth === null ? wrap.clientWidth : availableWidth);
-  const minTotal = effectiveMinWidth * count;
-  if (stretchWidth >= minTotal) {
-    const base = Math.floor(stretchWidth / count);
-    const remainder = stretchWidth - (base * count);
-    let totalWidth = 0;
-    cols.forEach((col, index) => {
-      const width = Math.max(effectiveMinWidth, Math.min(maxWidth, base + (index < remainder ? 1 : 0)));
-      col.style.width = `${width}px`;
-      totalWidth += width;
-    });
-    table.style.width = `${totalWidth + tableWidthOffset}px`;
-    return;
-  }
-
-  cols.forEach((col) => {
-    col.style.width = `${effectiveMinWidth}px`;
-  });
-  table.style.width = `${minTotal + tableWidthOffset}px`;
-};
-
-const autoSizeSplitTables = () => {
-  _autoSizeQueryOnly({
-    tableSelector: ".compact-grid-mobile-table",
-    wrapSelector: ".compact-grid-mobile-wrap",
-    queryVarName: "--compact-mobile-query-w",
-    minWidth: isCompactLayout() ? 120 : 150,
-    maxWidth: isCompactLayout() ? 180 : 240,
-    padding: isCompactLayout() ? 22 : 28,
-    capToMobileHalfScreen: isCompactLayout(),
-  });
-  _autoSizeQueryOnly({
-    tableSelector: ".temperature-sticky-wrap .temperature-single-table",
-    wrapSelector: ".temperature-sticky-wrap",
-    queryVarName: "--temp-query-w",
-    minWidth: 150,
-    maxWidth: 220,
-    capToMobileHalfScreen: isCompactLayout(),
-  });
-  _autoSizeQueryOnly({
-    tableSelector: ".weather-table-wrap .weather-table",
-    wrapSelector: ".weather-table-wrap",
-    queryVarName: "--weather-query-w",
-    minWidth: 150,
-    maxWidth: 220,
-    capToMobileHalfScreen: isCompactLayout(),
-  });
-  if (isCompactLayout()) {
-    const mobileColumnMax = _mobileHalfScreenCap();
-    const compactMobileDailyContext = _compactMobileDailyWidthContext();
-    const temperatureContext = _stickySingleTableWidthContext({
-      wrapSelector: ".temperature-sticky-wrap",
-      queryVarName: "--temp-query-w",
-    });
-    const weatherContext = _stickySingleTableWidthContext({
-      wrapSelector: ".weather-table-wrap",
-      queryVarName: "--weather-query-w",
-    });
-    const sunContext = _stickySingleTableWidthContext({
-      wrapSelector: ".sun-single-wrap",
-      queryVarName: "--sun-query-w",
-    });
-    _stretchColumnsToWrap({
-      wrapSelector: ".compact-grid-mobile-wrap",
-      tableSelector: ".compact-grid-mobile-table",
-      colSelector: "col.col-compact-day",
-      minWidth: 98,
-      maxWidth: mobileColumnMax,
-      availableWidth: compactMobileDailyContext.availableWidth,
-      tableWidthOffset: compactMobileDailyContext.reservedWidth,
-    });
-    _autoSizeQueryOnly({
-      tableSelector: ".snowfall-sticky-wrap.mobile-only .snowfall-sticky-table",
-      wrapSelector: ".snowfall-sticky-wrap.mobile-only",
-      queryVarName: "--snowfall-query-w",
-      minWidth: 150,
-      maxWidth: 220,
-      padding: 38,
-      capToMobileHalfScreen: true,
-      mobileCapOffset: 0,
-    });
-    _stretchColumnsToWrap({
-      wrapSelector: ".temperature-sticky-wrap",
-      tableSelector: ".temperature-single-table",
-      colSelector: "col.col-temp",
-      minWidth: 50,
-      maxWidth: mobileColumnMax,
-      availableWidth: temperatureContext.availableWidth,
-      tableWidthOffset: temperatureContext.reservedWidth,
-    });
-    _autoSizeQueryOnly({
-      tableSelector: ".rain-sticky-wrap.mobile-only .rain-sticky-table",
-      wrapSelector: ".rain-sticky-wrap.mobile-only",
-      queryVarName: "--rain-query-w",
-      minWidth: 150,
-      maxWidth: 220,
-      padding: 38,
-      capToMobileHalfScreen: true,
-      mobileCapOffset: 0,
-    });
-    _stretchColumnsToWrap({
-      wrapSelector: ".weather-table-wrap",
-      tableSelector: ".weather-table",
-      colSelector: "col.col-weather",
-      minWidth: 68,
-      maxWidth: mobileColumnMax,
-      availableWidth: weatherContext.availableWidth,
-      tableWidthOffset: weatherContext.reservedWidth,
-    });
-    _autoSizeQueryOnly({
-      tableSelector: ".sun-single-wrap .sun-single-table",
-      wrapSelector: ".sun-single-wrap",
-      queryVarName: "--sun-query-w",
-      minWidth: 150,
-      maxWidth: 220,
-      capToMobileHalfScreen: true,
-    });
-    _stretchColumnsToWrap({
-      wrapSelector: ".sun-single-wrap",
-      tableSelector: ".sun-single-table",
-      colSelector: "col.col-sun",
-      minWidth: 58,
-      maxWidth: mobileColumnMax,
-      availableWidth: sunContext.availableWidth,
-      tableWidthOffset: sunContext.reservedWidth,
-    });
-    return;
-  }
-  _autoSizeQueryOnly({
-    tableSelector: ".snowfall-sticky-wrap.desktop-only .snowfall-sticky-table",
-    wrapSelector: ".snowfall-sticky-wrap.desktop-only",
-    queryVarName: "--snowfall-query-w",
-  });
-  _autoSizeQueryOnly({
-    tableSelector: ".rain-sticky-wrap.desktop-only .rain-sticky-table",
-    wrapSelector: ".rain-sticky-wrap.desktop-only",
-    queryVarName: "--rain-query-w",
-  });
-  _autoSizeQueryOnly({
-    tableSelector: ".sun-single-wrap .sun-single-table",
-    wrapSelector: ".sun-single-wrap",
-    queryVarName: "--sun-query-w",
-  });
-  _stretchColumnsToWrap({
-    wrapSelector: ".sun-single-wrap",
-    tableSelector: ".sun-single-table",
-    colSelector: "col.col-sun",
-    minWidth: 58,
-  });
-};
-
-let layoutFrame = 0;
-let layoutObserver = null;
-let dynamicPayloadAbortController = null;
-
-const applyLayout = () => {
-  if (layoutFrame) cancelAnimationFrame(layoutFrame);
-  layoutFrame = requestAnimationFrame(() => {
-    layoutFrame = 0;
-    updateLayoutMode();
-    autoSizeSplitTables();
-    if (typeof stickySingleTableLayout.applyFromDom === "function") {
-      stickySingleTableLayout.applyFromDom({ root: pageContentRoot || document });
+  const resolveBootstrapUrl = (rawUrl) => {
+    const text = String(rawUrl || "").trim();
+    if (!text) throw new Error("Missing dataUrl bootstrap.");
+    if (/^[a-z][a-z0-9+.-]*:/i.test(text) || text.startsWith("//")) {
+      return new URL(text, window.location.href).toString();
     }
-  });
-};
+    const pathname = window.location.pathname || "/";
+    const normalizedPath = pathname.endsWith("/")
+      ? pathname
+      : (pathname.includes(".") ? pathname.replace(/[^/]+$/, "") : `${pathname}/`);
+    return new URL(text, `${window.location.origin}${normalizedPath}`).toString();
+  };
 
-const observeLayoutContainers = () => {
-  if (!window.ResizeObserver) return;
-  if (layoutObserver) layoutObserver.disconnect();
-  layoutObserver = new ResizeObserver(() => applyLayout());
-  const observed = new Set();
-  [
-    ".snowfall-sticky-wrap.desktop-only",
-    ".snowfall-sticky-wrap.mobile-only",
-    ".rain-sticky-wrap.desktop-only",
-    ".rain-sticky-wrap.mobile-only",
-    ".compact-grid-mobile-wrap",
-    ".temperature-sticky-wrap",
-    ".weather-table-wrap",
-    ".sun-single-wrap",
-  ].forEach((selector) => {
-    const element = document.querySelector(selector);
-    if (!element || observed.has(element)) return;
-    layoutObserver.observe(element);
-    observed.add(element);
-  });
-  document.querySelectorAll("[data-sticky-single-table-section]").forEach((element) => {
-    if (observed.has(element)) return;
-    layoutObserver.observe(element);
-    observed.add(element);
-  });
-};
+  const resolvedDataUrl = () => resolveBootstrapUrl(pageBootstrap.dataUrl);
 
-const getStoredUnitMode = (kind) => {
-  if (kind !== SUN_TIME_TOGGLE_KIND && fieldGuideUnits.readPreference) {
-    return fieldGuideUnits.readPreference();
-  }
-  try {
-    const saved = localStorage.getItem(`${UNIT_STORAGE_KEY_PREFIX}${kind}`);
-    return saved === "imperial" || saved === "metric" ? saved : "metric";
-  } catch (error) {
-    return "metric";
-  }
-};
-
-const syncCompactSummaryToggle = () => {
-  document.querySelectorAll(".unit-toggle[data-compact-summary-toggle='1']").forEach((toggle) => {
-    const mode = appState.compactSummaryUnitMode || "metric";
-    toggle.setAttribute("data-mode", mode);
-    toggle.querySelectorAll(".unit-btn[data-unit-mode]").forEach((button) => {
-      button.classList.toggle("is-active", button.getAttribute("data-unit-mode") === mode);
-    });
-  });
-};
-
-const syncSunTimeToggle = () => {
-  document.querySelectorAll(".unit-toggle[data-sun-time-toggle='1']").forEach((toggle) => {
-    const mode = appState.sunTimeToggleMode || "metric";
-    toggle.setAttribute("data-mode", mode);
-    toggle.querySelectorAll(".unit-btn[data-unit-mode]").forEach((button) => {
-      button.classList.toggle("is-active", button.getAttribute("data-unit-mode") === mode);
-    });
-  });
-};
-
-const renderCompactSummaryValues = () => {
-  const mode = appState.compactSummaryUnitMode || "metric";
-  document.querySelectorAll("[data-compact-unit-kind][data-compact-metric-value]").forEach((el) => {
-    const kind = String(el.getAttribute("data-compact-unit-kind") || "").trim();
-    const metricValue = Number(el.getAttribute("data-compact-metric-value"));
-    if (!Number.isFinite(metricValue)) return;
-    if (fieldGuideUnits.formatValue && ["temp", "snow", "rain"].includes(kind)) {
-      el.textContent = fieldGuideUnits.formatValue(kind, metricValue, mode, { withUnit: false, digits: kind === "temp" ? 0 : undefined });
-      return;
-    }
-    if (kind === "temp") {
-      el.textContent = mode === "imperial"
-        ? String(Math.round((metricValue * 9 / 5) + 32))
-        : String(Math.round(metricValue));
-      return;
-    }
-    if (kind === "snow") {
-      el.textContent = mode === "imperial"
-        ? (metricValue / 2.54).toFixed(1)
-        : metricValue.toFixed(1);
-      return;
-    }
-    if (kind === "rain") {
-      el.textContent = mode === "imperial"
-        ? (metricValue / 25.4).toFixed(2)
-        : metricValue.toFixed(1);
-    }
-  });
-  document.querySelectorAll("[data-compact-unit-label]").forEach((el) => {
-    const kind = String(el.getAttribute("data-compact-unit-label") || "").trim();
-    if (fieldGuideUnits.unitLabel && ["temp", "snow", "rain"].includes(kind)) {
-      el.textContent = fieldGuideUnits.unitLabel(kind, mode);
-      return;
-    }
-    if (kind === "snow") el.textContent = mode === "imperial" ? "in" : "cm";
-    if (kind === "temp") el.textContent = mode === "imperial" ? "°F" : "°C";
-    if (kind === "rain") el.textContent = mode === "imperial" ? "in" : "mm";
-  });
-};
-
-const renderSunTimeValues = () => {
-  const mode = appState.sunTimeToggleMode || "metric";
-  document.querySelectorAll("[data-sun-time-raw]").forEach((el) => {
-    const raw = String(el.getAttribute("data-sun-time-raw") || "").trim();
-    if (!raw) {
-      el.textContent = "";
-      return;
-    }
-    if (mode !== "imperial") {
-      el.textContent = raw;
-      return;
-    }
-    const match = /^(\d{2}):(\d{2})$/.exec(raw);
-    if (!match) {
-      el.textContent = raw;
-      return;
-    }
-    const hour24 = Number(match[1]);
-    if (!Number.isFinite(hour24)) {
-      el.textContent = raw;
-      return;
-    }
-    const minute = match[2];
-    const suffix = hour24 >= 12 ? "PM" : "AM";
-    const hour12 = hour24 % 12 || 12;
-    el.textContent = `${hour12}:${minute} ${suffix}`;
-  });
-};
-
-const formatMeasure = (metricValue, kind, mode) => {
-  if (fieldGuideUnits.formatValue) {
-    return fieldGuideUnits.formatValue(kind, metricValue, mode, { withUnit: false });
-  }
-  if (mode === "imperial") {
-    if (kind === "snow") return (metricValue / 2.54).toFixed(1);
-    if (kind === "rain") return (metricValue / 25.4).toFixed(2);
-    if (kind === "temp") return ((metricValue * 9 / 5) + 32).toFixed(1);
-  }
-  if (kind === "rain") return metricValue.toFixed(1);
-  return metricValue.toFixed(1);
-};
-
-const renderUnitValues = (kind, mode) => {
-  document.querySelectorAll(`td[data-kind="${kind}"][data-metric-value]`).forEach((cell) => {
-    const metricValue = Number(cell.getAttribute("data-metric-value"));
-    if (!Number.isFinite(metricValue)) return;
-    cell.textContent = formatMeasure(metricValue, kind, mode);
-  });
-};
-
-const syncToggleButtons = () => {
-  document.querySelectorAll(".unit-toggle[data-target-kind]").forEach((toggle) => {
-    const kind = toggle.getAttribute("data-target-kind");
-    const mode = appState.unitModes[kind] || "metric";
-    toggle.setAttribute("data-mode", mode);
-    toggle.querySelectorAll(".unit-btn[data-unit-mode]").forEach((button) => {
-      button.classList.toggle("is-active", button.getAttribute("data-unit-mode") === mode);
-    });
-  });
-};
-
-const applyUnitModes = () => {
-  Object.entries(appState.unitModes).forEach(([kind, mode]) => {
-    renderUnitValues(kind, mode);
-  });
-  renderCompactSummaryValues();
-  renderSunTimeValues();
-  syncToggleButtons();
-  syncCompactSummaryToggle();
-  syncSunTimeToggle();
-};
-
-const applySiteUnitMode = (mode) => {
-  const normalizedMode = mode === "imperial" ? "imperial" : "metric";
-  Object.keys(appState.unitModes).forEach((kind) => {
-    appState.unitModes[kind] = normalizedMode;
-  });
-  appState.compactSummaryUnitMode = normalizedMode;
-  applyUnitModes();
-  applyLayout();
-};
-
-const persistSiteUnitMode = (mode) => {
-  const normalizedMode = mode === "imperial" ? "imperial" : "metric";
-  if (fieldGuideUnits.setMode) {
-    fieldGuideUnits.setMode(normalizedMode);
-    return;
-  }
-  try {
-    VALID_UNIT_KINDS.forEach((kind) => localStorage.setItem(`${UNIT_STORAGE_KEY_PREFIX}${kind}`, normalizedMode));
-    localStorage.setItem(`${UNIT_STORAGE_KEY_PREFIX}${COMPACT_SUMMARY_UNIT_KIND}`, normalizedMode);
-  } catch (error) {
-    // Ignore storage failures.
-  }
-  applySiteUnitMode(normalizedMode);
-};
-
-const setUnitMode = (kind, mode) => {
-  if (!VALID_UNIT_KINDS.has(kind)) return;
-  persistSiteUnitMode(mode);
-};
-
-const setCompactSummaryUnitMode = (mode) => persistSiteUnitMode(mode);
-
-const setSunTimeToggleMode = (mode) => {
-  appState.sunTimeToggleMode = mode === "imperial" ? "imperial" : "metric";
-  try {
-    localStorage.setItem(`${UNIT_STORAGE_KEY_PREFIX}${SUN_TIME_TOGGLE_KIND}`, appState.sunTimeToggleMode);
-  } catch (error) {
-    // Ignore storage failures.
-  }
-  renderSunTimeValues();
-  syncSunTimeToggle();
-};
-
-const oppositeUnitMode = (mode) => (mode === "imperial" ? "metric" : "imperial");
-
-const renderReportDate = () => {
-  if (!reportDateEl) return;
-  const raw = appState.payload && appState.payload.generated_at_utc
-    ? appState.payload.generated_at_utc
-    : reportDateEl.getAttribute("data-generated-utc");
-  const utcDate = raw ? new Date(raw) : null;
-  if (!utcDate || Number.isNaN(utcDate.getTime())) return;
-  const tz = Intl.DateTimeFormat().resolvedOptions().timeZone || "local";
-  reportDateEl.textContent = `Generated At: ${utcDate.toLocaleString(undefined, {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-    hour12: false,
-    timeZoneName: "short",
-  })} (${tz})`;
-};
-
-const renderPage = () => {
-  if (!pageContentRoot || !appState.payload) return;
-  const visibleReports = _filteredReports();
-  const totalReports = _payloadReports().length;
-  const keyword = _normalizeSearch(appState.filterState.search);
-  const searchAllActive = Boolean(keyword) && appState.filterState.searchAll;
-  const emptyMessage = !searchAllActive && appState.filterState.favoritesOnly && appState.favoriteResortIds.size === 0
-    ? "No favorite resorts yet. Tap the heart icon to save some."
-    : (appState.filterState.favoritesOnly
-      ? "No favorite resorts match the current filters."
-      : "No resorts match the current filters.");
-  updateLayoutMode();
-  pageContentRoot.innerHTML = _renderSections(visibleReports, emptyMessage);
-  applyLayout();
-  observeLayoutContainers();
-  pageContentRoot.removeAttribute("data-loading");
-  syncFilterSummary(visibleReports.length, totalReports);
-  renderReportDate();
-  applyUnitModes();
-  document.body.classList.remove("units-pending");
-};
-
-const _SCROLLABLE_WRAP_SELECTORS = [
-  ".compact-grid-mobile-wrap",
-  ".snowfall-sticky-wrap.desktop-only",
-  ".snowfall-sticky-wrap.mobile-only",
-  ".rain-sticky-wrap.desktop-only",
-  ".rain-sticky-wrap.mobile-only",
-  ".temperature-sticky-wrap",
-  ".weather-table-wrap",
-  ".sun-single-wrap",
-];
-
-const _captureWrapScrollPositions = () => {
-  const entries = [];
-  const seen = new Set();
-  _SCROLLABLE_WRAP_SELECTORS.forEach((selector) => {
-    const element = document.querySelector(selector);
-    if (!element || seen.has(element)) return;
-    entries.push({
-      selector,
-      sectionKey: "",
-      scrollTop: element.scrollTop,
-      scrollLeft: element.scrollLeft,
-    });
-    seen.add(element);
-  });
-  document.querySelectorAll("[data-sticky-single-table-section]").forEach((element) => {
-    if (seen.has(element)) return;
-    const sectionKey = String(element.getAttribute("data-sticky-single-table-section") || "").trim();
-    entries.push({
-      selector: "",
-      sectionKey,
-      scrollTop: element.scrollTop,
-      scrollLeft: element.scrollLeft,
-    });
-    seen.add(element);
-  });
-  return entries;
-};
-
-const _restoreWrapScrollPositions = (positions) => {
-  positions.forEach((entry) => {
-    let element = null;
-    if (entry.sectionKey) {
-      const escapedSectionKey = String(entry.sectionKey).replace(/"/g, "\\\"");
-      element = document.querySelector(`[data-sticky-single-table-section="${escapedSectionKey}"]`);
-    }
-    if (!element && entry.selector) {
-      element = document.querySelector(entry.selector);
-    }
-    if (!element) return;
-    element.scrollTop = entry.scrollTop;
-    element.scrollLeft = entry.scrollLeft;
-  });
-};
-
-const renderPagePreservingScroll = () => {
-  const scrollX = window.scrollX;
-  const scrollY = window.scrollY;
-  const wrapScrollPositions = _captureWrapScrollPositions();
-  if (document.activeElement instanceof HTMLElement) {
-    document.activeElement.blur();
-  }
-  renderPage();
-  window.requestAnimationFrame(() => {
-    _restoreWrapScrollPositions(wrapScrollPositions);
-    window.scrollTo(scrollX, scrollY);
-    window.requestAnimationFrame(() => {
-      _restoreWrapScrollPositions(wrapScrollPositions);
-      window.scrollTo(scrollX, scrollY);
-    });
-  });
-};
-
-const renderSubregionOptions = () => {
-  if (!filterRegionOptions) return;
-  const selected = appState.filterState.subregions;
-  const counts = appState.availableFilters.subregion || {};
-  const rows = SUBREGION_OPTIONS
-    .filter((option) => Number(counts[option.value] || 0) > 0 || selected.has(option.value))
-    .map((option) => {
-      const count = Number(counts[option.value] || 0);
-      const checked = selected.has(option.value) ? " checked" : "";
-      const countHtml = count > 0 ? ` <span class=\"filter-count\">(${count})</span>` : "";
-      return `<label><input type=\"checkbox\" name=\"filter-subregion\" value=\"${option.value}\"${checked} /> ${option.label}${countHtml}</label>`;
-    });
-  filterRegionOptions.innerHTML = rows.length > 0 ? rows.join("") : "<div class='filter-option-empty'>No region filters available.</div>";
-};
-
-const updateFilterLabels = () => {
-  document.querySelectorAll("[data-pass-count]").forEach((el) => {
-    const key = _normalizeSearch(el.getAttribute("data-pass-count") || "");
-    const count = Number((appState.availableFilters.pass_type || {})[key] || 0);
-    el.textContent = count > 0 ? `(${count})` : "";
-  });
-  renderSubregionOptions();
-};
-
-const closeFilterModal = () => {
-  if (filterModal) filterModal.hidden = true;
-};
-
-const openFilterModal = () => {
-  if (filterModal) filterModal.hidden = false;
-};
-
-const loadPayload = async (url = _resolvedDataUrl(), options = {}) => {
-  const response = await fetch(url, options);
-  const payload = await response.json();
-  if (!response.ok) {
-    throw new Error(payload && payload.error ? payload.error : `HTTP ${response.status}`);
-  }
-  return payload;
-};
-
-const reloadDynamicPayloadForFilters = async () => {
-  const endpoint = new URL(_resolvedDataUrl());
-  endpoint.search = buildServerQueryParams().toString();
-  if (dynamicPayloadAbortController) dynamicPayloadAbortController.abort();
-  const controller = new AbortController();
-  dynamicPayloadAbortController = controller;
-  try {
-    const payload = await loadPayload(endpoint.toString(), { signal: controller.signal });
-    if (dynamicPayloadAbortController !== controller) return;
-    appState.payload = payload;
-    appState.reports = _payloadReports();
-    appState.availableFilters = _availableFilters();
-    updateFilterLabels();
-  } finally {
-    if (dynamicPayloadAbortController === controller) dynamicPayloadAbortController = null;
-  }
-};
-
-const resetFilterControls = () => {
-  filterPassTypeInputs.forEach((input) => { input.checked = false; });
-  if (filterRegionOptions) {
-    filterRegionOptions.querySelectorAll("input[name='filter-subregion']").forEach((input) => { input.checked = false; });
-  }
-  if (filterSortSelect) filterSortSelect.value = "week_snow";
-  if (filterIncludeAllInput) filterIncludeAllInput.checked = true;
-  if (filterSearchAllInput) filterSearchAllInput.checked = true;
-  setFavoritesOnlyControls(false);
-  if (resortSearchInput) resortSearchInput.value = "";
-};
-
-let scheduledFilterApplyTimeout = 0;
-
-const cancelScheduledFilterApply = () => {
-  if (!scheduledFilterApplyTimeout) return;
-  window.clearTimeout(scheduledFilterApplyTimeout);
-  scheduledFilterApplyTimeout = 0;
-};
-
-const scheduleApplyFilters = (delayMs = 120) => {
-  cancelScheduledFilterApply();
-  scheduledFilterApplyTimeout = window.setTimeout(() => {
-    scheduledFilterApplyTimeout = 0;
-    void applyFiltersImmediately();
-  }, delayMs);
-};
-
-const applyFiltersImmediately = async () => {
-  cancelScheduledFilterApply();
-  applyFilterStateFromControls();
-  syncUrlFromFilterState();
-  if (_isDynamicApiDataUrl()) {
+  const isDynamicApiDataUrl = () => {
     try {
-      await reloadDynamicPayloadForFilters();
-    } catch (error) {
-      if (error && error.name === "AbortError") return;
-      renderPageLoadError(error);
-      return;
+      return new URL(resolvedDataUrl()).pathname.endsWith("/api/data");
+    } catch (_error) {
+      return false;
     }
-  }
-  renderPage();
-};
+  };
 
-const bindControls = () => {
-  window.addEventListener("closesnow:unitschange", (event) => {
-    applySiteUnitMode(event?.detail?.mode);
-  });
-  if (resortSearchInput) {
-    resortSearchInput.addEventListener("input", () => {
-      scheduleApplyFilters();
+  const loadFavoriteResortIds = () => {
+    try {
+      const parsed = JSON.parse(localStorage.getItem(FAVORITES_STORAGE_KEY) || "[]");
+      if (!Array.isArray(parsed)) return [];
+      return Array.from(new Set(parsed.map((value) => String(value || "").trim()).filter(Boolean)));
+    } catch (_error) {
+      return [];
+    }
+  };
+
+  const persistFavoriteResortIds = () => {
+    try {
+      localStorage.setItem(FAVORITES_STORAGE_KEY, JSON.stringify([...appState.favoriteResortIds].sort()));
+    } catch (_error) {
+      // Storage can be unavailable in private or embedded browsing contexts.
+    }
+  };
+
+  const toggleFavorite = (resortId) => {
+    const normalized = String(resortId || "").trim();
+    if (!normalized) return;
+    if (appState.favoriteResortIds.has(normalized)) appState.favoriteResortIds.delete(normalized);
+    else appState.favoriteResortIds.add(normalized);
+    persistFavoriteResortIds();
+  };
+
+  const deriveAvailableFilters = (reports) => {
+    const output = { pass_type: {}, region: {}, subregion: {} };
+    reports.forEach((report) => {
+      const region = normalizeSearch(report.region);
+      const subregion = normalizeSearch(report.subregion);
+      if (region) output.region[region] = (output.region[region] || 0) + 1;
+      if (subregion) output.subregion[subregion] = (output.subregion[subregion] || 0) + 1;
+      (Array.isArray(report.pass_types) ? report.pass_types : []).forEach((passType) => {
+        const key = normalizeSearch(passType);
+        if (key) output.pass_type[key] = (output.pass_type[key] || 0) + 1;
+      });
     });
-  }
-  if (resortSearchClear) {
-    resortSearchClear.addEventListener("click", () => {
+    return output;
+  };
+
+  const availableFilters = () => {
+    if (Object.keys(filterMetaAvailable).length) {
+      return {
+        pass_type: typeof filterMetaAvailable.pass_type === "object" ? filterMetaAvailable.pass_type : {},
+        region: typeof filterMetaAvailable.region === "object" ? filterMetaAvailable.region : {},
+        subregion: typeof filterMetaAvailable.subregion === "object" ? filterMetaAvailable.subregion : {},
+      };
+    }
+    return deriveAvailableFilters(payloadReports());
+  };
+
+  const loadStoredFilterState = () => (typeof filterHelpers.loadStoredFilterState === "function"
+    ? filterHelpers.loadStoredFilterState(localStorage, FILTER_STORAGE_KEY)
+    : null);
+
+  const persistFilterState = () => {
+    if (typeof filterHelpers.persistFilterState !== "function") return;
+    filterHelpers.persistFilterState(localStorage, FILTER_STORAGE_KEY, appState.filterState);
+  };
+
+  const setFavoritesOnlyControls = (checked) => {
+    if (favoritesOnlyToggle) favoritesOnlyToggle.checked = Boolean(checked);
+    if (filterFavoritesOnlyInput) filterFavoritesOnlyInput.checked = Boolean(checked);
+  };
+
+  const applyControlsFromQueryOrMeta = () => {
+    const params = new URLSearchParams(window.location.search);
+    const stored = loadStoredFilterState();
+    const urlPassTypes = parsePassTypeValues(params.getAll("pass_type"));
+    const urlSubregions = parseSubregionValues(params.getAll("subregion"));
+    const metaPassTypes = parsePassTypeValues(Array.isArray(filterMetaApplied.pass_type) ? filterMetaApplied.pass_type : []);
+    const metaSubregions = parseSubregionValues(
+      Array.isArray(filterMetaApplied.subregion)
+        ? filterMetaApplied.subregion
+        : (filterMetaApplied.subregion ? [filterMetaApplied.subregion] : []),
+    );
+    const passTypes = urlPassTypes.length ? urlPassTypes : (stored?.passTypes || metaPassTypes);
+    const subregions = urlSubregions.length ? urlSubregions : (stored?.subregions || metaSubregions);
+    const sortBy = params.has("sort_by")
+      ? normalizeSortBy(params.get("sort_by"))
+      : (stored?.sortBy || normalizeSortBy(filterMetaApplied.sort_by || "week_snow"));
+    const search = params.has("search")
+      ? params.get("search")
+      : (stored?.search ?? String(filterMetaApplied.search || ""));
+    const searchAll = params.has("search_all")
+      ? isTruthyParam(params.get("search_all"))
+      : (stored?.searchAll ?? (Object.prototype.hasOwnProperty.call(filterMetaApplied, "search_all") ? Boolean(filterMetaApplied.search_all) : true));
+    const includeDefault = params.has("include_default")
+      ? isTruthyParam(params.get("include_default"))
+      : (params.has("include_all")
+        ? !isTruthyParam(params.get("include_all"))
+        : (stored?.includeDefault ?? (Object.prototype.hasOwnProperty.call(filterMetaApplied, "include_default")
+          ? Boolean(filterMetaApplied.include_default)
+          : !Boolean(filterMetaApplied.include_all))));
+    const favoritesOnly = Boolean(stored?.favoritesOnly);
+
+    appState.filterState = {
+      passTypes: new Set(passTypes),
+      subregions: new Set(subregions),
+      sortBy,
+      includeDefault,
+      searchAll,
+      search: String(search || ""),
+      favoritesOnly,
+    };
+    filterPassTypeInputs.forEach((input) => { input.checked = appState.filterState.passTypes.has(normalizeSearch(input.value)); });
+    filterRegionOptions?.querySelectorAll("input[name='filter-subregion']").forEach((input) => {
+      input.checked = appState.filterState.subregions.has(normalizeSearch(input.value));
+    });
+    if (filterSortSelect) filterSortSelect.value = sortBy;
+    if (filterIncludeAllInput) filterIncludeAllInput.checked = includeDefault;
+    if (filterSearchAllInput) filterSearchAllInput.checked = searchAll;
+    if (resortSearchInput) resortSearchInput.value = appState.filterState.search;
+    setFavoritesOnlyControls(favoritesOnly);
+  };
+
+  const applyFilterStateFromControls = () => {
+    appState.filterState.passTypes = new Set(filterPassTypeInputs
+      .filter((input) => input.checked)
+      .map((input) => normalizeSearch(input.value)));
+    appState.filterState.subregions = new Set(Array.from(
+      filterRegionOptions?.querySelectorAll("input[name='filter-subregion']:checked") || [],
+    ).map((input) => normalizeSearch(input.value)));
+    appState.filterState.sortBy = normalizeSortBy(filterSortSelect?.value || "week_snow");
+    appState.filterState.includeDefault = Boolean(filterIncludeAllInput?.checked);
+    appState.filterState.searchAll = Boolean(filterSearchAllInput?.checked);
+    appState.filterState.search = String(resortSearchInput?.value || "");
+    appState.filterState.favoritesOnly = Boolean(favoritesOnlyToggle?.checked || filterFavoritesOnlyInput?.checked);
+    setFavoritesOnlyControls(appState.filterState.favoritesOnly);
+    persistFilterState();
+  };
+
+  const buildServerQueryParams = () => {
+    const params = new URLSearchParams();
+    [...appState.filterState.passTypes].sort().forEach((value) => params.append("pass_type", value));
+    [...appState.filterState.subregions].sort().forEach((value) => params.append("subregion", value));
+    if (appState.filterState.search) params.set("search", appState.filterState.search);
+    params.set("search_all", appState.filterState.searchAll ? "1" : "0");
+    params.set(appState.filterState.includeDefault ? "include_default" : "include_all", "1");
+    return params;
+  };
+
+  const reportSearchText = (report) => {
+    const passTypes = Array.isArray(report.pass_types) ? report.pass_types.join(" ") : "";
+    const searchTerms = Array.isArray(report.search_terms) ? report.search_terms.join(" ") : "";
+    return normalizeSearch([
+      displayName(report), report.query, report.city, report.admin1, report.state_name,
+      report.country, report.country_code, report.country_name, report.address, passTypes, searchTerms,
+    ].filter(Boolean).join(" "));
+  };
+
+  const filteredReports = () => {
+    const keyword = normalizeSearch(appState.filterState.search);
+    const searchAllActive = Boolean(keyword) && appState.filterState.searchAll;
+    const reports = payloadReports().filter((report) => {
+      if (keyword && !reportSearchText(report).includes(keyword)) return false;
+      if (searchAllActive) return true;
+      const resortId = String(report.resort_id || "").trim();
+      if (appState.filterState.favoritesOnly && !appState.favoriteResortIds.has(resortId)) return false;
+      if (appState.filterState.includeDefault && !Boolean(report.default_resort || report.ljcc_favorite)) return false;
+      if (appState.filterState.passTypes.size) {
+        const reportPasses = new Set((Array.isArray(report.pass_types) ? report.pass_types : []).map(normalizeSearch));
+        if (![...appState.filterState.passTypes].some((passType) => reportPasses.has(passType))) return false;
+      }
+      if (appState.filterState.subregions.size) {
+        const reportRegion = normalizeSearch(report.subregion || report.region);
+        if (!appState.filterState.subregions.has(reportRegion)) return false;
+      }
+      return true;
+    });
+
+    const sortBy = appState.filterState.sortBy;
+    reports.sort((a, b) => {
+      if (sortBy === "favorites") {
+        const favoriteDelta = Number(appState.favoriteResortIds.has(String(b.resort_id || "")))
+          - Number(appState.favoriteResortIds.has(String(a.resort_id || "")));
+        if (favoriteDelta) return favoriteDelta;
+      }
+      if (sortBy === "today_snow") {
+        const delta = compareDescending(a, b, (report) => asFiniteNumber(dailyAt(report, 0).snowfall_cm));
+        if (delta) return delta;
+      }
+      if (sortBy === "week_snow") {
+        const delta = compareDescending(a, b, weeklySnowfall);
+        if (delta) return delta;
+      }
+      if (sortBy === "next_week_snow") {
+        const delta = compareDescending(a, b, nextWeekSnowfall);
+        if (delta) return delta;
+      }
+      if (sortBy === "two_week_snow") {
+        const delta = compareDescending(a, b, twoWeekSnowfall);
+        if (delta) return delta;
+      }
+      if (sortBy === "name") return displayName(a).localeCompare(displayName(b));
+      const stateDelta = String(a.admin1 || "").localeCompare(String(b.admin1 || ""));
+      return stateDelta || displayName(a).localeCompare(displayName(b));
+    });
+    return reports;
+  };
+
+  const activeFilterTotal = () => (
+    appState.filterState.passTypes.size
+    + appState.filterState.subregions.size
+    + Number(appState.filterState.favoritesOnly)
+    + Number(!appState.filterState.includeDefault)
+    + Number(Boolean(normalizeSearch(appState.filterState.search)))
+  );
+
+  const subregionLabel = (value) => SUBREGION_OPTIONS.find((option) => option.value === normalizeSearch(value))?.label || value;
+
+  const syncFilterSummary = (visibleCount, totalCount) => {
+    const details = [];
+    if (appState.filterState.favoritesOnly) details.push("favorites");
+    if (appState.filterState.passTypes.size) details.push([...appState.filterState.passTypes].map((value) => value.toUpperCase()).join(" / "));
+    if (appState.filterState.subregions.size) details.push([...appState.filterState.subregions].map(subregionLabel).join(" / "));
+    if (!appState.filterState.includeDefault) details.push("all supported resorts");
+    if (normalizeSearch(appState.filterState.search)) details.push(`search: “${appState.filterState.search.trim()}”`);
+    const suffix = details.length ? ` · ${details.join(" · ")}` : "";
+    if (filterSummary) filterSummary.textContent = `${visibleCount} of ${totalCount} resorts · ${sortLabel(appState.filterState.sortBy)}${suffix}`;
+    if (visibleResortCountEl) visibleResortCountEl.textContent = `${visibleCount} of ${totalCount} resorts`;
+    if (activeFilterCount) {
+      const count = activeFilterTotal();
+      activeFilterCount.hidden = count === 0;
+      activeFilterCount.textContent = String(count);
+      activeFilterCount.setAttribute("aria-label", `${count} active filter${count === 1 ? "" : "s"}`);
+    }
+  };
+
+  const renderReportMetadata = () => {
+    const raw = appState.payload?.generated_at_utc || reportDateEl?.getAttribute("data-generated-utc");
+    const generated = raw ? new Date(raw) : null;
+    if (reportDateEl && generated && !Number.isNaN(generated.getTime())) {
+      reportDateEl.textContent = generated.toLocaleString(undefined, {
+        month: "short", day: "numeric", hour: "numeric", minute: "2-digit", timeZoneName: "short",
+      });
+    }
+    if (reportModelEl) {
+      const model = String(appState.payload?.model || "ecmwf_ifs025");
+      reportModelEl.textContent = model === "ecmwf_ifs025" ? "ECMWF IFS 0.25°" : model.replaceAll("_", " ").toUpperCase();
+    }
+    unitStatusEls.forEach((element) => { element.textContent = appState.unitMode === "imperial" ? "Imperial" : "Metric"; });
+  };
+
+  const captureOpenDisclosures = () => new Set(Array.from(
+    pageContentRoot?.querySelectorAll("details[data-resort-disclosure][open]") || [],
+  ).map((details) => details.getAttribute("data-resort-disclosure")));
+
+  const restoreOpenDisclosures = (ids) => {
+    pageContentRoot?.querySelectorAll("details[data-resort-disclosure]").forEach((details) => {
+      if (ids.has(details.getAttribute("data-resort-disclosure"))) details.open = true;
+    });
+  };
+
+  const emptyStateMessage = () => {
+    if (appState.filterState.favoritesOnly && appState.favoriteResortIds.size === 0) {
+      return "You have not saved any favorites yet. Turn off Favorites only, then use the heart button on a resort.";
+    }
+    if (normalizeSearch(appState.filterState.search)) return "No resort matched that search with the current scope. Try a broader name, state, country, or pass.";
+    return "No resort matched the current filters. Reset the filters to return to the full morning report.";
+  };
+
+  const renderPage = (options = {}) => {
+    if (!pageContentRoot || !appState.payload || typeof homepage.render !== "function") return;
+    const openDisclosures = captureOpenDisclosures();
+    const visibleReports = filteredReports();
+    pageContentRoot.innerHTML = homepage.render(visibleReports, {
+      mode: appState.unitMode,
+      favorites: appState.favoriteResortIds,
+      emptyMessage: emptyStateMessage(),
+    });
+    restoreOpenDisclosures(openDisclosures);
+    pageContentRoot.removeAttribute("data-loading");
+    pageContentRoot.setAttribute("aria-busy", "false");
+    syncFilterSummary(visibleReports.length, payloadReports().length);
+    renderReportMetadata();
+    document.body.classList.remove("units-pending");
+    if (options.focusFavoriteId) {
+      const selectorId = window.CSS?.escape ? window.CSS.escape(options.focusFavoriteId) : options.focusFavoriteId.replaceAll("\"", "\\\"");
+      pageContentRoot.querySelector(`.favorite-btn[data-resort-id="${selectorId}"]`)?.focus();
+    }
+  };
+
+  const renderPagePreservingPosition = (options = {}) => {
+    const scrollX = window.scrollX;
+    const scrollY = window.scrollY;
+    renderPage(options);
+    window.requestAnimationFrame(() => window.scrollTo(scrollX, scrollY));
+  };
+
+  const renderSubregionOptions = () => {
+    if (!filterRegionOptions) return;
+    const selected = appState.filterState.subregions;
+    const counts = appState.availableFilters.subregion || {};
+    const html = SUBREGION_OPTIONS
+      .filter((option) => Number(counts[option.value] || 0) > 0 || selected.has(option.value))
+      .map((option) => {
+        const count = Number(counts[option.value] || 0);
+        return `<label><input type="checkbox" name="filter-subregion" value="${option.value}"${selected.has(option.value) ? " checked" : ""} /> <span>${option.label}</span><small>${count}</small></label>`;
+      }).join("");
+    filterRegionOptions.innerHTML = html || `<p class="filter-option-empty">Region filters are not available for this report.</p>`;
+  };
+
+  const updateFilterLabels = () => {
+    document.querySelectorAll("[data-pass-count]").forEach((element) => {
+      const count = Number(appState.availableFilters.pass_type?.[normalizeSearch(element.getAttribute("data-pass-count"))] || 0);
+      element.textContent = count ? `(${count})` : "";
+    });
+    renderSubregionOptions();
+  };
+
+  let focusBeforeFilter = null;
+  const filterFocusable = () => Array.from(filterModal?.querySelectorAll(
+    "button:not([disabled]), input:not([disabled]), select:not([disabled]), [href], [tabindex]:not([tabindex='-1'])",
+  ) || []).filter((element) => !element.hidden && element.getClientRects().length > 0);
+
+  const openFilterModal = () => {
+    if (!filterModal) return;
+    focusBeforeFilter = document.activeElement;
+    filterModal.hidden = false;
+    document.body.classList.add("filter-sheet-open");
+    window.requestAnimationFrame(() => filterCloseBtn?.focus());
+  };
+
+  const closeFilterModal = (restoreFocus = true) => {
+    if (!filterModal) return;
+    filterModal.hidden = true;
+    document.body.classList.remove("filter-sheet-open");
+    if (restoreFocus && focusBeforeFilter instanceof HTMLElement) focusBeforeFilter.focus();
+  };
+
+  const loadPayload = async (url = resolvedDataUrl(), options = {}) => {
+    const response = await fetch(url, options);
+    let payload;
+    try {
+      payload = await response.json();
+    } catch (_error) {
+      throw new Error("The forecast service returned an unreadable response. Please try again.");
+    }
+    if (!response.ok) throw new Error(payload?.error || `Forecast request failed (${response.status}).`);
+    return payload;
+  };
+
+  let dynamicPayloadAbortController = null;
+  const reloadDynamicPayloadForFilters = async () => {
+    const endpoint = new URL(resolvedDataUrl());
+    endpoint.search = buildServerQueryParams().toString();
+    dynamicPayloadAbortController?.abort();
+    const controller = new AbortController();
+    dynamicPayloadAbortController = controller;
+    try {
+      appState.payload = await loadPayload(endpoint.toString(), { signal: controller.signal });
+      appState.availableFilters = availableFilters();
+      updateFilterLabels();
+    } finally {
+      if (dynamicPayloadAbortController === controller) dynamicPayloadAbortController = null;
+    }
+  };
+
+  const renderPageLoadError = (error) => {
+    if (!pageContentRoot) return;
+    const wrapper = document.createElement("section");
+    wrapper.className = "page-load-error";
+    const heading = document.createElement("h2");
+    heading.textContent = "The morning report could not load";
+    const detail = document.createElement("p");
+    detail.textContent = error instanceof Error ? error.message : String(error);
+    wrapper.append(heading, detail);
+    pageContentRoot.replaceChildren(wrapper);
+    pageContentRoot.setAttribute("aria-busy", "false");
+    document.body.classList.remove("units-pending");
+  };
+
+  const resetFilterControls = () => {
+    filterPassTypeInputs.forEach((input) => { input.checked = false; });
+    filterRegionOptions?.querySelectorAll("input[name='filter-subregion']").forEach((input) => { input.checked = false; });
+    if (filterSortSelect) filterSortSelect.value = "week_snow";
+    if (filterIncludeAllInput) filterIncludeAllInput.checked = true;
+    if (filterSearchAllInput) filterSearchAllInput.checked = true;
+    if (resortSearchInput) resortSearchInput.value = "";
+    setFavoritesOnlyControls(false);
+  };
+
+  let scheduledFilterApplyTimeout = 0;
+  const cancelScheduledFilterApply = () => {
+    if (!scheduledFilterApplyTimeout) return;
+    window.clearTimeout(scheduledFilterApplyTimeout);
+    scheduledFilterApplyTimeout = 0;
+  };
+
+  const applyFiltersImmediately = async () => {
+    cancelScheduledFilterApply();
+    applyFilterStateFromControls();
+    if (isDynamicApiDataUrl()) {
+      try {
+        await reloadDynamicPayloadForFilters();
+      } catch (error) {
+        if (error?.name === "AbortError") return;
+        renderPageLoadError(error);
+        return;
+      }
+    }
+    renderPage();
+  };
+
+  const scheduleApplyFilters = () => {
+    cancelScheduledFilterApply();
+    scheduledFilterApplyTimeout = window.setTimeout(() => {
+      scheduledFilterApplyTimeout = 0;
+      void applyFiltersImmediately();
+    }, 140);
+  };
+
+  const bindControls = () => {
+    window.addEventListener("closesnow:unitschange", (event) => {
+      appState.unitMode = event?.detail?.mode === "imperial" ? "imperial" : "metric";
+      renderPagePreservingPosition();
+    });
+    resortSearchInput?.addEventListener("input", scheduleApplyFilters);
+    resortSearchClear?.addEventListener("click", () => {
       if (resortSearchInput) resortSearchInput.value = "";
-      applyFiltersImmediately();
+      void applyFiltersImmediately();
+      resortSearchInput?.focus();
     });
-  }
-  if (filterOpenBtn) filterOpenBtn.addEventListener("click", openFilterModal);
-  if (filterCloseBtn) filterCloseBtn.addEventListener("click", closeFilterModal);
-  if (filterResetBtn) {
-    filterResetBtn.addEventListener("click", () => {
+    filterOpenBtn?.addEventListener("click", openFilterModal);
+    filterCloseBtn?.addEventListener("click", () => closeFilterModal());
+    filterDoneBtn?.addEventListener("click", () => closeFilterModal());
+    filterResetBtn?.addEventListener("click", () => {
       resetFilterControls();
-      applyFiltersImmediately();
+      void applyFiltersImmediately();
     });
-  }
-  filterPassTypeInputs.forEach((input) => {
-    input.addEventListener("change", applyFiltersImmediately);
-  });
-  if (filterRegionOptions) filterRegionOptions.addEventListener("change", applyFiltersImmediately);
-  if (filterSortSelect) filterSortSelect.addEventListener("change", applyFiltersImmediately);
-  if (filterIncludeAllInput) filterIncludeAllInput.addEventListener("change", applyFiltersImmediately);
-  if (filterSearchAllInput) filterSearchAllInput.addEventListener("change", applyFiltersImmediately);
-  if (favoritesOnlyToggle) {
-    favoritesOnlyToggle.addEventListener("change", () => {
+    filterPassTypeInputs.forEach((input) => input.addEventListener("change", () => void applyFiltersImmediately()));
+    filterRegionOptions?.addEventListener("change", () => void applyFiltersImmediately());
+    filterSortSelect?.addEventListener("change", () => void applyFiltersImmediately());
+    filterIncludeAllInput?.addEventListener("change", () => void applyFiltersImmediately());
+    filterSearchAllInput?.addEventListener("change", () => void applyFiltersImmediately());
+    favoritesOnlyToggle?.addEventListener("change", () => {
       setFavoritesOnlyControls(favoritesOnlyToggle.checked);
-      applyFiltersImmediately();
+      void applyFiltersImmediately();
     });
-  }
-  if (filterFavoritesOnlyInput) {
-    filterFavoritesOnlyInput.addEventListener("change", () => {
+    filterFavoritesOnlyInput?.addEventListener("change", () => {
       setFavoritesOnlyControls(filterFavoritesOnlyInput.checked);
-      applyFiltersImmediately();
+      void applyFiltersImmediately();
     });
-  }
-  if (filterModal) {
-    filterModal.addEventListener("click", (event) => {
+    filterModal?.addEventListener("click", (event) => {
       if (event.target === filterModal) closeFilterModal();
     });
-  }
-  document.addEventListener("keydown", (event) => {
-    if (event.key === "Escape" && filterModal && !filterModal.hidden) closeFilterModal();
-  });
-  document.addEventListener("click", (event) => {
-    const favoriteAllButton = event.target.closest(".favorite-all-btn[data-favorite-all='1']");
-    if (favoriteAllButton) {
-      event.preventDefault();
-      const visibleReports = _filteredReports();
-      toggleFavoriteVisibleReports(visibleReports);
-      if (favoriteInteractionNeedsFullRender()) {
-        renderPagePreservingScroll();
-      } else {
-        syncFavoriteUiInPlace(visibleReports);
+    document.addEventListener("keydown", (event) => {
+      if (!filterModal || filterModal.hidden) return;
+      if (event.key === "Escape") {
+        event.preventDefault();
+        closeFilterModal();
+        return;
       }
-      return;
-    }
-    const favoriteButton = event.target.closest(".favorite-btn[data-resort-id]");
-    if (favoriteButton) {
-      event.preventDefault();
-      const visibleReports = _filteredReports();
-      toggleFavoriteResortId(favoriteButton.getAttribute("data-resort-id"));
-      if (favoriteInteractionNeedsFullRender()) {
-        renderPagePreservingScroll();
-      } else {
-        syncFavoriteUiInPlace(visibleReports);
+      if (event.key !== "Tab") return;
+      const focusable = filterFocusable();
+      if (!focusable.length) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
       }
-      return;
-    }
-    const button = event.target.closest(".unit-btn[data-unit-mode]");
-    if (!button) return;
-    const compactToggle = button.closest(".unit-toggle[data-compact-summary-toggle='1']");
-    if (compactToggle) {
-      setCompactSummaryUnitMode(oppositeUnitMode(appState.compactSummaryUnitMode));
-      return;
-    }
-    const sunTimeToggle = button.closest(".unit-toggle[data-sun-time-toggle='1']");
-    if (sunTimeToggle) {
-      setSunTimeToggleMode(oppositeUnitMode(appState.sunTimeToggleMode));
-      return;
-    }
-    const group = button.closest(".unit-toggle[data-target-kind]");
-    if (!group) return;
-    const kind = group.getAttribute("data-target-kind");
-    const currentMode = appState.unitModes[kind] || "metric";
-    setUnitMode(kind, oppositeUnitMode(currentMode));
-  });
-  window.addEventListener("resize", () => {
-    if (appState.payload && getLayoutModeForWidth() !== appState.layoutMode) {
-      renderPagePreservingScroll();
-      return;
-    }
-    applyLayout();
-  }, { passive: true });
-};
+    });
+    document.addEventListener("click", (event) => {
+      const button = event.target.closest(".favorite-btn[data-resort-id]");
+      if (!button) return;
+      event.preventDefault();
+      const resortId = String(button.getAttribute("data-resort-id") || "");
+      toggleFavorite(resortId);
+      renderPagePreservingPosition({ focusFavoriteId: resortId });
+    });
+  };
 
-const initialize = async () => {
-  Object.keys(appState.unitModes).forEach((kind) => {
-    appState.unitModes[kind] = getStoredUnitMode(kind);
-  });
-  appState.compactSummaryUnitMode = getStoredUnitMode(COMPACT_SUMMARY_UNIT_KIND);
-  appState.sunTimeToggleMode = getStoredUnitMode(SUN_TIME_TOGGLE_KIND);
-  appState.favoriteResortIds = new Set(loadFavoriteResortIds());
-  try {
-    appState.payload = initialPayload || await loadPayload();
-    appState.reports = _payloadReports();
-    appState.availableFilters = _availableFilters();
-    updateFilterLabels();
-    applyControlsFromQueryOrMeta();
-    renderPage();
-  } catch (error) {
-    renderPageLoadError(error);
-    document.body.classList.remove("units-pending");
-  }
-};
+  const initialize = async () => {
+    appState.unitMode = typeof fieldGuideUnits.readPreference === "function"
+      ? fieldGuideUnits.readPreference()
+      : "metric";
+    appState.favoriteResortIds = new Set(loadFavoriteResortIds());
+    try {
+      appState.payload = initialPayload || await loadPayload();
+      appState.availableFilters = availableFilters();
+      updateFilterLabels();
+      applyControlsFromQueryOrMeta();
+      renderPage();
+    } catch (error) {
+      renderPageLoadError(error);
+    }
+  };
 
-bindControls();
-void initialize();
+  bindControls();
+  void initialize();
+}());

--- a/src/web/asset_manifest.py
+++ b/src/web/asset_manifest.py
@@ -43,6 +43,7 @@ WEB_ASSET_MANIFEST: Final[tuple[WebAsset, ...]] = (
     WebAsset("assets/js/weather_filter_state.js", "application/javascript; charset=utf-8"),
     WebAsset("assets/js/sticky_single_table_layout.js", "application/javascript; charset=utf-8"),
     WebAsset("assets/js/weather_page_formatters.js", "application/javascript; charset=utf-8"),
+    WebAsset("assets/js/field_guide_homepage.js", "application/javascript; charset=utf-8"),
     WebAsset("assets/js/weather_page.js", "application/javascript; charset=utf-8"),
     WebAsset("assets/css/resort_hourly.css", "text/css; charset=utf-8"),
     WebAsset("assets/js/resort_hourly_metrics.js", "application/javascript; charset=utf-8"),

--- a/src/web/templates/weather_page.html
+++ b/src/web/templates/weather_page.html
@@ -3,15 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-V9NBX3H6M9"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag() {dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-V9NBX3H6M9');
-  </script>
-  <title>Ski Resorts Weather Forecast</title>
+  <title>CloseSnow Mountain Morning Report</title>
   <link rel="stylesheet" href="assets/css/weather_page.css" />
   <link rel="stylesheet" href="assets/css/field_guide_foundation.css" />
 </head>
@@ -31,7 +23,7 @@
         </span>
       </a>
       <div class="site-header-actions">
-        <span class="site-header-note"><span aria-hidden="true"></span> Fresh mountain intelligence</span>
+        <span class="site-header-note"><span aria-hidden="true"></span> Forecast ready</span>
         <button class="field-guide-unit-switch" type="button" data-field-guide-unit-toggle aria-pressed="false">
           <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M8 5h8M8 12h8M8 19h8"></path><path d="M5 3v4M5 10v4M5 17v4M19 3v4M19 10v4M19 17v4"></path></svg>
           <span data-field-guide-unit-label>Metric</span>
@@ -39,45 +31,48 @@
       </div>
     </div>
   </header>
-  <main>
-    <section class="forecast-hero" aria-labelledby="page-title">
-      <div class="forecast-hero-copy">
-        <p class="eyebrow">Ski Resorts Weather Forecast</p>
-        <h1 id="page-title">Find your next <span>snow day.</span></h1>
-        <p class="hero-lede">Compare the mountains at a glance, follow the strongest storms, and plan with confidence.</p>
-        <div class="report-date">
-          <div class="report-powered">
-            Forecast model <a href="https://open-meteo.com/en/docs/ecmwf-api" target="_blank" rel="noopener noreferrer">Open-Meteo ECMWF IFS 0.25</a>
-          </div>
-          <div id="report-date" class="report-generated" data-generated-utc="{{generated_utc_iso}}">Generated At: loading...</div>
-        </div>
+
+  <main class="field-guide-home">
+    <section class="morning-masthead" aria-labelledby="page-title">
+      <div class="morning-masthead__copy">
+        <p class="section-kicker">Mountain morning report</p>
+        <h1 id="page-title">Make the call before first chair.</h1>
+        <p>See where the useful weather is, why it matters, and what every forecast day looks like—without reading a spreadsheet.</p>
       </div>
-      <div class="hero-landscape" aria-hidden="true">
-        <span class="hero-sun"></span>
-        <svg viewBox="0 0 560 250" preserveAspectRatio="none">
-          <path class="mountain-back" d="M0 207 78 137l44 36 77-105 63 84 40-51 100 106H0Z" />
-          <path class="mountain-front" d="M138 220 262 92l41 48 46-62 135 142H138Z" />
-          <path class="snow-line" d="m78 137 23 19 21 17 77-105 29 39 34 45 40-51 36 38" />
-          <path class="snow-line snow-line-front" d="m262 92 41 48 46-62 48 51" />
-        </svg>
-        <span class="hero-contour hero-contour-one"></span>
-        <span class="hero-contour hero-contour-two"></span>
-      </div>
-    </section>
-    <section class="control-panel" aria-labelledby="explore-title">
-      <div class="control-panel-heading">
+      <dl class="morning-meta" aria-label="Forecast report details">
         <div>
-          <p class="eyebrow">Your mountain finder</p>
-          <h2 id="explore-title">Explore the forecast</h2>
+          <dt>Updated</dt>
+          <dd id="report-date" data-generated-utc="{{generated_utc_iso}}">Loading forecast time…</dd>
         </div>
-        <span id="filter-summary" class="filter-summary">Default resorts</span>
+        <div>
+          <dt>Model</dt>
+          <dd id="report-model">ECMWF IFS 0.25</dd>
+        </div>
+        <div>
+          <dt>In view</dt>
+          <dd id="visible-resort-count">Loading resorts…</dd>
+        </div>
+        <div>
+          <dt>Units</dt>
+          <dd data-field-guide-unit-status>Metric</dd>
+        </div>
+      </dl>
+    </section>
+
+    <section class="forecast-toolbar" aria-labelledby="explore-title">
+      <div class="forecast-toolbar__heading">
+        <div>
+          <p class="section-kicker">Find your mountain</p>
+          <h2 id="explore-title">Search, filter, then compare</h2>
+        </div>
+        <span id="filter-summary" class="filter-summary" aria-live="polite">Loading resorts…</span>
       </div>
       <div class="resort-controls">
         <div class="resort-search">
-          <label class="sr-only" for="resort-search-input">Search Resorts</label>
+          <label class="sr-only" for="resort-search-input">Search resorts</label>
           <span class="search-field">
             <svg aria-hidden="true" viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"></circle><path d="m16.2 16.2 4.1 4.1"></path></svg>
-            <input id="resort-search-input" type="search" placeholder="Search name, state, or pass" autocomplete="off" />
+            <input id="resort-search-input" type="search" placeholder="Search resort, state, country, or pass" autocomplete="off" />
           </span>
           <button id="resort-search-clear" type="button">Clear</button>
         </div>
@@ -91,74 +86,76 @@
             <span>Favorites only</span>
           </label>
         </div>
-        <div class="resort-filter-bar">
-          <button id="filter-open-btn" type="button">
-            <svg aria-hidden="true" viewBox="0 0 24 24"><path d="M4 7h16M7 12h10M10 17h4"></path></svg>
-            Filters &amp; sorting
-          </button>
-        </div>
+        <button id="filter-open-btn" type="button" aria-haspopup="dialog" aria-controls="filter-modal">
+          <svg aria-hidden="true" viewBox="0 0 24 24"><path d="M4 7h16M7 12h10M10 17h4"></path></svg>
+          <span>Filters &amp; sorting</span>
+          <span id="active-filter-count" class="active-filter-count" hidden></span>
+        </button>
       </div>
     </section>
-    <div id="filter-modal" class="filter-modal" hidden>
-      <div class="filter-panel" role="dialog" aria-modal="true" aria-labelledby="filter-title">
-        <h3 id="filter-title">Resort Filters</h3>
-        <div class="filter-group">
-          <div class="filter-group-title">Sort By</div>
-          <select id="filter-sort-select">
-            <option value="state">State (A-Z)</option>
-            <option value="name">Resort Name (A-Z)</option>
-            <option value="favorites">Favorites First</option>
-            <option value="today_snow">Today's Snowfall</option>
-            <option value="week_snow" selected>This Week's Snowfall</option>
-            <option value="next_week_snow">Next Week's Snowfall</option>
-            <option value="two_week_snow">Two-Week Snowfall</option>
-          </select>
-        </div>
-        <div class="filter-group">
-          <label class="filter-include-all-label">
-            <input type="checkbox" id="filter-include-all" checked />
-            Default resorts only
-          </label>
-        </div>
-        <div class="filter-group">
-          <label class="filter-include-all-label">
-            <input type="checkbox" id="filter-favorites-only" />
-            Favorites only
-          </label>
-        </div>
-        <div class="filter-group">
-          <div class="filter-group-title">Pass Type</div>
-          <label><input type="checkbox" name="filter-pass-type" value="ikon" /> Ikon <span data-pass-count="ikon"></span></label>
-          <label><input type="checkbox" name="filter-pass-type" value="epic" /> Epic <span data-pass-count="epic"></span></label>
-        </div>
-        <div class="filter-group">
-          <div class="filter-group-title">Region</div>
-          <div id="filter-region-options" class="filter-option-grid filter-option-list" role="group" aria-label="Region filters"></div>
-        </div>
-        <div class="filter-actions">
-          <button id="filter-reset-btn" type="button">Reset</button>
-          <button id="filter-close-btn" type="button">Close</button>
-        </div>
-      </div>
-    </div>
-    <div id="page-content-root" data-loading="1">
+
+    <div id="page-content-root" data-loading="1" aria-busy="true">
       {{page_shell_placeholder}}
     </div>
   </main>
+
+  <div id="filter-modal" class="filter-modal" hidden>
+    <section class="filter-panel" role="dialog" aria-modal="true" aria-labelledby="filter-title">
+      <header class="filter-panel__header">
+        <div><p class="section-kicker">Refine the directory</p><h2 id="filter-title">Filters &amp; sorting</h2></div>
+        <button id="filter-close-btn" class="filter-close-btn" type="button" aria-label="Close filters">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m6 6 12 12M18 6 6 18"></path></svg>
+        </button>
+      </header>
+      <div class="filter-panel__body">
+        <div class="filter-group">
+          <label class="filter-group-title" for="filter-sort-select">Sort resorts by</label>
+          <select id="filter-sort-select">
+            <option value="state">State (A–Z)</option>
+            <option value="name">Resort name (A–Z)</option>
+            <option value="favorites">Favorites first</option>
+            <option value="today_snow">Today's snowfall</option>
+            <option value="week_snow" selected>This week's snowfall</option>
+            <option value="next_week_snow">Next week's snowfall</option>
+            <option value="two_week_snow">Two-week snowfall</option>
+          </select>
+        </div>
+        <fieldset class="filter-group filter-check-list">
+          <legend class="filter-group-title">Directory scope</legend>
+          <label><input type="checkbox" id="filter-include-all" checked /> Show default resorts only</label>
+          <label><input type="checkbox" id="filter-favorites-only" /> Show favorites only</label>
+        </fieldset>
+        <fieldset class="filter-group filter-check-list">
+          <legend class="filter-group-title">Pass</legend>
+          <label><input type="checkbox" name="filter-pass-type" value="ikon" /> Ikon <span data-pass-count="ikon"></span></label>
+          <label><input type="checkbox" name="filter-pass-type" value="epic" /> Epic <span data-pass-count="epic"></span></label>
+        </fieldset>
+        <fieldset class="filter-group">
+          <legend class="filter-group-title">Region</legend>
+          <div id="filter-region-options" class="filter-option-grid" role="group" aria-label="Region filters"></div>
+        </fieldset>
+      </div>
+      <footer class="filter-actions">
+        <button id="filter-reset-btn" class="fg-button" type="button">Reset all</button>
+        <button id="filter-done-btn" class="fg-button fg-button--primary" type="button">Show resorts</button>
+      </footer>
+    </section>
+  </div>
+
   <footer class="page-footer">
-    <span><strong>CloseSnow</strong> · Built for better mountain days.</span>
-    <span>Made by <a href="https://ljcc0930.github.io/" target="_blank" rel="noopener noreferrer">ljcc</a> with Codex · <a href="https://github.com/ljcc0930/CloseSnow/issues/new?template=feature_request.yml" target="_blank" rel="noopener noreferrer">Request a feature</a></span>
+    <span><strong>CloseSnow</strong> · Built for better mountain decisions.</span>
+    <span>Forecasts are guidance, not safety advice · <a href="https://github.com/ljcc0930/CloseSnow/issues/new?template=feature_request.yml" target="_blank" rel="noopener noreferrer">Request a feature</a></span>
   </footer>
+
   <script>
     window.CLOSESNOW_FILTER_META = {{filter_meta_json}};
     window.CLOSESNOW_PAGE_BOOTSTRAP = {{page_bootstrap_json}};
     window.CLOSESNOW_INITIAL_PAYLOAD = {{initial_payload_json}};
   </script>
   <script src="assets/js/field_guide_foundation.js"></script>
-  <script src="assets/js/compact_daily_summary.js"></script>
   <script src="assets/js/weather_filter_state.js"></script>
-  <script src="assets/js/sticky_single_table_layout.js"></script>
   <script src="assets/js/weather_page_formatters.js"></script>
+  <script src="assets/js/field_guide_homepage.js"></script>
   <script src="assets/js/weather_page.js"></script>
 </body>
 </html>

--- a/src/web/weather_html_renderer.py
+++ b/src/web/weather_html_renderer.py
@@ -9,16 +9,15 @@ from typing import Any, Dict, List
 _PAGE_TEMPLATE = (Path(__file__).resolve().parent / "templates" / "weather_page.html").read_text(encoding="utf-8")
 
 _PAGE_SHELL_PLACEHOLDER = """
-    <section class="forecast-overview forecast-loading-overview" aria-hidden="true">
+    <section class="insight-board forecast-loading-overview" aria-hidden="true">
       <div class="skeleton skeleton-heading"></div>
-      <div class="loading-card-grid"><div class="skeleton skeleton-card"></div><div class="skeleton skeleton-card"></div><div class="skeleton skeleton-card"></div></div>
+      <div class="insight-grid loading-card-grid"><div class="skeleton skeleton-card"></div><div class="skeleton skeleton-card"></div><div class="skeleton skeleton-card"></div></div>
     </section>
-    <section class="forecast-section forecast-section-loading"><h2>Daily Summary</h2><div class="skeleton skeleton-table"></div><p class="section-loading sr-only">Loading forecast...</p></section>
-    <section class="forecast-section forecast-section-loading"><h2>Snowfall</h2><div class="skeleton skeleton-table"></div></section>
-    <section class="forecast-section forecast-section-loading"><h2>Rainfall</h2><div class="skeleton skeleton-table"></div></section>
-    <section class="forecast-section forecast-section-loading"><h2>Temperature</h2><div class="skeleton skeleton-table"></div></section>
-    <section class="forecast-section forecast-section-loading"><h2>Weather</h2><div class="skeleton skeleton-table"></div></section>
-    <section class="forecast-section forecast-section-loading"><h2>Sunrise / Sunset</h2><div class="skeleton skeleton-table"></div></section>
+    <section class="forecast-results forecast-section-loading" aria-hidden="true">
+      <div class="skeleton skeleton-heading"></div>
+      <div class="resort-card-grid"><div class="skeleton skeleton-resort-card"></div><div class="skeleton skeleton-resort-card"></div></div>
+      <p class="section-loading sr-only">Loading forecast...</p>
+    </section>
 """
 
 

--- a/tests/frontend/test_renderers.py
+++ b/tests/frontend/test_renderers.py
@@ -242,24 +242,32 @@ def test_build_html_contains_meta_sections():
         applied_filters={"pass_type": ["ikon"], "include_default": True, "search_all": True, "include_all": False},
     )
     assert "<!doctype html>" in html
-    assert "Ski Resorts Weather Forecast" in html
+    assert "CloseSnow Mountain Morning Report" in html
     assert "CloseSnow" in html
-    assert "Find your next <span>snow day.</span>" in html
+    assert "Make the call before first chair." in html
+    assert "without reading a spreadsheet" in html
     assert "forecast-loading-overview" in html
-    assert 'class="skeleton skeleton-table"' in html
-    assert "<h2>Daily Summary</h2>" in html
-    assert "<h2>Sunrise / Sunset</h2>" in html
+    assert 'class="skeleton skeleton-resort-card"' in html
+    assert "Loading forecast..." in html
+    assert 'id="report-model"' in html
+    assert 'id="visible-resort-count"' in html
+    assert "Mountain-by-mountain outlook" not in html
     assert 'href="assets/css/field_guide_foundation.css"' in html
     assert html.index('href="assets/css/weather_page.css"') < html.index('href="assets/css/field_guide_foundation.css"')
     assert 'src="assets/js/field_guide_foundation.js"' in html
+    assert 'src="assets/js/field_guide_homepage.js"' in html
     assert html.index('src="assets/js/field_guide_foundation.js"') < html.index(
-        'src="assets/js/compact_daily_summary.js"'
+        'src="assets/js/field_guide_homepage.js"'
     )
     assert 'src="assets/js/weather_page_formatters.js"' in html
-    assert html.index('src="assets/js/weather_page_formatters.js"') < html.index('src="assets/js/weather_page.js"')
+    assert html.index('src="assets/js/weather_page_formatters.js"') < html.index(
+        'src="assets/js/field_guide_homepage.js"'
+    )
+    assert html.index('src="assets/js/field_guide_homepage.js"') < html.index('src="assets/js/weather_page.js"')
     assert 'src="assets/js/weather_code_emoji.js"' not in html
+    assert 'src="assets/js/compact_daily_summary.js"' not in html
+    assert 'src="assets/js/sticky_single_table_layout.js"' not in html
     assert "data-field-guide-unit-toggle" in html
-    assert html.index("<h2>Temperature</h2>") < html.index("<h2>Weather</h2>")
     assert 'id="resort-search-input"' in html
     assert 'id="filter-modal"' in html
     assert 'id="filter-sort-select"' in html
@@ -272,6 +280,8 @@ def test_build_html_contains_meta_sections():
     assert 'id="filter-apply-btn"' not in html
     assert 'id="filter-include-all" checked' in html
     assert 'id="filter-search-all" checked' in html
+    assert 'id="filter-done-btn"' in html
+    assert 'aria-haspopup="dialog"' in html
     assert "window.CLOSESNOW_FILTER_META" in html
     assert "window.CLOSESNOW_PAGE_BOOTSTRAP" in html
     assert "window.CLOSESNOW_INITIAL_PAYLOAD = null" in html
@@ -298,6 +308,7 @@ def test_build_html_keeps_legacy_table_args_out_of_page_shell():
     assert "Legacy Sun" not in html
     assert "Legacy Temp" not in html
     assert "Loading forecast..." in html
+    assert "Daily Summary" not in html
     assert 'window.CLOSESNOW_INITIAL_PAYLOAD = {"reports": []};' in html
 
 

--- a/tests/frontend/test_styles_and_transform.py
+++ b/tests/frontend/test_styles_and_transform.py
@@ -54,6 +54,36 @@ process.stdout.write(JSON.stringify(result));
     return json.loads(result.stdout)
 
 
+def _run_homepage_expression(expression: str):
+    foundation_path = REPO_ROOT / "assets" / "js" / "field_guide_foundation.js"
+    homepage_path = REPO_ROOT / "assets" / "js" / "field_guide_homepage.js"
+    runner = f"""
+const fs = require("fs");
+const storageState = {{}};
+global.window = {{
+  localStorage: {{
+    getItem: (key) => Object.prototype.hasOwnProperty.call(storageState, key) ? storageState[key] : null,
+    setItem: (key, value) => {{ storageState[key] = String(value); }},
+  }},
+  addEventListener: () => {{}},
+  dispatchEvent: () => {{}},
+  CustomEvent: function (type, init) {{ this.type = type; this.detail = init.detail; }},
+}};
+eval(fs.readFileSync({json.dumps(str(foundation_path))}, "utf8"));
+eval(fs.readFileSync({json.dumps(str(homepage_path))}, "utf8"));
+const result = (() => ({expression}))();
+process.stdout.write(JSON.stringify(result));
+"""
+    result = subprocess.run(
+        [_node_binary(), "-e", runner],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
 def test_to_float_and_color_functions():
     assert to_float(" 2.5 ") == 2.5
     assert to_float("") is None
@@ -288,3 +318,117 @@ def test_field_guide_styles_define_shared_semantics_and_compact_header():
     assert ".fg-card" in css
     assert "[data-field-guide-tabs]" in css
     assert "details[data-field-guide-disclosure]" in css
+
+
+def test_homepage_ranking_explains_signal_best_day_and_temperature_context():
+    result = _run_homepage_expression(
+        """(() => {
+  const homepage = window.CloseSnowFieldGuideHomepage;
+  const reports = [
+    {
+      resort_id: "quiet",
+      display_name: "Quiet Hill",
+      week1_total_snowfall_cm: 1,
+      week1_total_rain_mm: 0,
+      daily: [{ date: "2026-03-03", snowfall_cm: 1, rain_mm: 0, temperature_max_c: 2, temperature_min_c: -4 }],
+    },
+    {
+      resort_id: "deep",
+      display_name: "Deep Peak",
+      week1_total_snowfall_cm: 12,
+      week1_total_rain_mm: 1.2,
+      daily: [
+        { date: "2026-03-03", snowfall_cm: 2, rain_mm: 0, temperature_max_c: -1, temperature_min_c: -8 },
+        { date: "2026-03-04", snowfall_cm: 8, rain_mm: 0, temperature_max_c: 1, temperature_min_c: -5 },
+      ],
+    },
+  ];
+  const ranked = homepage.rankCandidates(reports, 2);
+  return {
+    order: ranked.map((entry) => entry.report.resort_id),
+    signal: ranked[0].signal,
+    explanation: homepage.rankingExplanation(ranked[0].report, ranked[0].signal, "metric"),
+  };
+})()"""
+    )
+
+    assert result["order"] == ["deep", "quiet"]
+    assert result["signal"] == "snow"
+    assert "12.0 cm of snow is forecast over seven days" in result["explanation"]
+    assert "Mar 4" in result["explanation"]
+    assert "8.0 cm" in result["explanation"]
+    assert "-8 °C to -1 °C" in result["explanation"]
+
+
+def test_homepage_card_discloses_every_daily_field_uses_global_units_and_escapes_content():
+    result = _run_homepage_expression(
+        """(() => {
+  const homepage = window.CloseSnowFieldGuideHomepage;
+  const report = {
+    resort_id: "safe-resort",
+    display_name: "Peak <script>alert(1)</script>",
+    admin1: "State <unsafe>",
+    pass_types: ["ikon"],
+    week1_total_snowfall_cm: 2.54,
+    week2_total_snowfall_cm: 0,
+    week1_total_rain_mm: 25.4,
+    daily: [
+      {
+        date: "2026-03-03",
+        weather_code: 71,
+        temperature_max_c: 0,
+        temperature_min_c: -10,
+        snowfall_cm: 2.54,
+        rain_mm: 25.4,
+        sunrise_local_hhmm: "07:01",
+        sunset_local_hhmm: "18:22",
+      },
+      {
+        date: "2026-03-04",
+        weather_code: 3,
+        temperature_max_c: 2,
+        temperature_min_c: -4,
+        snowfall_cm: 0,
+        rain_mm: 0,
+        sunrise_iso: "2026-03-04T07:00",
+        sunset_iso: "2026-03-04T18:23",
+      },
+    ],
+  };
+  return homepage.renderResortCard(report, { mode: "imperial", favorite: true });
+})()"""
+    )
+
+    assert "Peak &lt;script&gt;alert(1)&lt;/script&gt;" in result
+    assert "State &lt;unsafe&gt;" in result
+    assert "<script>alert(1)</script>" not in result
+    assert 'aria-pressed="true"' in result
+    assert "Full 2-day forecast" in result
+    assert result.count('class="daily-detail-card"') == 2
+    assert "High / low" in result
+    assert ">Snow<" in result
+    assert ">Rain<" in result
+    assert ">Daylight<" in result
+    assert "32 °F" in result
+    assert "1.0 in" in result
+    assert "1.00 in" in result
+    assert "07:01–18:22" in result
+    assert "07:00–18:23" in result
+    assert "No snow forecast" in result
+
+
+def test_homepage_missing_and_no_results_copy_is_honest_and_readable():
+    result = _run_homepage_expression(
+        """(() => {
+  const homepage = window.CloseSnowFieldGuideHomepage;
+  return {
+    missing: homepage.renderResortCard({ resort_id: "missing", display_name: "Missing Mountain", daily: [] }),
+    empty: homepage.render([], { emptyMessage: "Try clearing your filters." }),
+  };
+})()"""
+    )
+
+    assert "Forecast details are not available for this resort yet." in result["missing"]
+    assert "Daily guidance is not available yet." in result["missing"]
+    assert "No resorts match this view" in result["empty"]
+    assert "Try clearing your filters." in result["empty"]

--- a/tests/smoke/test_static_pipeline_smoke.py
+++ b/tests/smoke/test_static_pipeline_smoke.py
@@ -70,7 +70,11 @@ def test_static_split_pipeline_smoke(monkeypatch, tmp_path, valid_payload):
 
     html = Path(render_args.output_dir, "index.html").read_text(encoding="utf-8")
     assert "<!doctype html>" in html
-    assert "Snowfall" in html
+    assert "CloseSnow Mountain Morning Report" in html
+    assert "Make the call before first chair." in html
+    assert 'src="assets/js/field_guide_homepage.js"' in html
+    assert "window.CLOSESNOW_INITIAL_PAYLOAD = {" in html
+    assert "Snowbird, Utah" in html
     assert 'id="page-content-root"' in html
     assert "window.CLOSESNOW_PAGE_BOOTSTRAP" in html
     assert '"dataUrl": "./data.json"' in html


### PR DESCRIPTION
## Summary
- replaces the marketing hero and six metric tables with a compact mountain morning report
- adds plain-language ranked picks plus responsive resort forecast cards
- exposes every available daily condition, high/low, snow, rain, sunrise, and sunset through keyboard-accessible disclosures
- preserves search, scope/pass/region/favorite filters, sorting, resort links, favorites persistence, metadata, and global unit preference
- adds a page-specific renderer with safe HTML escaping and focused ranking/disclosure/unit tests

## Validation
- Asset lint passed
- Ruff format and check passed
- 267 pytest tests passed
- Static build passed for 125 resorts and 125 hourly pages
- Real payload render produced 125 resort cards and 1,875 daily cards

## Browser QA
The Browser runtime reported no available browser in this worker session, so interactive screenshot QA could not be executed here. The responsive layout and interaction contracts are covered by automated checks; integration QA should still perform the planned 1440, 1280, 768, and 390 pixel browser pass.