### PR TITLE
feat: rebuild resort forecast as a readable field guide

### DIFF
--- a/assets/css/resort_hourly.css
+++ b/assets/css/resort_hourly.css
@@ -1,1267 +1,956 @@
-body {
-  margin: 0;
-  font-family: "Avenir Next", "Segoe UI", sans-serif;
-  color: #1f2937;
-  background: linear-gradient(180deg, #f8fafc 0%, #eef2ff 100%);
+/* Resort Field Guide: compact, decision-first daily and hourly weather. */
+
+[hidden] {
+  display: none !important;
 }
 
-main {
-  max-width: 1400px;
-  margin: 0 auto;
-  padding: 20px;
-}
-
-.back-link {
-  display: inline-block;
-  margin-bottom: 12px;
-  color: #0f766e;
-  text-decoration: none;
-  font-weight: 600;
-}
-
-.back-link:hover {
-  text-decoration: underline;
-}
-
-h1 {
-  margin: 0 0 12px;
-  font-size: 26px;
-}
-
-.resort-local-time {
-  margin: -4px 0 14px;
-  color: #0f172a;
-  font-size: 14px;
-  font-weight: 700;
-}
-
-.resort-website-link {
-  margin: -8px 0 14px;
-  font-size: 14px;
-  font-weight: 600;
-}
-
-.resort-website-link a {
-  color: #0f766e;
-  text-decoration: none;
-}
-
-.resort-website-link a:hover {
-  text-decoration: underline;
-}
-
-.resort-location-link {
-  margin: -8px 0 14px;
-  font-size: 14px;
-  font-weight: 600;
-}
-
-.resort-location-link a {
-  color: #0f766e;
-  text-decoration: none;
-}
-
-.resort-location-link a:hover {
-  text-decoration: underline;
-}
-
-.resort-timeline-section {
-  margin: 0 0 14px;
-}
-
-.resort-timeline-section h2 {
-  margin: 0 0 8px;
-  font-size: 16px;
-}
-
-.resort-airport-access-section {
-  margin: 0 0 14px;
-}
-
-.resort-airport-access-section h2 {
-  margin: 0 0 8px;
-  font-size: 16px;
-}
-
-.resort-airport-access-list {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 10px;
-}
-
-.resort-airport-access-card {
-  border: 1px solid #d1d5db;
-  border-radius: 10px;
-  background: #fff;
-  box-shadow: 0 6px 24px rgba(0,0,0,0.06);
-  padding: 10px 12px;
-}
-
-.resort-airport-access-card-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  margin: 0 0 6px;
-}
-
-.resort-airport-access-code {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 40px;
-  padding: 2px 8px;
-  border-radius: 999px;
-  background: #e2e8f0;
-  color: #0f172a;
-  font-size: 12px;
-  font-weight: 700;
-  letter-spacing: 0.02em;
-}
-
-.resort-airport-access-distance {
-  color: #0f172a;
-  font-size: 12px;
-  font-weight: 700;
-}
-
-.resort-airport-access-name {
-  margin: 0 0 4px;
-  color: #0f172a;
-  font-size: 13px;
-  font-weight: 700;
-}
-
-.resort-airport-access-location {
-  margin: 0;
-  color: #64748b;
-  font-size: 12px;
-  font-weight: 600;
-}
-
-.resort-airport-access-empty {
-  margin: 0;
-  padding: 10px 12px;
-  border: 1px solid #d1d5db;
-  border-radius: 10px;
-  background: #fff;
-  box-shadow: 0 6px 24px rgba(0,0,0,0.06);
-  color: #475569;
-  font-size: 12px;
-  font-weight: 600;
-}
-
-.resort-daily-summary-wrap {
-  overflow-x: auto;
-  border: 1px solid #d1d5db;
-  border-radius: 10px;
-  background: #fff;
-  box-shadow: 0 6px 24px rgba(0,0,0,0.06);
-}
-
-.resort-daily-summary-table {
-  border-collapse: separate;
-  border-spacing: 0;
-  width: max-content;
-  min-width: 100%;
-  table-layout: fixed;
-}
-
-.resort-daily-summary-table col.col-compact-day {
-  width: 98px;
-}
-
-.resort-daily-summary-table th {
-  position: sticky;
-  top: 0;
-  z-index: 2;
-  background: #e5e7eb;
-}
-
-.resort-daily-summary-table th.compact-day-head-history {
-  background: #e5e7eb;
-}
-
-.resort-daily-summary-table th.compact-day-head-forecast {
-  background: #e5e7eb;
-}
-
-.resort-daily-summary-table td {
-  background-clip: padding-box;
-}
-
-.compact-day-cell {
-  padding: 5px 8px;
-  height: 62px;
-  min-height: 62px;
-  vertical-align: top;
-}
-
-.compact-day-head-today-anchor {
-  background: #d7dde6;
-  box-shadow: inset 1px 0 0 #f3f4f6, inset -1px 0 0 #f3f4f6;
-}
-
-.compact-day-cell-today-anchor {
-  box-shadow: inset 1px 0 0 #f3f4f6, inset -1px 0 0 #f3f4f6;
-}
-
-.compact-day-card {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  gap: 4px;
-  height: 100%;
-}
-
-.compact-row {
-  display: grid;
-  align-items: center;
-}
-
-.compact-row-primary {
-  grid-template-columns: 20px 1fr;
-  gap: 2px;
-  align-items: stretch;
-}
-
-.compact-row-secondary {
-  grid-template-columns: 1fr 1fr;
-  gap: 6px;
-  align-items: center;
-}
-
-.compact-weather {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  align-self: stretch;
-  font-size: 26px;
-  line-height: 1;
-}
-
-.compact-temp-stack {
-  display: grid;
-  justify-items: end;
-  line-height: 1.1;
-  gap: 1px;
-}
-
-.compact-temp-high {
-  font-size: 15px;
-  font-weight: 600;
-  color: #0f172a;
-}
-
-.compact-temp-low {
-  font-size: 12px;
-  font-weight: 500;
-  color: #475569;
-}
-
-.compact-pair {
-  display: inline-flex;
-  align-items: center;
-  gap: 2px;
+.resort-page {
   min-width: 0;
-  font-size: 12px;
-  line-height: 1;
-  white-space: nowrap;
-  color: #334155;
-  font-weight: 600;
-}
-
-.compact-pair-value {
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.compact-snow .compact-pair-icon {
-  color: #2563eb;
-}
-
-.compact-rain {
-  justify-self: end;
-  justify-content: flex-end;
-  text-align: right;
-}
-
-.compact-rain .compact-pair-icon {
-  color: #0f766e;
-}
-
-.daily-summary-empty {
-  margin: 0;
-  padding: 10px 12px;
-  font-size: 12px;
-  color: #64748b;
-  font-weight: 600;
-}
-
-.hourly-section-title {
-  margin: 0 0 8px;
-  color: #0f172a;
-  font-size: 15px;
-  font-weight: 700;
-}
-
-.hourly-controls {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-bottom: 10px;
-}
-
-.hourly-controls label {
-  font-size: 13px;
-  font-weight: 600;
-}
-
-.hourly-controls select,
-.hourly-controls button {
-  border: 1px solid #cbd5e1;
-  border-radius: 8px;
-  padding: 6px 10px;
-  font-size: 13px;
-  background: #fff;
-}
-
-.hourly-controls button {
-  cursor: pointer;
-  font-weight: 600;
-}
-
-.hourly-meta {
-  margin: 0 0 10px;
-  color: #475569;
-  font-size: 13px;
-  font-weight: 600;
-}
-
-.hourly-meta a {
-  color: #0f766e;
-  text-decoration: none;
-}
-
-.hourly-meta a:hover {
-  text-decoration: underline;
-}
-
-.hourly-meta-coordinate-label {
-  color: #0f172a;
-  font-weight: 700;
-}
-
-.hourly-meta-issue-link {
-  color: #b91c1c;
-}
-
-.hourly-error {
-  margin: 0 0 12px;
-  color: #b91c1c;
-  font-size: 13px;
-  font-weight: 700;
-}
-
-.hourly-chart-error {
-  margin: 0 0 12px;
-  color: #9a3412;
-  font-size: 13px;
-  font-weight: 700;
-}
-
-.hourly-charts {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
-  margin: 0 0 14px;
-}
-
-.chart-card {
-  border: 1px solid #d1d5db;
-  border-radius: 10px;
-  background: #fff;
-  box-shadow: 0 6px 24px rgba(0,0,0,0.06);
-  padding: 10px 10px 8px;
-}
-
-.chart-title {
-  margin: 0;
-  font-size: 13px;
-  font-weight: 700;
-  color: #0f172a;
-}
-
-.chart-subtitle {
-  margin: 2px 0 8px;
-  font-size: 12px;
-  color: #64748b;
-}
-
-.chart-empty {
-  border: 1px dashed #cbd5e1;
-  border-radius: 8px;
-  min-height: 180px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: #64748b;
-  font-size: 12px;
-  font-weight: 600;
-  background: #f8fafc;
-}
-
-.chart-svg-wrap {
-  overflow-x: auto;
-}
-
-.chart-svg {
-  width: 100%;
-  min-width: 0;
-  height: 220px;
-  display: block;
-}
-
-.chart-grid-line {
-  stroke: #e5e7eb;
-  stroke-width: 1;
-}
-
-.chart-axis-line {
-  stroke: #cbd5e1;
-  stroke-width: 1;
-}
-
-.chart-line {
-  fill: none;
-  stroke-width: 2;
-}
-
-.chart-point {
-  opacity: 0.85;
-}
-
-.chart-tick-text {
-  fill: #64748b;
-  font-size: 10px;
-  font-weight: 600;
-}
-
-@media (max-width: 1200px) {
-  .resort-airport-access-list {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
-@media (max-width: 980px) {
-  .resort-airport-access-list {
-    grid-template-columns: 1fr;
-  }
-
-  .hourly-charts {
-    grid-template-columns: 1fr;
-  }
-}
-
-.table-wrap {
-  overflow: auto;
-  border: 1px solid #d1d5db;
-  border-radius: 10px;
-  background: #fff;
-  box-shadow: 0 6px 24px rgba(0,0,0,0.06);
-}
-
-table {
-  border-collapse: separate;
-  border-spacing: 0;
-  width: max-content;
-  min-width: 100%;
-}
-
-th,
-td {
-  border-bottom: 1px solid #e5e7eb;
-  border-right: 1px solid #f3f4f6;
-  padding: 7px 9px;
-  line-height: 14px;
-  font-size: 12px;
-  text-align: right;
-  white-space: nowrap;
-}
-
-th {
-  position: sticky;
-  top: 0;
-  background: #f3f4f6;
-  text-align: center;
-  font-weight: 700;
-}
-
-.hourly-table td:first-child,
-.hourly-table th:first-child {
-  text-align: left;
-  font-weight: 600;
-}
-
-th .day-label-date,
-th .day-label-weekday {
-  display: block;
-  line-height: 1.15;
-}
-
-th .day-label-weekday {
-  font-size: 11px;
-  color: #475569;
-  font-weight: 600;
-}
-
-/* Alpine resort detail shell */
-:root {
-  --ink-950: #081a29;
-  --ink-900: #10283a;
-  --ink-800: #1c3a4d;
-  --ink-700: #37566a;
-  --ink-500: #6a8291;
-  --snow-50: #f8fbfc;
-  --snow-100: #eef4f6;
-  --snow-200: #dce7eb;
-  --glacier-300: #8fd8e8;
-  --glacier-500: #28a9c2;
-  --glacier-600: #148ca8;
-  --surface: #ffffff;
-  --border: #d8e3e7;
-  --shadow-card: 0 12px 32px rgba(8, 26, 41, 0.08);
-  --radius-lg: 24px;
-  --radius-md: 16px;
-  --radius-sm: 11px;
-}
-
-* {
-  box-sizing: border-box;
-}
-
-html {
-  background: var(--snow-100);
-}
-
-body {
-  min-width: 0;
-  overflow-x: clip;
-  color: var(--ink-900);
+  color: var(--fg-ink, #17252e);
   background:
-    radial-gradient(circle at 10% -8%, rgba(143, 216, 232, 0.3), transparent 32rem),
-    linear-gradient(180deg, #f7fbfc 0%, var(--snow-100) 45%, #f5f8f7 100%);
-  font-family: "Avenir Next", "Segoe UI", sans-serif;
-  -webkit-font-smoothing: antialiased;
+    linear-gradient(90deg, rgba(23, 122, 155, 0.035) 1px, transparent 1px),
+    var(--fg-paper, #fbfcfa);
+  background-size: 72px 72px;
 }
 
-button,
-select {
-  font: inherit;
-}
-
-button,
-a,
-select {
-  transition: border-color 160ms ease, box-shadow 160ms ease, color 160ms ease, background-color 160ms ease, transform 160ms ease;
-}
-
-button:focus-visible,
-a:focus-visible,
-select:focus-visible,
-summary:focus-visible {
-  outline: 3px solid rgba(40, 169, 194, 0.28);
-  outline-offset: 2px;
-}
-
-.site-header {
-  color: #fff;
-  background: var(--ink-950);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.09);
-}
-
-.site-header-inner {
-  width: min(1400px, 100%);
-  min-height: 72px;
-  margin: 0 auto;
-  padding: 0 28px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 24px;
-}
-
-.brand {
-  display: inline-flex;
-  align-items: center;
-  gap: 11px;
-  color: #fff;
-  text-decoration: none;
-}
-
-.brand:hover {
-  color: var(--glacier-300);
-}
-
-.brand-mark {
-  width: 40px;
-  height: 40px;
-  border-radius: 13px;
-  display: grid;
-  place-items: center;
-  color: var(--ink-950);
-  background: linear-gradient(145deg, #d9f5fa, var(--glacier-300));
-  box-shadow: 0 8px 22px rgba(40, 169, 194, 0.22);
-}
-
-.brand-mark svg {
-  width: 30px;
-  height: 30px;
-  fill: currentColor;
-}
-
-.brand-mark svg path + path {
-  fill: none;
-  stroke: #eefdff;
-  stroke-width: 2.8;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-}
-
-.brand-copy {
-  display: grid;
-  gap: 1px;
-}
-
-.brand-copy strong {
-  font-size: 18px;
-  line-height: 1.05;
-  letter-spacing: -0.02em;
-}
-
-.brand-copy span {
-  color: #a9bfca;
-  font-size: 10px;
-  font-weight: 600;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-}
-
-.site-header-note {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  color: #c7d5dc;
-  font-size: 12px;
-  font-weight: 650;
-}
-
-.site-header-note > span {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: #65d6aa;
-  box-shadow: 0 0 0 5px rgba(101, 214, 170, 0.1);
-}
-
-main {
-  width: min(1400px, 100%);
-  max-width: none;
-  min-width: 0;
-  padding: 28px;
+.resort-field-guide {
+  width: min(var(--fg-content-max, 90rem), 100%);
+  margin-inline: auto;
+  padding: clamp(1rem, 2.4vw, 2rem) var(--fg-page-gutter, 1.5rem) 3rem;
 }
 
 .eyebrow {
-  margin: 0 0 7px;
-  color: var(--glacier-600);
-  font-size: 11px;
-  line-height: 1.2;
+  margin: 0 0 0.35rem;
+  color: var(--fg-glacier, #167a9b);
+  font-size: 0.72rem;
   font-weight: 800;
-  letter-spacing: 0.13em;
+  letter-spacing: 0.11em;
+  line-height: 1.2;
   text-transform: uppercase;
 }
 
-.resort-hero {
-  position: relative;
-  min-height: 330px;
-  padding: clamp(32px, 4vw, 56px);
-  overflow: hidden;
-  border-radius: var(--radius-lg);
-  color: #fff;
+.resort-masthead {
+  padding: clamp(1rem, 2vw, 1.5rem);
+  border: 1px solid var(--fg-line, #d8e1dd);
+  border-top: 4px solid var(--fg-pine, #16705d);
+  border-radius: var(--fg-radius-lg, 12px);
+  color: var(--fg-ink, #17252e);
   background:
-    radial-gradient(circle at 78% 12%, rgba(143, 216, 232, 0.24), transparent 24rem),
-    linear-gradient(128deg, #0a1e2e 0%, #12364b 58%, #155268 100%);
-  box-shadow: 0 28px 70px rgba(8, 26, 41, 0.16);
+    linear-gradient(110deg, rgba(220, 239, 245, 0.68), transparent 48%),
+    var(--fg-surface, #fff);
 }
 
-.resort-hero::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  opacity: 0.24;
-  background-image: radial-gradient(circle, rgba(255, 255, 255, 0.65) 0 1px, transparent 1.3px);
-  background-size: 42px 42px;
-  mask-image: linear-gradient(90deg, transparent 0%, #000 55%);
-}
-
-.resort-hero > :not(.resort-hero-mountain) {
-  position: relative;
-  z-index: 3;
+.resort-masthead-topline {
+  padding-bottom: 0.85rem;
+  border-bottom: 1px solid var(--fg-line, #d8e1dd);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
 }
 
 .back-link {
-  margin-bottom: 28px;
+  min-height: 36px;
   display: inline-flex;
   align-items: center;
-  gap: 7px;
-  color: #c6e9ef;
-  font-size: 12px;
-  font-weight: 700;
+  gap: 0.4rem;
+  color: var(--fg-ink-muted, #526671);
+  font-size: 0.82rem;
+  font-weight: 750;
+  text-decoration: none;
 }
 
 .back-link:hover {
-  color: #fff;
-  text-decoration: none;
-  transform: translateX(-2px);
+  color: var(--fg-glacier, #167a9b);
 }
 
-.resort-hero .eyebrow {
-  color: var(--glacier-300);
+.resort-report-label {
+  color: var(--fg-ink-subtle, #71838c);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
-.resort-hero h1 {
-  max-width: 770px;
+.resort-masthead-grid {
+  padding-top: clamp(1.1rem, 2.5vw, 2rem);
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(30rem, 0.95fr);
+  align-items: stretch;
+  gap: clamp(1.25rem, 3vw, 3rem);
+}
+
+.resort-intro {
+  min-width: 0;
+  align-self: center;
+}
+
+.resort-intro h1 {
+  max-width: 18ch;
   margin: 0;
-  color: #fff;
-  font-size: clamp(36px, 5.4vw, 68px);
-  line-height: 1.02;
-  letter-spacing: -0.05em;
+  overflow-wrap: anywhere;
+  color: var(--fg-ink, #17252e);
+  font-size: clamp(2.35rem, 4.6vw, 4.25rem);
+  letter-spacing: -0.055em;
+  line-height: 0.98;
+}
+
+.resort-outlook {
+  max-width: 62ch;
+  margin: 1rem 0 0;
+  color: var(--fg-ink-muted, #526671);
+  font-size: clamp(0.95rem, 1.4vw, 1.1rem);
+  line-height: 1.55;
+}
+
+.resort-context {
+  margin: 0.7rem 0 0;
+  color: var(--fg-pine, #16705d);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+}
+
+.resort-context:empty {
+  display: none;
 }
 
 .resort-identity-meta {
-  max-width: 760px;
-  margin: 22px 0 0;
+  margin-top: 1.1rem;
   display: flex;
   align-items: center;
-  gap: 9px;
   flex-wrap: wrap;
+  gap: 0.5rem;
 }
 
 .resort-identity-meta p {
+  min-height: 34px;
   margin: 0;
-  padding: 7px 10px;
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  border-radius: 999px;
-  color: #d3e3e9;
-  background: rgba(255, 255, 255, 0.06);
-  font-size: 11px;
-  font-weight: 650;
+  padding: 0.42rem 0.68rem;
+  border: 1px solid var(--fg-line, #d8e1dd);
+  border-radius: var(--fg-radius-md, 8px);
+  display: inline-flex;
+  align-items: center;
+  color: var(--fg-ink-muted, #526671);
+  background: rgba(255, 255, 255, 0.72);
+  font-size: 0.75rem;
+}
+
+.resort-identity-meta p:empty {
+  display: none;
 }
 
 .resort-identity-meta a {
-  color: #fff;
-  text-decoration: none;
-}
-
-.resort-identity-meta a:hover {
-  color: var(--glacier-300);
+  font-weight: 750;
 }
 
 .resort-snapshot {
-  max-width: 820px;
-  margin-top: 28px;
+  min-width: 0;
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 10px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.65rem;
 }
 
 .snapshot-card {
   min-width: 0;
-  padding: 13px 15px;
-  display: flex;
+  min-height: 104px;
+  padding: 0.9rem;
+  border: 1px solid var(--fg-line, #d8e1dd);
+  border-radius: var(--fg-radius-md, 8px);
+  display: grid;
+  grid-template-columns: 38px minmax(0, 1fr);
   align-items: center;
-  gap: 11px;
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  border-radius: 14px;
-  background: rgba(255, 255, 255, 0.08);
-  backdrop-filter: blur(10px);
+  gap: 0.7rem;
+  background: var(--fg-surface, #fff);
+}
+
+.snapshot-card:first-child {
+  grid-column: 1 / -1;
+  border-left: 3px solid var(--fg-signal, #c75518);
+}
+
+.snapshot-icon {
+  width: 38px;
+  height: 38px;
+  border-radius: var(--fg-radius-md, 8px);
+  display: grid;
+  place-items: center;
+  color: var(--fg-glacier, #167a9b);
+  background: var(--fg-glacier-soft, #dceff5);
+  font-size: 1.45rem;
+}
+
+.snapshot-icon-rain {
+  color: var(--fg-pine, #16705d);
+  background: var(--fg-pine-soft, #dcefe9);
 }
 
 .snapshot-card > span:last-child {
   min-width: 0;
   display: grid;
-  gap: 2px;
+  gap: 0.08rem;
 }
 
 .snapshot-card small,
 .snapshot-card em {
-  overflow: hidden;
-  color: #b9ccd5;
-  font-size: 9px;
+  color: var(--fg-ink-subtle, #71838c);
+  font-size: 0.7rem;
   font-style: normal;
-  font-weight: 650;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  line-height: 1.25;
 }
 
 .snapshot-card strong {
-  overflow: hidden;
-  color: #fff;
-  font-size: 18px;
-  line-height: 1.15;
-  letter-spacing: -0.02em;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow-wrap: anywhere;
+  color: var(--fg-ink, #17252e);
+  font-size: 1.28rem;
+  letter-spacing: -0.035em;
+  line-height: 1.1;
 }
 
-.snapshot-icon {
-  flex: 0 0 auto;
-  width: 34px;
-  height: 34px;
-  display: grid;
-  place-items: center;
-  border-radius: 11px;
-  background: rgba(255, 255, 255, 0.1);
-  font-size: 22px;
-}
-
-.snapshot-icon-snow {
-  color: #bfefff;
-}
-
-.snapshot-icon-rain {
-  color: #75d6e8;
-  font-size: 28px;
-}
-
-.resort-hero-mountain {
-  position: absolute;
-  z-index: 1;
-  right: -2%;
-  bottom: -7px;
-  width: min(45%, 600px);
-  height: 78%;
-  opacity: 0.68;
-  pointer-events: none;
-}
-
-.resort-hero-mountain svg {
-  width: 100%;
-  height: 100%;
-}
-
-.resort-hero-mountain path:first-child {
-  fill: rgba(4, 22, 34, 0.72);
-}
-
-.resort-hero-mountain path:last-child {
-  fill: none;
-  stroke: rgba(229, 250, 253, 0.7);
-  stroke-width: 5;
-  stroke-linejoin: round;
-}
-
-.resort-timeline-section,
-.resort-airport-access-section,
-.hourly-workspace {
+.field-guide-section {
   min-width: 0;
-  margin: 18px 0 0;
-  padding: 22px;
-  overflow: hidden;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  background: rgba(255, 255, 255, 0.94);
-  box-shadow: var(--shadow-card);
+  margin-top: clamp(1.25rem, 2.4vw, 2rem);
+  padding: clamp(1rem, 2vw, 1.5rem);
+  border: 1px solid var(--fg-line, #d8e1dd);
+  border-radius: var(--fg-radius-lg, 12px);
+  background: var(--fg-surface, #fff);
 }
 
 .section-heading,
 .hourly-workspace-heading {
-  margin-bottom: 14px;
+  margin-bottom: 1rem;
   display: flex;
   align-items: end;
   justify-content: space-between;
-  gap: 16px;
-}
-
-.section-heading .eyebrow,
-.hourly-workspace-heading .eyebrow {
-  margin-bottom: 4px;
+  gap: 1.25rem;
 }
 
 .section-heading h2,
 .hourly-section-title {
   margin: 0;
-  color: var(--ink-950);
-  font-size: 20px;
-  line-height: 1.2;
-  letter-spacing: -0.025em;
+  color: var(--fg-ink, #17252e);
+  font-size: clamp(1.35rem, 2.2vw, 1.8rem);
+  letter-spacing: -0.035em;
+  line-height: 1.12;
 }
 
-.section-heading > span {
-  color: var(--ink-500);
-  font-size: 10px;
-  font-weight: 650;
+.section-heading p:not(.eyebrow),
+.hourly-workspace-heading p:not(.eyebrow) {
+  max-width: 62ch;
+  margin: 0.45rem 0 0;
+  color: var(--fg-ink-muted, #526671);
+  font-size: 0.85rem;
 }
 
-.resort-daily-summary-wrap,
-.table-wrap {
-  max-width: 100%;
-  border-color: var(--border);
-  border-radius: var(--radius-sm);
-  box-shadow: none;
-  scrollbar-color: #a9bdc7 var(--snow-100);
+.timeline-legend {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.timeline-legend span {
+  padding: 0.34rem 0.55rem;
+  border: 1px solid var(--fg-line, #d8e1dd);
+  border-radius: 999px;
+  color: var(--fg-ink-muted, #526671);
+  background: var(--fg-surface-muted, #f1f5f3);
+  font-size: 0.68rem;
+  font-weight: 750;
+}
+
+.timeline-legend [data-phase="today"] {
+  border-color: color-mix(in srgb, var(--fg-signal, #c75518) 38%, var(--fg-line, #d8e1dd));
+  color: var(--fg-signal, #c75518);
+  background: var(--fg-signal-soft, #fbe7da);
+}
+
+.timeline-scroll-hint {
+  margin: -0.25rem 0 0.55rem;
+  color: var(--fg-ink-subtle, #71838c);
+  font-size: 0.7rem;
+  font-weight: 750;
+  text-align: right;
+}
+
+.field-guide-timeline {
+  position: relative;
+  width: 100%;
+  padding: 0.15rem 0 0.6rem;
+  overflow-x: auto;
+  overscroll-behavior-inline: contain;
+  scroll-snap-type: x proximity;
+  scrollbar-color: var(--fg-line-strong, #b8c7c1) transparent;
   scrollbar-width: thin;
 }
 
-.resort-daily-summary-wrap::-webkit-scrollbar,
-.table-wrap::-webkit-scrollbar,
-.chart-svg-wrap::-webkit-scrollbar {
-  width: 9px;
-  height: 9px;
+.field-guide-timeline-track {
+  width: max-content;
+  display: grid;
+  grid-auto-columns: 168px;
+  grid-auto-flow: column;
+  gap: 0.6rem;
 }
 
-.resort-daily-summary-wrap::-webkit-scrollbar-thumb,
-.table-wrap::-webkit-scrollbar-thumb,
-.chart-svg-wrap::-webkit-scrollbar-thumb {
-  border: 2px solid var(--snow-100);
-  border-radius: 999px;
-  background: #a9bdc7;
+.timeline-day-card {
+  min-width: 0;
+  min-height: 272px;
+  padding: 0.85rem;
+  border: 1px solid var(--fg-line, #d8e1dd);
+  border-radius: var(--fg-radius-md, 8px);
+  display: flex;
+  flex-direction: column;
+  scroll-snap-align: center;
+  background: var(--fg-surface, #fff);
 }
 
-.resort-daily-summary-table th,
-th {
-  color: var(--ink-800);
-  background: #e9f0f2;
-  border-color: #d7e2e6;
+.timeline-day-card[data-phase="history"] {
+  color: var(--fg-ink-muted, #526671);
+  background: var(--fg-surface-muted, #f1f5f3);
 }
 
-.resort-daily-summary-table th.compact-day-head-history {
-  background: #eef3f4;
+.timeline-day-card[data-phase="today"] {
+  border-color: color-mix(in srgb, var(--fg-signal, #c75518) 52%, var(--fg-line, #d8e1dd));
+  box-shadow: inset 0 4px var(--fg-signal, #c75518);
+  background: color-mix(in srgb, var(--fg-signal-soft, #fbe7da) 36%, #fff);
 }
 
-.resort-daily-summary-table th.compact-day-head-forecast {
-  background: #e4f1f4;
+.timeline-day-card[data-phase="forecast"] {
+  background: color-mix(in srgb, var(--fg-glacier-soft, #dceff5) 24%, #fff);
 }
 
-td {
-  color: var(--ink-800);
-  border-color: #e7eef0;
+.timeline-card-topline {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 0.5rem;
 }
 
-.resort-airport-access-list {
-  gap: 12px;
+.timeline-phase {
+  color: var(--fg-ink-subtle, #71838c);
+  font-size: 0.64rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
-.resort-airport-access-card {
-  padding: 16px;
-  border-color: var(--border);
-  border-radius: 14px;
-  box-shadow: none;
+.timeline-date {
+  display: grid;
+  color: var(--fg-ink, #17252e);
+  font-size: 0.8rem;
+  font-weight: 800;
+  line-height: 1.25;
+  text-align: right;
 }
 
-.resort-airport-access-card:hover {
-  border-color: #acd8e1;
-  transform: translateY(-1px);
-  box-shadow: 0 10px 24px rgba(8, 26, 41, 0.06);
+.timeline-condition {
+  margin-top: 1rem;
+  display: grid;
+  grid-template-columns: 34px minmax(0, 1fr);
+  align-items: center;
+  gap: 0.5rem;
 }
 
-.resort-airport-access-code {
-  color: #08748b;
-  background: #e8f7f9;
+.timeline-condition .field-guide-weather-icon {
+  width: 34px;
+  height: 34px;
 }
 
-.resort-airport-access-distance,
-.resort-airport-access-name {
-  color: var(--ink-950);
+.timeline-condition strong {
+  font-size: 0.82rem;
+  line-height: 1.2;
 }
 
-.resort-airport-access-location {
-  color: var(--ink-500);
+.timeline-temperature {
+  margin-top: 0.85rem;
+  display: grid;
+  gap: 0.18rem;
 }
 
-.hourly-workspace {
-  padding: 24px;
+.timeline-temperature strong {
+  font-size: 1.08rem;
+  letter-spacing: -0.04em;
+  white-space: nowrap;
+}
+
+.timeline-temperature span {
+  color: var(--fg-ink-subtle, #71838c);
+  font-size: 0.78rem;
+}
+
+.timeline-metrics {
+  margin: 0.75rem 0 0;
+  padding: 0.7rem 0 0;
+  border-top: 1px solid var(--fg-line, #d8e1dd);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.55rem;
+}
+
+.timeline-metrics div {
+  min-width: 0;
+}
+
+.timeline-metrics dt,
+.timeline-daylight dt {
+  color: var(--fg-ink-subtle, #71838c);
+  font-size: 0.63rem;
+  font-weight: 750;
+  text-transform: uppercase;
+}
+
+.timeline-metrics dd,
+.timeline-daylight dd {
+  margin: 0.1rem 0 0;
+  color: var(--fg-ink, #17252e);
+  font-size: 0.76rem;
+  font-weight: 750;
+}
+
+.timeline-daylight {
+  margin: auto 0 0;
+  padding-top: 0.75rem;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.55rem;
+}
+
+.hourly-workspace-heading {
+  align-items: flex-start;
 }
 
 .hourly-controls {
-  margin: 0;
-  padding: 5px;
-  gap: 6px;
-  border: 1px solid var(--border);
-  border-radius: 13px;
-  background: var(--snow-50);
+  min-width: 330px;
+  padding: 0.35rem;
+  border: 1px solid var(--fg-line, #d8e1dd);
+  border-radius: var(--fg-radius-md, 8px);
+  display: grid;
+  grid-template-columns: auto minmax(100px, 1fr) auto;
+  align-items: center;
+  gap: 0.4rem;
+  background: var(--fg-surface-muted, #f1f5f3);
 }
 
 .hourly-controls label {
-  padding-left: 7px;
-  color: var(--ink-500);
-  font-size: 10px;
+  padding-left: 0.35rem;
+  color: var(--fg-ink-subtle, #71838c);
+  font-size: 0.68rem;
+  font-weight: 800;
   text-transform: uppercase;
-  letter-spacing: 0.07em;
 }
 
 .hourly-controls select,
 .hourly-controls button {
-  height: 34px;
-  padding: 0 10px;
-  border-color: var(--border);
-  border-radius: 9px;
-  color: var(--ink-800);
-  background: #fff;
-  font-size: 11px;
-}
-
-.hourly-controls button {
-  border-color: var(--ink-950);
-  color: #fff;
-  background: var(--ink-950);
-}
-
-.hourly-controls button:hover {
-  background: var(--ink-800);
-  transform: translateY(-1px);
-}
-
-.hourly-meta {
-  margin: 0 0 16px;
-  padding: 10px 12px;
-  border-radius: 10px;
-  color: var(--ink-500);
-  background: var(--snow-50);
-  font-size: 11px;
-}
-
-.hourly-meta a {
-  color: #08748b;
-}
-
-.hourly-charts {
-  gap: 14px;
-  margin-bottom: 16px;
-}
-
-.chart-card {
-  padding: 16px 16px 11px;
-  border-color: var(--border);
-  border-radius: 14px;
-  box-shadow: none;
-}
-
-.chart-card:hover {
-  border-color: #b9d9df;
-  box-shadow: 0 10px 26px rgba(8, 26, 41, 0.05);
-}
-
-.chart-title {
-  color: var(--ink-950);
-  font-size: 14px;
-}
-
-.chart-subtitle,
-.chart-tick-text {
-  color: var(--ink-500);
-  fill: var(--ink-500);
-}
-
-.chart-grid-line {
-  stroke: #e7eef0;
-}
-
-.chart-axis-line {
-  stroke: #c8d7dc;
-}
-
-.chart-line {
-  stroke-width: 2.5;
-}
-
-.raw-data-panel {
-  border: 1px solid var(--border);
-  border-radius: 13px;
-  background: var(--snow-50);
-}
-
-.raw-data-panel summary {
-  padding: 13px 15px;
-  cursor: pointer;
-  color: var(--ink-700);
-  font-size: 12px;
+  min-height: 38px;
+  padding: 0.45rem 0.65rem;
+  border: 1px solid var(--fg-line-strong, #b8c7c1);
+  border-radius: var(--fg-radius-sm, 4px);
+  background: var(--fg-surface, #fff);
+  font-size: 0.78rem;
   font-weight: 700;
 }
 
-.raw-data-panel[open] summary {
-  color: var(--ink-950);
-  border-bottom: 1px solid var(--border);
+.hourly-controls button {
+  border-color: var(--fg-glacier, #167a9b);
+  color: #fff;
+  background: var(--fg-glacier, #167a9b);
+  cursor: pointer;
 }
 
-.raw-data-panel .table-wrap {
+.hourly-meta {
+  min-height: 40px;
+  margin: 0;
+  padding: 0.65rem 0.8rem;
+  border-left: 3px solid var(--fg-glacier, #167a9b);
+  color: var(--fg-ink-muted, #526671);
+  background: var(--fg-surface-muted, #f1f5f3);
+  font-size: 0.75rem;
+  overflow-wrap: anywhere;
+}
+
+.hourly-meta-coordinate-entry,
+.hourly-meta-coordinate {
+  display: inline;
+}
+
+.hourly-meta-coordinate-label {
+  font-weight: 750;
+}
+
+.hourly-meta-issue-link {
+  white-space: nowrap;
+}
+
+.hourly-error,
+.hourly-chart-error {
+  margin-top: 0.8rem;
+  padding: 0.75rem 0.85rem;
+  border: 1px solid color-mix(in srgb, var(--fg-danger, #a43e38) 38%, var(--fg-line, #d8e1dd));
+  border-radius: var(--fg-radius-md, 8px);
+  color: var(--fg-danger, #a43e38);
+  background: #fff4f2;
+  font-size: 0.85rem;
+}
+
+.hourly-narrative {
+  min-height: 2.5rem;
+  margin: 1rem 0 0;
+  padding: 0.85rem 1rem;
+  border: 1px solid var(--fg-line, #d8e1dd);
+  border-radius: var(--fg-radius-md, 8px);
+  color: var(--fg-ink, #17252e);
+  background: color-mix(in srgb, var(--fg-glacier-soft, #dceff5) 26%, #fff);
+  font-size: 0.88rem;
+  font-weight: 650;
+}
+
+.hourly-view-tabs {
+  margin-top: 0.8rem;
+  padding: 0.25rem;
+  border: 1px solid var(--fg-line, #d8e1dd);
+  border-radius: var(--fg-radius-md, 8px);
+  display: inline-flex;
+  gap: 0.25rem;
+  background: var(--fg-surface-muted, #f1f5f3);
+}
+
+.hourly-view-tabs button {
+  min-height: 40px;
+  padding: 0.55rem 0.8rem;
   border: 0;
-  border-radius: 0 0 12px 12px;
+  border-radius: var(--fg-radius-sm, 4px);
+  color: var(--fg-ink-muted, #526671);
+  background: transparent;
+  cursor: pointer;
+  font-size: 0.78rem;
+  font-weight: 750;
+}
+
+.hourly-view-tabs button[aria-selected="true"] {
+  color: #fff;
+  background: var(--fg-header, #122b36);
+}
+
+.hourly-charts {
+  min-width: 0;
+  margin-top: 0.9rem;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.hourly-charts[data-hourly-group="storm"] {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.chart-card {
+  min-width: 0;
+  padding: 0.9rem;
+  border: 1px solid var(--fg-line, #d8e1dd);
+  border-radius: var(--fg-radius-md, 8px);
+  background: var(--fg-surface, #fff);
+}
+
+.chart-card-header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.chart-title {
+  margin: 0;
+  color: var(--fg-ink, #17252e);
+  font-size: 0.95rem;
+  line-height: 1.2;
+}
+
+.chart-subtitle {
+  margin: 0.2rem 0 0;
+  color: var(--fg-ink-subtle, #71838c);
+  font-size: 0.7rem;
+}
+
+.chart-summary-value {
+  flex: 0 0 auto;
+  color: var(--fg-ink, #17252e);
+  font-size: 1rem;
+  font-weight: 800;
+  letter-spacing: -0.025em;
+}
+
+.chart-svg-wrap {
+  width: 100%;
+  margin-top: 0.55rem;
+  overflow-x: auto;
+}
+
+.chart-svg {
+  min-width: 320px;
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.chart-grid-line {
+  stroke: var(--fg-line, #d8e1dd);
+  stroke-width: 1;
+}
+
+.chart-axis-line {
+  stroke: var(--fg-line-strong, #b8c7c1);
+  stroke-width: 1;
+}
+
+.chart-line {
+  fill: none;
+  stroke-width: 2.3;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.chart-area {
+  opacity: 0.16;
+}
+
+.chart-bar {
+  rx: 2;
+  opacity: 0.8;
+}
+
+.chart-tick-text {
+  fill: var(--fg-ink-subtle, #71838c);
+  font-family: inherit;
+  font-size: 9px;
+}
+
+.chart-empty {
+  min-height: 180px;
+  display: grid;
+  place-items: center;
+  color: var(--fg-ink-subtle, #71838c);
+  background: var(--fg-surface-muted, #f1f5f3);
+  font-size: 0.8rem;
+}
+
+.chart-empty-zero {
+  min-height: 220px;
+  padding: 1rem;
+  color: var(--fg-ink-muted, #526671);
+  background:
+    linear-gradient(var(--fg-line, #d8e1dd), var(--fg-line, #d8e1dd)) 0 78% / 100% 1px no-repeat,
+    var(--fg-surface-muted, #f1f5f3);
+  text-align: center;
+}
+
+.wind-direction-grid {
+  margin-top: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(78px, 1fr));
+  gap: 0.45rem;
+}
+
+.wind-direction-sample {
+  min-height: 88px;
+  padding: 0.55rem;
+  border: 1px solid var(--fg-line, #d8e1dd);
+  border-radius: var(--fg-radius-sm, 4px);
+  display: grid;
+  place-items: center;
+  gap: 0.18rem;
+  background: var(--fg-surface-muted, #f1f5f3);
+  text-align: center;
+}
+
+.wind-direction-sample svg {
+  width: 24px;
+  height: 24px;
+  fill: none;
+  stroke: var(--fg-pine, #16705d);
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 2;
+}
+
+.wind-direction-sample strong {
+  font-size: 0.72rem;
+}
+
+.wind-direction-sample span {
+  color: var(--fg-ink-subtle, #71838c);
+  font-size: 0.64rem;
+}
+
+.raw-data-panel {
+  margin-top: 1rem;
+  overflow: hidden;
+}
+
+.raw-data-panel > summary {
+  min-height: 44px;
+}
+
+.raw-data-panel > p {
+  margin: 0;
+  padding: 0 0.9rem 0.8rem;
+  color: var(--fg-ink-muted, #526671);
+  font-size: 0.76rem;
+}
+
+.table-wrap {
+  max-width: 100%;
+  overflow: auto;
+  border-top: 1px solid var(--fg-line, #d8e1dd);
+}
+
+.hourly-table {
+  min-width: 920px;
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.72rem;
+}
+
+.hourly-table th,
+.hourly-table td {
+  padding: 0.5rem 0.6rem;
+  border-right: 1px solid var(--fg-line, #d8e1dd);
+  border-bottom: 1px solid var(--fg-line, #d8e1dd);
+  text-align: right;
+  white-space: nowrap;
+}
+
+.hourly-table th {
+  color: var(--fg-ink-muted, #526671);
+  background: var(--fg-surface-muted, #f1f5f3);
+  font-weight: 800;
+}
+
+.hourly-table th:first-child,
+.hourly-table td:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 2;
+  text-align: left;
+  background: var(--fg-surface, #fff);
+}
+
+.resort-airport-access-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 235px), 1fr));
+  gap: 0.7rem;
+}
+
+.resort-airport-access-card {
+  min-width: 0;
+  padding: 0.9rem;
+  border: 1px solid var(--fg-line, #d8e1dd);
+  border-radius: var(--fg-radius-md, 8px);
+  background: var(--fg-surface, #fff);
+}
+
+.resort-airport-access-card-head {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.resort-airport-access-code {
+  padding: 0.22rem 0.42rem;
+  border-radius: var(--fg-radius-sm, 4px);
+  color: var(--fg-glacier, #167a9b);
+  background: var(--fg-glacier-soft, #dceff5);
+  font-size: 0.72rem;
+  font-weight: 850;
+  letter-spacing: 0.06em;
+}
+
+.resort-airport-access-distance {
+  color: var(--fg-ink-muted, #526671);
+  font-size: 0.75rem;
+  font-weight: 750;
+}
+
+.resort-airport-access-name {
+  margin: 0.8rem 0 0;
+  color: var(--fg-ink, #17252e);
+  font-size: 0.9rem;
+  font-weight: 800;
+  line-height: 1.3;
+}
+
+.resort-airport-access-location,
+.resort-airport-access-empty {
+  margin: 0.25rem 0 0;
+  color: var(--fg-ink-muted, #526671);
+  font-size: 0.75rem;
 }
 
 .page-footer {
-  width: min(1400px, 100%);
-  margin: 0 auto;
-  padding: 0 28px 28px;
-  color: var(--ink-500);
-  font-size: 11px;
+  width: min(var(--fg-content-max, 90rem), 100%);
+  margin-inline: auto;
+  padding: 0 var(--fg-page-gutter, 1.5rem) 2rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  color: var(--fg-ink-subtle, #71838c);
+  font-size: 0.75rem;
 }
 
 .page-footer strong {
-  color: var(--ink-800);
+  color: var(--fg-ink, #17252e);
 }
 
 @media (max-width: 980px) {
-  .resort-hero-mountain {
-    right: -12%;
-    width: 58%;
-    opacity: 0.48;
+  .resort-masthead-grid {
+    grid-template-columns: 1fr;
   }
 
   .resort-snapshot {
-    max-width: 100%;
-  }
-}
-
-@media (max-width: 700px) {
-  .site-header-inner {
-    min-height: 64px;
-    padding: 0 16px;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
-  .site-header-note,
-  .brand-copy span {
-    display: none;
-  }
-
-  .brand-mark {
-    width: 36px;
-    height: 36px;
-  }
-
-  main {
-    padding: 14px;
-  }
-
-  .resort-hero {
-    min-height: 470px;
-    padding: 24px 20px 150px;
-    border-radius: 20px;
-  }
-
-  .back-link {
-    margin-bottom: 24px;
-  }
-
-  .resort-hero h1 {
-    font-size: clamp(36px, 11.5vw, 50px);
-  }
-
-  .resort-identity-meta {
-    margin-top: 17px;
-    align-items: flex-start;
-    flex-direction: column;
-    gap: 6px;
-  }
-
-  .resort-identity-meta p {
-    max-width: 100%;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .resort-snapshot {
-    width: calc(100% + 20px);
-    margin-top: 20px;
-    padding-right: 20px;
-    display: flex;
-    gap: 8px;
-    overflow-x: auto;
-    scroll-snap-type: x mandatory;
-    scrollbar-width: none;
-  }
-
-  .resort-snapshot::-webkit-scrollbar {
-    display: none;
-  }
-
-  .snapshot-card {
-    min-width: 190px;
-    scroll-snap-align: start;
-  }
-
-  .resort-hero-mountain {
-    right: -15%;
-    width: 112%;
-    height: 42%;
-    opacity: 0.72;
-  }
-
-  .resort-timeline-section,
-  .resort-airport-access-section,
-  .hourly-workspace {
-    margin-top: 12px;
-    padding: 16px 12px;
-    border-radius: 15px;
+  .snapshot-card:first-child {
+    grid-column: auto;
   }
 
   .section-heading,
   .hourly-workspace-heading {
-    padding: 0 3px;
     align-items: flex-start;
   }
 
-  .section-heading h2,
-  .hourly-section-title {
-    font-size: 18px;
-  }
-
-  .section-heading > span {
-    padding-top: 20px;
-  }
-
-  .resort-daily-summary-wrap {
-    position: relative;
-    box-shadow: 12px 0 18px -18px rgba(8, 26, 41, 0.55) inset;
-  }
-
-  .resort-airport-access-card {
-    padding: 14px;
-  }
-
   .hourly-workspace-heading {
-    margin-bottom: 12px;
     flex-direction: column;
-    gap: 12px;
   }
 
   .hourly-controls {
     width: 100%;
   }
 
-  .hourly-controls select {
+  .hourly-charts,
+  .hourly-charts[data-hourly-group="storm"] {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 700px) {
+  .resort-field-guide {
+    padding: 0.85rem var(--fg-page-gutter, 0.875rem) 2rem;
+  }
+
+  .resort-masthead,
+  .field-guide-section {
+    padding: 0.9rem;
+    border-radius: var(--fg-radius-md, 8px);
+  }
+
+  .resort-masthead-topline {
+    padding-bottom: 0.65rem;
+  }
+
+  .resort-report-label {
+    display: none;
+  }
+
+  .resort-masthead-grid {
+    padding-top: 1rem;
+    gap: 1rem;
+  }
+
+  .resort-intro h1 {
+    max-width: none;
+    font-size: clamp(2.15rem, 10.5vw, 3rem);
+  }
+
+  .resort-outlook {
+    margin-top: 0.75rem;
+    font-size: 0.92rem;
+  }
+
+  .resort-identity-meta {
+    margin-top: 0.8rem;
+    align-items: stretch;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+
+  .resort-identity-meta p {
+    width: 100%;
+  }
+
+  .resort-snapshot {
+    grid-template-columns: 1fr;
+    gap: 0.45rem;
+  }
+
+  .snapshot-card,
+  .snapshot-card:first-child {
+    min-height: 76px;
+    grid-column: auto;
+  }
+
+  .section-heading {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .timeline-scroll-hint {
+    display: block;
+  }
+
+  .field-guide-timeline-track {
+    grid-auto-columns: min(78vw, 176px);
+  }
+
+  .hourly-controls {
     min-width: 0;
-    flex: 1;
+    grid-template-columns: 1fr auto;
+  }
+
+  .hourly-controls label {
+    grid-column: 1 / -1;
+    padding-left: 0;
+  }
+
+  .hourly-view-tabs {
+    width: 100%;
+    overflow-x: auto;
+  }
+
+  .hourly-view-tabs button {
+    flex: 1 0 auto;
+  }
+
+  .hourly-charts {
+    grid-template-columns: 1fr;
   }
 
   .chart-card {
-    padding: 14px 10px 8px;
+    padding: 0.75rem;
+  }
+
+  .wind-direction-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
   .page-footer {
-    padding: 0 16px 24px;
+    padding: 0 var(--fg-page-gutter, 0.875rem) 1.5rem;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+}
+
+@media (max-width: 390px) {
+  .wind-direction-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  *,
-  *::before,
-  *::after {
-    scroll-behavior: auto !important;
-    transition-duration: 0.01ms !important;
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
+  .field-guide-timeline {
+    scroll-behavior: auto;
   }
 }

--- a/assets/js/resort_hourly.js
+++ b/assets/js/resort_hourly.js
@@ -12,6 +12,8 @@ const fieldGuideWeather = fieldGuide.weather || {};
 const hoursSelect = document.getElementById("hours-select");
 const refreshBtn = document.getElementById("hours-refresh-btn");
 const titleEl = document.getElementById("hourly-title");
+const resortContextEl = document.getElementById("resort-context");
+const outlookEl = document.getElementById("resort-outlook");
 const localTimeEl = document.getElementById("resort-local-time");
 const websiteLinkEl = document.getElementById("resort-website-link");
 const locationLinkEl = document.getElementById("resort-location-link");
@@ -23,7 +25,9 @@ const airportAccessRootEl = document.getElementById("resort-airport-access-root"
 const metaEl = document.getElementById("hourly-meta");
 const errorEl = document.getElementById("hourly-error");
 const chartErrorEl = document.getElementById("hourly-chart-error");
+const hourlyNarrativeEl = document.getElementById("hourly-narrative");
 const chartsEl = document.getElementById("hourly-charts");
+const hourlyTabButtons = Array.from(document.querySelectorAll("[data-hourly-group]"));
 const table = document.getElementById("hourly-table");
 const thead = table ? table.querySelector("thead") : null;
 const tbody = table ? table.querySelector("tbody") : null;
@@ -32,9 +36,24 @@ let localTimeTimerId = null;
 let timelineAutoCentered = false;
 let lastHourlyPayload = null;
 let chartResizeRafId = null;
+let activeHourlyGroup = "storm";
 
 const metricDefs = Array.isArray(hourlyMetricHelpers.metricDefs) ? hourlyMetricHelpers.metricDefs : [];
 const trimHourlyPayload = hourlyMetricHelpers.trimHourlyPayload;
+const HOURLY_GROUPS = Object.freeze({
+  storm: Object.freeze({
+    label: "Storm",
+    metrics: Object.freeze(["snowfall", "rain", "precipitation_probability"]),
+  }),
+  wind: Object.freeze({
+    label: "Wind",
+    metrics: Object.freeze(["wind_speed_10m", "wind_direction_10m"]),
+  }),
+  visibility: Object.freeze({
+    label: "Visibility and depth",
+    metrics: Object.freeze(["visibility", "snow_depth"]),
+  }),
+});
 
 const routePrefix = (() => {
   const path = window.location.pathname || "";
@@ -88,6 +107,81 @@ const resolveResortLabel = (payload) => String(
   || resortId
   || "Unknown resort",
 ).trim();
+
+const friendlyDate = (rawDate, fallback = "") => {
+  const text = String(rawDate || "").trim();
+  if (!text) return fallback;
+  const datePart = text.split("T", 1)[0];
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(datePart);
+  if (!match) return text;
+  try {
+    return new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric", weekday: "short", timeZone: "UTC" })
+      .format(new Date(`${datePart}T12:00:00Z`));
+  } catch (_error) {
+    return `${match[2]}-${match[3]}`;
+  }
+};
+
+const contextText = (value) => {
+  if (Array.isArray(value)) return value.flatMap((item) => contextText(item));
+  if (value && typeof value === "object") {
+    return contextText(value.display_name || value.name || value.label || value.code || "");
+  }
+  const text = String(value || "").trim();
+  return text ? [text] : [];
+};
+
+const renderResortIdentity = (payload = null) => {
+  const label = resolveResortLabel(payload);
+  if (titleEl) titleEl.textContent = label;
+  document.title = `${label} forecast | CloseSnow`;
+  if (!resortContextEl) return;
+  const source = { ...(dailySummary || {}), ...(payload || {}) };
+  const place = [source.region || source.subregion, source.admin1, source.country]
+    .flatMap((value) => contextText(value))
+    .filter((value, index, values) => values.indexOf(value) === index);
+  const passes = contextText(source.pass_types).map((value) => `${value} pass`);
+  resortContextEl.textContent = [...place, ...passes].join(" · ");
+};
+
+const strongestDailySignal = (daily, unitMode) => {
+  const days = Array.isArray(daily) ? daily.slice(0, 7) : [];
+  let snowDay = null;
+  let rainDay = null;
+  days.forEach((day) => {
+    const snow = toFiniteNumber(day?.snowfall_cm) || 0;
+    const rain = toFiniteNumber(day?.rain_mm) || 0;
+    if (!snowDay || snow > snowDay.value) snowDay = { day, value: snow };
+    if (!rainDay || rain > rainDay.value) rainDay = { day, value: rain };
+  });
+  if (snowDay && snowDay.value > 0) {
+    const amount = fieldGuideUnits.formatSnow
+      ? fieldGuideUnits.formatSnow(snowDay.value, unitMode)
+      : `${snowDay.value.toFixed(1)} cm`;
+    return `The strongest snow signal is ${amount} on ${friendlyDate(snowDay.day?.date, "the leading forecast day")}.`;
+  }
+  if (rainDay && rainDay.value > 0) {
+    const amount = fieldGuideUnits.formatRain
+      ? fieldGuideUnits.formatRain(rainDay.value, unitMode)
+      : `${rainDay.value.toFixed(1)} mm`;
+    return `The wettest signal is ${amount} on ${friendlyDate(rainDay.day?.date, "the leading forecast day")}.`;
+  }
+  return "No meaningful snow or rain signal stands out in the next seven days.";
+};
+
+const renderResortOutlook = () => {
+  if (!outlookEl) return;
+  const daily = Array.isArray(dailySummary?.daily) ? dailySummary.daily : [];
+  if (!daily.length) {
+    outlookEl.textContent = "The seven-day outlook is not available yet.";
+    return;
+  }
+  const unitMode = currentUnitMode();
+  const base = fieldGuideCopy.dailyOutlook
+    ? fieldGuideCopy.dailyOutlook(daily, { mode: unitMode, days: 7 })
+    : "Seven-day forecast available below.";
+  outlookEl.textContent = `${base} ${strongestDailySignal(daily, unitMode)}`.trim();
+};
 
 const buildExternalLink = (href, label, className = "") => {
   const url = String(href || "").trim();
@@ -439,6 +533,9 @@ const renderResortSnapshot = () => {
   const snow = daily.slice(0, 7).reduce((sum, day) => sum + (toFiniteNumber(day?.snowfall_cm) || 0), 0);
   const rain = daily.slice(0, 7).reduce((sum, day) => sum + (toFiniteNumber(day?.rain_mm) || 0), 0);
   const weatherCode = today.weather_code;
+  const conditionName = fieldGuideWeather.conditionName
+    ? fieldGuideWeather.conditionName(weatherCode)
+    : "Conditions unavailable";
   const unitMode = currentUnitMode();
   const weatherIcon = fieldGuideWeather.iconHtml
     ? fieldGuideWeather.iconHtml(weatherCode)
@@ -464,7 +561,7 @@ const renderResortSnapshot = () => {
   snapshotEl.innerHTML = `
     <article class="snapshot-card snapshot-card-weather">
       <span class="snapshot-icon">${weatherIcon}</span>
-      <span><small>Today</small><strong>${temperature}</strong><em>High / low</em></span>
+      <span><small>Today</small><strong>${temperature}</strong><em>${conditionName}</em></span>
     </article>
     <article class="snapshot-card">
       <span class="snapshot-icon snapshot-icon-snow">${metricIcon("snow", "Snowfall")}</span>
@@ -476,6 +573,7 @@ const renderResortSnapshot = () => {
     </article>`;
   if (outlook) snapshotEl.setAttribute("aria-label", outlook);
   snapshotEl.hidden = false;
+  renderResortOutlook();
 };
 
 const toFiniteNumber = (value) => {
@@ -495,18 +593,161 @@ const splitTimeLabel = (rawTime) => {
   return { dateLabel: md, timeLabel: hourLabel };
 };
 
+const METRIC_PRESENTATION = Object.freeze({
+  snowfall: Object.freeze({
+    title: "Snowfall",
+    description: "Hourly accumulation across the selected weather window",
+    chart: "bar",
+    color: "#167a9b",
+  }),
+  rain: Object.freeze({
+    title: "Rainfall",
+    description: "Hourly liquid precipitation at the forecast grid",
+    chart: "bar",
+    color: "#16705d",
+  }),
+  precipitation_probability: Object.freeze({
+    title: "Precipitation chance",
+    description: "Likelihood of measurable precipitation each hour",
+    chart: "area",
+    color: "#486b9b",
+  }),
+  wind_speed_10m: Object.freeze({
+    title: "Wind speed",
+    description: "Forecast wind at 10 metres above the surface",
+    chart: "line",
+    color: "#c75518",
+  }),
+  wind_direction_10m: Object.freeze({
+    title: "Wind direction",
+    description: "Where the wind is coming from, sampled across the window",
+    chart: "direction",
+    color: "#16705d",
+  }),
+  visibility: Object.freeze({
+    title: "Visibility",
+    description: "Forecast sight distance; lower values mean poorer visibility",
+    chart: "area",
+    color: "#486b9b",
+  }),
+  snow_depth: Object.freeze({
+    title: "Snow depth",
+    description: "Modelled snowpack depth at the forecast grid",
+    chart: "line",
+    color: "#167a9b",
+  }),
+});
+
+const degreesToCardinal = (rawDegrees) => {
+  const degrees = toFiniteNumber(rawDegrees);
+  if (degrees === null) return "—";
+  const labels = ["N", "NNE", "NE", "ENE", "E", "ESE", "SE", "SSE", "S", "SSW", "SW", "WSW", "W", "WNW", "NW", "NNW"];
+  const normalized = ((degrees % 360) + 360) % 360;
+  return labels[Math.round(normalized / 22.5) % labels.length];
+};
+
+const metricUnit = (metricKey, mode = currentUnitMode()) => {
+  if (metricKey === "snowfall") return fieldGuideUnits.unitLabel ? fieldGuideUnits.unitLabel("snow", mode) : "cm";
+  if (metricKey === "rain") return fieldGuideUnits.unitLabel ? fieldGuideUnits.unitLabel("rain", mode) : "mm";
+  if (metricKey === "precipitation_probability") return "%";
+  if (metricKey === "snow_depth") return mode === "imperial" ? "ft" : "m";
+  if (metricKey === "wind_speed_10m") return mode === "imperial" ? "mph" : "km/h";
+  if (metricKey === "wind_direction_10m") return "°";
+  if (metricKey === "visibility") return mode === "imperial" ? "mi" : "km";
+  return "";
+};
+
+const convertHourlyMetric = (metricKey, rawValue, mode = currentUnitMode()) => {
+  const value = toFiniteNumber(rawValue);
+  if (value === null) return null;
+  if (metricKey === "snowfall") {
+    return fieldGuideUnits.convertValue ? fieldGuideUnits.convertValue("snow", value, mode) : value;
+  }
+  if (metricKey === "rain") {
+    return fieldGuideUnits.convertValue ? fieldGuideUnits.convertValue("rain", value, mode) : value;
+  }
+  if (metricKey === "snow_depth") return mode === "imperial" ? value * 3.28084 : value;
+  if (metricKey === "wind_speed_10m") return mode === "imperial" ? value / 1.609344 : value;
+  if (metricKey === "visibility") return mode === "imperial" ? value / 1609.344 : value / 1000;
+  return value;
+};
+
+const metricDigits = (metricKey, mode = currentUnitMode()) => {
+  if (metricKey === "precipitation_probability" || metricKey === "wind_direction_10m") return 0;
+  if (metricKey === "rain" && mode === "imperial") return 2;
+  if (metricKey === "visibility") return 1;
+  return 1;
+};
+
+const formatMetricValue = (metricKey, rawValue, options = {}) => {
+  const mode = options.mode || currentUnitMode();
+  const converted = convertHourlyMetric(metricKey, rawValue, mode);
+  if (converted === null) return "—";
+  if (metricKey === "wind_direction_10m") {
+    return `${degreesToCardinal(converted)} ${Math.round(converted)}°`;
+  }
+  const digits = Number.isInteger(options.digits) ? options.digits : metricDigits(metricKey, mode);
+  const number = converted.toFixed(digits);
+  if (options.withUnit === false) return number;
+  if (metricKey === "precipitation_probability") return `${number}%`;
+  const unit = metricUnit(metricKey, mode);
+  return unit ? `${number} ${unit}` : number;
+};
+
+const friendlyHour = (rawTime) => {
+  const text = String(rawTime || "").trim();
+  const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})/.exec(text);
+  if (!match) return text || "the selected window";
+  try {
+    const date = new Date(Date.UTC(
+      Number(match[1]),
+      Number(match[2]) - 1,
+      Number(match[3]),
+      Number(match[4]),
+      Number(match[5]),
+    ));
+    return new Intl.DateTimeFormat(undefined, {
+      weekday: "short",
+      hour: "numeric",
+      minute: match[5] === "00" ? undefined : "2-digit",
+      timeZone: "UTC",
+    }).format(date);
+  } catch (_error) {
+    return text.replace("T", " ");
+  }
+};
+
+const finiteSeries = (values) => values.map((value) => toFiniteNumber(value));
+
+const extremeIndex = (values, type = "max") => {
+  let selectedIndex = -1;
+  let selectedValue = null;
+  values.forEach((value, index) => {
+    const number = toFiniteNumber(value);
+    if (number === null) return;
+    if (selectedValue === null || (type === "min" ? number < selectedValue : number > selectedValue)) {
+      selectedIndex = index;
+      selectedValue = number;
+    }
+  });
+  return { index: selectedIndex, value: selectedValue };
+};
+
 const chartYBounds = (metricKey, values) => {
   if (metricKey === "precipitation_probability") return { min: 0, max: 100 };
-  if (metricKey === "wind_direction_10m") return { min: 0, max: 360 };
-  const finiteValues = values.filter((v) => v !== null);
+  const finiteValues = values.filter((value) => value !== null);
   if (!finiteValues.length) return null;
   let min = Math.min(...finiteValues);
   let max = Math.max(...finiteValues);
-  if (min === max) {
-    const pad = min === 0 ? 1 : Math.abs(min) * 0.1;
-    min -= pad;
-    max += pad;
+  if (["snowfall", "rain", "wind_speed_10m"].includes(metricKey)) {
+    min = 0;
+    max = Math.max(max * 1.1, metricKey === "wind_speed_10m" ? 5 : 1);
+    return { min, max };
   }
+  const span = max - min;
+  const pad = span > 0 ? span * 0.12 : (Math.abs(max) * 0.08 || 1);
+  min = Math.max(0, min - pad);
+  max += pad;
   return { min, max };
 };
 
@@ -526,30 +767,81 @@ const chartLinePath = (values, xForIndex, yForValue) => {
   return path.trim();
 };
 
+const chartAreaPath = (values, xForIndex, yForValue, baselineY) => {
+  const segments = [];
+  let current = [];
+  values.forEach((value, index) => {
+    if (value === null) {
+      if (current.length) segments.push(current);
+      current = [];
+      return;
+    }
+    current.push({ index, value });
+  });
+  if (current.length) segments.push(current);
+  return segments.map((segment) => {
+    const first = segment[0];
+    const last = segment[segment.length - 1];
+    const line = segment.map((point) => `L${xForIndex(point.index).toFixed(2)} ${yForValue(point.value).toFixed(2)}`).join(" ");
+    return `M${xForIndex(first.index).toFixed(2)} ${baselineY.toFixed(2)} ${line} L${xForIndex(last.index).toFixed(2)} ${baselineY.toFixed(2)} Z`;
+  }).join(" ");
+};
+
 const resolveChartWidth = () => {
   if (!chartsEl) return 720;
   const containerWidth = chartsEl.getBoundingClientRect().width || chartsEl.clientWidth || 720;
   const isSingleColumn = typeof window.matchMedia === "function"
     && window.matchMedia("(max-width: 980px)").matches;
+  const columns = isSingleColumn ? 1 : (activeHourlyGroup === "storm" ? 3 : 2);
   const gap = 12;
   const cardHorizontalPadding = 22;
-  const rawCardWidth = isSingleColumn ? containerWidth : ((containerWidth - gap) / 2);
+  const rawCardWidth = (containerWidth - (gap * (columns - 1))) / columns;
   return Math.max(320, Math.round(rawCardWidth - cardHorizontalPadding));
 };
 
-const renderMetricChartCard = (metric, times, values, chartWidth) => {
+const metricSummary = (metricKey, rawValues) => {
+  const finite = rawValues.map((value) => toFiniteNumber(value)).filter((value) => value !== null);
+  if (!finite.length) return "No readings";
+  if (["snowfall", "rain"].includes(metricKey)) {
+    const total = finite.reduce((sum, value) => sum + value, 0);
+    return `Total ${formatMetricValue(metricKey, total)}`;
+  }
+  if (metricKey === "visibility") {
+    return `Low ${formatMetricValue(metricKey, Math.min(...finite))}`;
+  }
+  if (metricKey === "snow_depth") {
+    return `Latest ${formatMetricValue(metricKey, finite[finite.length - 1])}`;
+  }
+  return `Peak ${formatMetricValue(metricKey, Math.max(...finite))}`;
+};
+
+const renderMetricChartCard = (metricKey, times, rawValues, chartWidth) => {
+  const metric = METRIC_PRESENTATION[metricKey];
   const card = document.createElement("article");
   card.className = "chart-card";
+  card.dataset.metric = metricKey;
 
-  const title = document.createElement("h2");
+  const header = document.createElement("div");
+  header.className = "chart-card-header";
+  const copy = document.createElement("div");
+  const title = document.createElement("h3");
   title.className = "chart-title";
   title.textContent = metric.title;
-  card.appendChild(title);
+  copy.appendChild(title);
 
   const subtitle = document.createElement("p");
   subtitle.className = "chart-subtitle";
-  subtitle.textContent = `Unit: ${metric.unit}`;
-  card.appendChild(subtitle);
+  subtitle.textContent = `${metric.description} · ${metricUnit(metricKey)}`;
+  copy.appendChild(subtitle);
+
+  const summary = document.createElement("strong");
+  summary.className = "chart-summary-value";
+  summary.textContent = metricSummary(metricKey, rawValues);
+  header.appendChild(copy);
+  header.appendChild(summary);
+  card.appendChild(header);
+
+  const values = rawValues.map((value) => convertHourlyMetric(metricKey, value));
 
   const finiteValues = values.filter((v) => v !== null);
   if (!times.length || !finiteValues.length) {
@@ -559,8 +851,17 @@ const renderMetricChartCard = (metric, times, values, chartWidth) => {
     card.appendChild(empty);
     return card;
   }
+  if (metric.chart === "bar" && finiteValues.every((value) => value === 0)) {
+    const empty = document.createElement("div");
+    empty.className = "chart-empty chart-empty-zero";
+    empty.textContent = metricKey === "snowfall"
+      ? "No hourly snow accumulation is modelled in this window."
+      : "No hourly rain accumulation is modelled in this window.";
+    card.appendChild(empty);
+    return card;
+  }
 
-  const yBounds = chartYBounds(metric.key, values);
+  const yBounds = chartYBounds(metricKey, values);
   if (!yBounds) {
     const empty = document.createElement("div");
     empty.className = "chart-empty";
@@ -590,7 +891,7 @@ const renderMetricChartCard = (metric, times, values, chartWidth) => {
   svg.setAttribute("class", "chart-svg");
   svg.setAttribute("viewBox", `0 0 ${width} ${height}`);
   svg.setAttribute("role", "img");
-  svg.setAttribute("aria-label", `${metric.title} hourly trend line chart`);
+  svg.setAttribute("aria-label", `${metric.title} by hour. ${summary.textContent}.`);
 
   const yTicks = 4;
   for (let i = 0; i <= yTicks; i += 1) {
@@ -611,7 +912,7 @@ const renderMetricChartCard = (metric, times, values, chartWidth) => {
     tick.setAttribute("x", String(padLeft - 6));
     tick.setAttribute("y", String(y + 3));
     tick.setAttribute("text-anchor", "end");
-    tick.textContent = formatValue(value);
+    tick.textContent = value.toFixed(metricDigits(metricKey));
     svg.appendChild(tick);
   }
 
@@ -654,29 +955,146 @@ const renderMetricChartCard = (metric, times, values, chartWidth) => {
   axisY.setAttribute("y2", String(height - padBottom));
   svg.appendChild(axisY);
 
-  const line = document.createElementNS(svgNs, "path");
-  line.setAttribute("class", "chart-line");
-  line.setAttribute("stroke", metric.color);
-  line.setAttribute("d", chartLinePath(values, xForIndex, yForValue));
-  svg.appendChild(line);
-
-  values.forEach((value, idx) => {
-    if (value === null) return;
-    const point = document.createElementNS(svgNs, "circle");
-    point.setAttribute("class", "chart-point");
-    point.setAttribute("cx", xForIndex(idx).toFixed(2));
-    point.setAttribute("cy", yForValue(value).toFixed(2));
-    point.setAttribute("r", "2.6");
-    point.setAttribute("fill", metric.color);
-    const pointTitle = document.createElementNS(svgNs, "title");
-    pointTitle.textContent = `${times[idx]} | ${formatValue(value)} ${metric.unit}`;
-    point.appendChild(pointTitle);
-    svg.appendChild(point);
-  });
+  if (metric.chart === "bar") {
+    const baselineY = yForValue(0);
+    const barWidth = Math.max(1.5, Math.min(18, (innerW / Math.max(1, times.length)) * 0.68));
+    values.forEach((value, index) => {
+      if (value === null) return;
+      const bar = document.createElementNS(svgNs, "rect");
+      const y = yForValue(Math.max(0, value));
+      bar.setAttribute("class", "chart-bar");
+      bar.setAttribute("x", (xForIndex(index) - (barWidth / 2)).toFixed(2));
+      bar.setAttribute("y", y.toFixed(2));
+      bar.setAttribute("width", barWidth.toFixed(2));
+      bar.setAttribute("height", Math.max(0, baselineY - y).toFixed(2));
+      bar.setAttribute("fill", metric.color);
+      svg.appendChild(bar);
+    });
+  } else {
+    if (metric.chart === "area") {
+      const area = document.createElementNS(svgNs, "path");
+      area.setAttribute("class", "chart-area");
+      area.setAttribute("fill", metric.color);
+      area.setAttribute("d", chartAreaPath(values, xForIndex, yForValue, yForValue(yBounds.min)));
+      svg.appendChild(area);
+    }
+    const line = document.createElementNS(svgNs, "path");
+    line.setAttribute("class", "chart-line");
+    line.setAttribute("stroke", metric.color);
+    line.setAttribute("d", chartLinePath(values, xForIndex, yForValue));
+    svg.appendChild(line);
+  }
 
   svgWrap.appendChild(svg);
   card.appendChild(svgWrap);
   return card;
+};
+
+const renderWindDirectionCard = (times, rawValues) => {
+  const metric = METRIC_PRESENTATION.wind_direction_10m;
+  const card = document.createElement("article");
+  card.className = "chart-card wind-direction-card";
+  card.dataset.metric = "wind_direction_10m";
+  const title = document.createElement("h3");
+  title.className = "chart-title";
+  title.textContent = metric.title;
+  const subtitle = document.createElement("p");
+  subtitle.className = "chart-subtitle";
+  subtitle.textContent = metric.description;
+  card.appendChild(title);
+  card.appendChild(subtitle);
+
+  const validIndexes = rawValues
+    .map((value, index) => (toFiniteNumber(value) === null ? -1 : index))
+    .filter((index) => index >= 0);
+  if (!validIndexes.length) {
+    const empty = document.createElement("div");
+    empty.className = "chart-empty";
+    empty.textContent = "No wind direction readings in this window.";
+    card.appendChild(empty);
+    return card;
+  }
+  const step = Math.max(1, Math.ceil(validIndexes.length / 12));
+  const sampled = validIndexes.filter((_, index) => index % step === 0);
+  const lastIndex = validIndexes[validIndexes.length - 1];
+  if (!sampled.includes(lastIndex)) sampled.push(lastIndex);
+
+  const grid = document.createElement("div");
+  grid.className = "wind-direction-grid";
+  sampled.forEach((index) => {
+    const degrees = toFiniteNumber(rawValues[index]);
+    const sample = document.createElement("div");
+    sample.className = "wind-direction-sample";
+    sample.setAttribute("aria-label", `${friendlyHour(times[index])}: wind from ${degreesToCardinal(degrees)}, ${Math.round(degrees)} degrees`);
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    svg.setAttribute("viewBox", "0 0 24 24");
+    svg.setAttribute("aria-hidden", "true");
+    svg.style.transform = `rotate(${degrees}deg)`;
+    const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    path.setAttribute("d", "M12 20V4m0 0-5 5m5-5 5 5");
+    svg.appendChild(path);
+    const direction = document.createElement("strong");
+    direction.textContent = `${degreesToCardinal(degrees)} ${Math.round(degrees)}°`;
+    const time = document.createElement("span");
+    time.textContent = friendlyHour(times[index]);
+    sample.appendChild(svg);
+    sample.appendChild(direction);
+    sample.appendChild(time);
+    grid.appendChild(sample);
+  });
+  card.appendChild(grid);
+  return card;
+};
+
+const renderHourlyNarrative = (payload) => {
+  if (!hourlyNarrativeEl) return;
+  const hourly = payload?.hourly || {};
+  const times = Array.isArray(hourly.time) ? hourly.time : [];
+  const windowLabel = `${times.length || 0}-hour window`;
+  if (!times.length) {
+    hourlyNarrativeEl.textContent = "Hourly readings are not available for this forecast window.";
+    return;
+  }
+  if (activeHourlyGroup === "storm") {
+    const snow = finiteSeries(Array.isArray(hourly.snowfall) ? hourly.snowfall : []);
+    const rain = finiteSeries(Array.isArray(hourly.rain) ? hourly.rain : []);
+    const snowTotal = snow.reduce((sum, value) => sum + (value || 0), 0);
+    const rainTotal = rain.reduce((sum, value) => sum + (value || 0), 0);
+    const probability = extremeIndex(Array.isArray(hourly.precipitation_probability) ? hourly.precipitation_probability : []);
+    const accumulation = snowTotal > 0 || rainTotal > 0
+      ? `the model shows ${formatMetricValue("snowfall", snowTotal)} of snow and ${formatMetricValue("rain", rainTotal)} of rain.`
+      : "no accumulating snow or rain is currently modelled.";
+    const chance = probability.value === null
+      ? "Precipitation probability is unavailable."
+      : `The highest precipitation chance is ${Math.round(probability.value)}% around ${friendlyHour(times[probability.index])}.`;
+    hourlyNarrativeEl.textContent = `Across this ${windowLabel}, ${accumulation} ${chance}`;
+    return;
+  }
+  if (activeHourlyGroup === "wind") {
+    const wind = Array.isArray(hourly.wind_speed_10m) ? hourly.wind_speed_10m : [];
+    const peak = extremeIndex(wind);
+    if (peak.value === null) {
+      hourlyNarrativeEl.textContent = `Wind readings are unavailable across this ${windowLabel}.`;
+      return;
+    }
+    const directions = Array.isArray(hourly.wind_direction_10m) ? hourly.wind_direction_10m : [];
+    const direction = toFiniteNumber(directions[peak.index]);
+    const directionCopy = direction === null ? "Direction is unavailable at that hour." : `It is coming from ${degreesToCardinal(direction)} (${Math.round(direction)}°) at that hour.`;
+    hourlyNarrativeEl.textContent = `Peak wind reaches ${formatMetricValue("wind_speed_10m", peak.value)} around ${friendlyHour(times[peak.index])}. ${directionCopy}`;
+    return;
+  }
+  const visibility = Array.isArray(hourly.visibility) ? hourly.visibility : [];
+  const minimum = extremeIndex(visibility, "min");
+  const depth = (Array.isArray(hourly.snow_depth) ? hourly.snow_depth : [])
+    .map((value) => toFiniteNumber(value))
+    .filter((value) => value !== null);
+  const visibilityCopy = minimum.value === null
+    ? "Visibility readings are unavailable."
+    : `Visibility is lowest at ${formatMetricValue("visibility", minimum.value)} around ${friendlyHour(times[minimum.index])}.`;
+  const depthCopy = depth.length
+    ? `Modelled snow depth ends near ${formatMetricValue("snow_depth", depth[depth.length - 1])}.`
+    : "Snow-depth readings are unavailable.";
+  hourlyNarrativeEl.textContent = `${visibilityCopy} ${depthCopy}`;
 };
 
 const renderHourlyCharts = (payload) => {
@@ -687,12 +1105,19 @@ const renderHourlyCharts = (payload) => {
   const times = Array.isArray(hourly.time) ? hourly.time : [];
   const chartWidth = resolveChartWidth();
   const frag = document.createDocumentFragment();
-  metricDefs.forEach((metric) => {
-    const rawValues = Array.isArray(hourly[metric.key]) ? hourly[metric.key] : [];
-    const values = times.map((_, idx) => toFiniteNumber(rawValues[idx]));
-    frag.appendChild(renderMetricChartCard(metric, times, values, chartWidth));
+  const group = HOURLY_GROUPS[activeHourlyGroup] || HOURLY_GROUPS.storm;
+  chartsEl.dataset.hourlyGroup = activeHourlyGroup;
+  group.metrics.forEach((metricKey) => {
+    const rawValues = Array.isArray(hourly[metricKey]) ? hourly[metricKey] : [];
+    if (metricKey === "wind_direction_10m") {
+      frag.appendChild(renderWindDirectionCard(times, rawValues));
+    } else {
+      frag.appendChild(renderMetricChartCard(metricKey, times, rawValues, chartWidth));
+    }
   });
   chartsEl.appendChild(frag);
+  chartsEl.setAttribute("aria-labelledby", `hourly-tab-${activeHourlyGroup}`);
+  renderHourlyNarrative(payload);
 };
 
 const rerenderChartsForResize = () => {
@@ -744,8 +1169,8 @@ const buildMergedTimelineDays = () => {
 
 const centerTimelineOnToday = () => {
   if (!timelineRoot || timelineAutoCentered) return;
-  const wrap = timelineRoot.querySelector(".resort-daily-summary-wrap");
-  const todayCell = timelineRoot.querySelector("[data-compact-today-anchor='1']");
+  const wrap = timelineRoot.querySelector(".field-guide-timeline");
+  const todayCell = timelineRoot.querySelector("[data-timeline-today='1']");
   if (!(wrap instanceof HTMLElement) || !(todayCell instanceof HTMLElement)) return;
   const targetLeft = todayCell.offsetLeft + (todayCell.offsetWidth / 2) - (wrap.clientWidth / 2);
   const maxScroll = Math.max(0, wrap.scrollWidth - wrap.clientWidth);
@@ -753,18 +1178,114 @@ const centerTimelineOnToday = () => {
   timelineAutoCentered = true;
 };
 
+const daylightValue = (day, key) => {
+  const local = String(day?.[`${key}_local_hhmm`] || "").trim();
+  if (local) return local;
+  const iso = String(day?.[`${key}_iso`] || "").trim();
+  const match = /T(\d{2}:\d{2})/.exec(iso);
+  return match ? match[1] : "—";
+};
+
+const appendDefinition = (list, term, value) => {
+  const wrapper = document.createElement("div");
+  const dt = document.createElement("dt");
+  dt.textContent = term;
+  const dd = document.createElement("dd");
+  dd.textContent = value;
+  wrapper.appendChild(dt);
+  wrapper.appendChild(dd);
+  list.appendChild(wrapper);
+};
+
 const renderTimelineSummary = () => {
-  if (!timelineSection || !timelineRoot || !compactDailySummary.renderSingleResortHtml) return;
+  if (!timelineSection || !timelineRoot) return;
   const merged = buildMergedTimelineDays();
   if (!merged.length) {
     timelineSection.hidden = true;
     timelineRoot.innerHTML = "";
     return;
   }
-  timelineRoot.innerHTML = compactDailySummary.renderSingleResortHtml(merged, {
-    emptyText: "No forecast or recent history",
-    unitMode: currentUnitMode(),
+  timelineRoot.textContent = "";
+  const unitMode = currentUnitMode();
+  const temperatureUnit = fieldGuideUnits.unitLabel ? fieldGuideUnits.unitLabel("temperature", unitMode) : "°C";
+  const wrap = document.createElement("div");
+  wrap.className = "field-guide-timeline";
+  wrap.tabIndex = 0;
+  wrap.setAttribute("aria-label", "Recent conditions and daily forecast. Scroll horizontally for more dates.");
+  const track = document.createElement("div");
+  track.className = "field-guide-timeline-track";
+  merged.forEach((day) => {
+    const isToday = Boolean(day.summary_is_today);
+    const phase = isToday ? "today" : (day.summary_phase === "history" ? "history" : "forecast");
+    const phaseLabel = isToday ? "Today" : (phase === "history" ? "Past" : "Forecast");
+    const card = document.createElement("article");
+    card.className = "timeline-day-card";
+    card.dataset.phase = phase;
+    if (isToday) card.dataset.timelineToday = "1";
+
+    const topline = document.createElement("div");
+    topline.className = "timeline-card-topline";
+    const phaseEl = document.createElement("span");
+    phaseEl.className = "timeline-phase";
+    phaseEl.textContent = phaseLabel;
+    const date = document.createElement("time");
+    date.className = "timeline-date";
+    date.dateTime = String(day.date || "");
+    date.textContent = friendlyDate(day.date, day.summary_label || phaseLabel);
+    topline.appendChild(phaseEl);
+    topline.appendChild(date);
+
+    const condition = document.createElement("div");
+    condition.className = "timeline-condition";
+    const icon = document.createElement("span");
+    icon.innerHTML = fieldGuideWeather.iconHtml
+      ? fieldGuideWeather.iconHtml(day.weather_code)
+      : '<span class="field-guide-weather-icon" role="img" aria-label="Conditions unavailable">?</span>';
+    const conditionName = document.createElement("strong");
+    conditionName.textContent = fieldGuideWeather.conditionName
+      ? fieldGuideWeather.conditionName(day.weather_code)
+      : "Conditions unavailable";
+    condition.appendChild(icon);
+    condition.appendChild(conditionName);
+
+    const temperature = document.createElement("div");
+    temperature.className = "timeline-temperature";
+    const high = document.createElement("strong");
+    const low = document.createElement("span");
+    const highValue = fieldGuideUnits.formatTemperature
+      ? fieldGuideUnits.formatTemperature(day.temperature_max_c, unitMode, { withUnit: false, digits: 0 })
+      : formatValue(day.temperature_max_c);
+    const lowValue = fieldGuideUnits.formatTemperature
+      ? fieldGuideUnits.formatTemperature(day.temperature_min_c, unitMode, { withUnit: false, digits: 0 })
+      : formatValue(day.temperature_min_c);
+    high.textContent = `High ${highValue} ${temperatureUnit}`;
+    low.textContent = `Low ${lowValue} ${temperatureUnit}`;
+    temperature.appendChild(high);
+    temperature.appendChild(low);
+
+    const metrics = document.createElement("dl");
+    metrics.className = "timeline-metrics";
+    appendDefinition(metrics, "Snow", fieldGuideUnits.formatSnow
+      ? fieldGuideUnits.formatSnow(day.snowfall_cm, unitMode)
+      : `${formatValue(day.snowfall_cm)} cm`);
+    appendDefinition(metrics, "Rain", fieldGuideUnits.formatRain
+      ? fieldGuideUnits.formatRain(day.rain_mm, unitMode)
+      : `${formatValue(day.rain_mm)} mm`);
+
+    const daylight = document.createElement("dl");
+    daylight.className = "timeline-daylight";
+    appendDefinition(daylight, "Sunrise", daylightValue(day, "sunrise"));
+    appendDefinition(daylight, "Sunset", daylightValue(day, "sunset"));
+
+    card.appendChild(topline);
+    card.appendChild(condition);
+    card.appendChild(temperature);
+    card.appendChild(metrics);
+    card.appendChild(daylight);
+    track.appendChild(card);
   });
+  wrap.appendChild(track);
+  timelineRoot.appendChild(wrap);
   timelineSection.hidden = false;
   window.requestAnimationFrame(centerTimelineOnToday);
 };
@@ -773,29 +1294,67 @@ const renderHourlyTable = (payload) => {
   if (!thead || !tbody) return;
   const hourly = payload?.hourly || {};
   const times = Array.isArray(hourly.time) ? hourly.time : [];
-
-  thead.innerHTML = `<tr>${["time", ...metricDefs.map((m) => m.label)].map((h) => `<th>${h}</th>`).join("")}</tr>`;
-
-  const rows = times.map((time, idx) => {
-    const cells = [`<td>${time}</td>`];
-    metricDefs.forEach((metric) => {
-      const values = Array.isArray(hourly[metric.key]) ? hourly[metric.key] : [];
-      cells.push(`<td>${formatValue(values[idx])}</td>`);
-    });
-    return `<tr>${cells.join("")}</tr>`;
+  const metricKeys = metricDefs.length
+    ? metricDefs.map((metric) => metric.key)
+    : [...new Set(Object.values(HOURLY_GROUPS).flatMap((group) => group.metrics))];
+  thead.textContent = "";
+  tbody.textContent = "";
+  const headRow = document.createElement("tr");
+  const timeHead = document.createElement("th");
+  timeHead.scope = "col";
+  timeHead.textContent = "Local time";
+  headRow.appendChild(timeHead);
+  metricKeys.forEach((metricKey) => {
+    const th = document.createElement("th");
+    th.scope = "col";
+    const title = METRIC_PRESENTATION[metricKey]?.title || metricKey;
+    const unit = metricKey === "wind_direction_10m" ? "cardinal / °" : metricUnit(metricKey);
+    th.textContent = unit ? `${title} (${unit})` : title;
+    headRow.appendChild(th);
   });
-  tbody.innerHTML = rows.join("");
+  thead.appendChild(headRow);
+
+  times.forEach((timeValue, index) => {
+    const row = document.createElement("tr");
+    const timeCell = document.createElement("td");
+    const time = document.createElement("time");
+    time.dateTime = String(timeValue || "");
+    time.textContent = friendlyHour(timeValue);
+    time.title = String(timeValue || "");
+    timeCell.appendChild(time);
+    row.appendChild(timeCell);
+    metricKeys.forEach((metricKey) => {
+      const cell = document.createElement("td");
+      const values = Array.isArray(hourly[metricKey]) ? hourly[metricKey] : [];
+      cell.textContent = formatMetricValue(metricKey, values[index], { withUnit: false });
+      row.appendChild(cell);
+    });
+    tbody.appendChild(row);
+  });
+};
+
+const selectHourlyGroup = (groupKey, options = {}) => {
+  if (!Object.prototype.hasOwnProperty.call(HOURLY_GROUPS, groupKey)) return;
+  activeHourlyGroup = groupKey;
+  hourlyTabButtons.forEach((button) => {
+    const selected = button.dataset.hourlyGroup === groupKey;
+    button.setAttribute("aria-selected", selected ? "true" : "false");
+    button.tabIndex = selected ? 0 : -1;
+    if (selected && options.focus) button.focus();
+  });
+  if (chartsEl) chartsEl.setAttribute("aria-labelledby", `hourly-tab-${groupKey}`);
+  if (lastHourlyPayload) renderHourlyCharts(lastHourlyPayload);
 };
 
 const loadHourly = async () => {
   if (!resortId) {
-    setError("Missing resort id.");
+    setError("We could not identify this resort. Return to All resorts and choose it again.");
     return;
   }
   const hours = hoursSelect ? String(hoursSelect.value || "72") : "72";
   setError("");
   setChartError("");
-  if (metaEl) metaEl.textContent = "Loading...";
+  if (metaEl) metaEl.textContent = "Loading the latest hourly field report…";
 
   try {
     let payload;
@@ -806,7 +1365,9 @@ const loadHourly = async () => {
       if (!resp.ok) {
         throw new Error(rawPayload.error || `HTTP ${resp.status}`);
       }
-      payload = trimHourlyPayload(rawPayload, Number(hours));
+      payload = typeof trimHourlyPayload === "function"
+        ? trimHourlyPayload(rawPayload, Number(hours))
+        : rawPayload;
     } else {
       const endpoint = new URL(withPrefix("/api/resort-hourly"), window.location.origin);
       endpoint.searchParams.set("resort_id", resortId);
@@ -817,10 +1378,7 @@ const loadHourly = async () => {
         throw new Error(payload.error || `HTTP ${resp.status}`);
       }
     }
-    if (titleEl) {
-      const resortLabel = String(payload?.display_name || payload?.query || dailySummary?.display_name || dailySummary?.query || "").trim();
-      titleEl.textContent = resortLabel ? `Resort Forecast: ${resortLabel}` : "Resort Forecast";
-    }
+    renderResortIdentity(payload);
     metaState = {
       timezone: String(payload.timezone || "").trim(),
       model: String(payload.model || "").trim(),
@@ -840,7 +1398,8 @@ const loadHourly = async () => {
       setChartError(chartErr instanceof Error ? chartErr.message : String(chartErr));
     }
   } catch (err) {
-    setError(err instanceof Error ? err.message : String(err));
+    const detail = err instanceof Error ? err.message : String(err);
+    setError(`We could not load the hourly forecast. ${detail}`.trim());
     setChartError("");
     metaState = null;
     lastHourlyPayload = null;
@@ -853,6 +1412,7 @@ const loadHourly = async () => {
     if (thead) thead.innerHTML = "";
     if (tbody) tbody.innerHTML = "";
     if (chartsEl) chartsEl.innerHTML = "";
+    if (hourlyNarrativeEl) hourlyNarrativeEl.textContent = "Daily information is still available above; try refreshing the hourly report in a moment.";
   }
 };
 
@@ -862,15 +1422,36 @@ if (refreshBtn) {
 if (hoursSelect) {
   hoursSelect.addEventListener("change", loadHourly);
 }
+hourlyTabButtons.forEach((button, buttonIndex) => {
+  button.addEventListener("click", () => selectHourlyGroup(button.dataset.hourlyGroup || "storm"));
+  button.addEventListener("keydown", (event) => {
+    let targetIndex = buttonIndex;
+    if (event.key === "ArrowRight") targetIndex = (buttonIndex + 1) % hourlyTabButtons.length;
+    else if (event.key === "ArrowLeft") targetIndex = (buttonIndex - 1 + hourlyTabButtons.length) % hourlyTabButtons.length;
+    else if (event.key === "Home") targetIndex = 0;
+    else if (event.key === "End") targetIndex = hourlyTabButtons.length - 1;
+    else return;
+    event.preventDefault();
+    const target = hourlyTabButtons[targetIndex];
+    selectHourlyGroup(target?.dataset.hourlyGroup || "storm", { focus: true });
+  });
+});
 window.addEventListener("resize", rerenderChartsForResize);
 window.addEventListener("closesnow:unitschange", () => {
   renderResortSnapshot();
   timelineAutoCentered = false;
   renderTimelineSummary();
   renderNearbyAirports(lastHourlyPayload);
+  if (lastHourlyPayload) {
+    renderHourlyTable(lastHourlyPayload);
+    renderHourlyCharts(lastHourlyPayload);
+  }
 });
 
+renderResortIdentity(null);
+renderResortOutlook();
 renderResortSnapshot();
 renderTimelineSummary();
 renderNearbyAirports(null);
+selectHourlyGroup(activeHourlyGroup);
 loadHourly();

--- a/src/web/resort_hourly_context.py
+++ b/src/web/resort_hourly_context.py
@@ -30,6 +30,12 @@ def _build_context_from_report(report: Dict[str, Any]) -> Optional[Dict[str, Any
         "website": report.get("website", ""),
         "daily": daily,
     }
+    # Keep compact location and pass context available to the detail page so the
+    # masthead can orient readers without another lookup.
+    for key in ("region", "subregion", "admin1", "country", "pass_types"):
+        value = report.get(key)
+        if value not in (None, "", []):
+            context[key] = value
     nearby_airports = report.get("nearby_airports")
     if isinstance(nearby_airports, list):
         context["nearbyAirports"] = [item for item in nearby_airports if isinstance(item, dict)]

--- a/src/web/templates/resort_hourly_page.html
+++ b/src/web/templates/resort_hourly_page.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="{{asset_prefix}}/css/resort_hourly.css" />
   <link rel="stylesheet" href="{{asset_prefix}}/css/field_guide_foundation.css" />
 </head>
-<body>
+<body class="resort-page">
   <header class="site-header">
     <div class="site-header-inner">
       <a class="brand" href="{{back_href}}" aria-label="CloseSnow home">
@@ -25,42 +25,54 @@
       </div>
     </div>
   </header>
-  <main>
-    <section class="resort-hero" aria-labelledby="hourly-title">
-      <a class="back-link" href="{{back_href}}"><span aria-hidden="true">←</span> Back to all resorts</a>
-      <p class="eyebrow">Mountain forecast</p>
-      <h1 id="hourly-title">Resort Forecast</h1>
-      <div class="resort-identity-meta">
-        <p id="resort-local-time" class="resort-local-time"></p>
-        <p id="resort-website-link" class="resort-website-link"></p>
-        <p id="resort-location-link" class="resort-location-link"></p>
+  <main class="resort-field-guide">
+    <section class="resort-masthead" aria-labelledby="hourly-title">
+      <div class="resort-masthead-topline">
+        <a class="back-link" href="{{back_href}}"><span aria-hidden="true">←</span> All resorts</a>
+        <span class="resort-report-label">Mountain field report</span>
       </div>
-      <div id="resort-snapshot" class="resort-snapshot" aria-label="Resort forecast overview"></div>
-      <div class="resort-hero-mountain" aria-hidden="true">
-        <svg viewBox="0 0 420 180" preserveAspectRatio="none"><path d="M18 178 120 62l42 50 56-86 170 152H18Z" /><path d="m120 62 42 50 56-86 55 49" /></svg>
+      <div class="resort-masthead-grid">
+        <div class="resort-intro">
+          <p class="eyebrow">Resort field guide</p>
+          <h1 id="hourly-title">Loading resort…</h1>
+          <p id="resort-context" class="resort-context"></p>
+          <p id="resort-outlook" class="resort-outlook">Building the latest seven-day outlook.</p>
+          <div class="resort-identity-meta" aria-label="Resort details and actions">
+            <p id="resort-local-time" class="resort-local-time"></p>
+            <p id="resort-website-link" class="resort-website-link"></p>
+            <p id="resort-location-link" class="resort-location-link"></p>
+          </div>
+        </div>
+        <div id="resort-snapshot" class="resort-snapshot" aria-label="Resort forecast overview"></div>
       </div>
     </section>
-    <section id="resort-timeline-section" class="resort-timeline-section" hidden>
+
+    <section id="resort-timeline-section" class="resort-timeline-section field-guide-section" hidden>
       <div class="section-heading">
-        <div><p class="eyebrow">Snow timeline</p><h2>Past 14 days + forecast</h2></div>
-        <span>Swipe to explore</span>
+        <div>
+          <p class="eyebrow">Daily field guide</p>
+          <h2>Recent weather and 14-day outlook</h2>
+          <p>Every card keeps conditions, temperature, snow, rain, and daylight together.</p>
+        </div>
+        <div class="timeline-legend" aria-label="Timeline legend">
+          <span data-phase="history">Past</span>
+          <span data-phase="today">Today</span>
+          <span data-phase="forecast">Forecast</span>
+        </div>
       </div>
+      <div class="timeline-scroll-hint" aria-hidden="true">Scroll dates →</div>
       <div id="resort-timeline-root"></div>
     </section>
-    <section id="resort-airport-access-section" class="resort-airport-access-section" hidden>
-      <div class="section-heading">
-        <div><p class="eyebrow">Getting there</p><h2>Nearby airports (&lt;250 miles)</h2></div>
-      </div>
-      <div id="resort-airport-access-root"></div>
-    </section>
-    <section class="hourly-workspace" aria-labelledby="hourly-section-title">
+
+    <section class="hourly-workspace field-guide-section" aria-labelledby="hourly-section-title">
       <div class="hourly-workspace-heading">
         <div>
           <p class="eyebrow">Weather, hour by hour</p>
-          <h2 id="hourly-section-title" class="hourly-section-title">Hourly forecast</h2>
+          <h2 id="hourly-section-title" class="hourly-section-title">Read the next weather window</h2>
+          <p>Choose a layer to focus on what changes mountain travel and visibility.</p>
         </div>
         <div class="hourly-controls">
-          <label for="hours-select">Range</label>
+          <label for="hours-select">Forecast range</label>
           <select id="hours-select">
             <option value="24">24 hours</option>
             <option value="48">48 hours</option>
@@ -70,12 +82,19 @@
           <button id="hours-refresh-btn" type="button">Refresh</button>
         </div>
       </div>
-      <p id="hourly-meta" class="hourly-meta">Loading...</p>
-      <div id="hourly-error" class="hourly-error" hidden></div>
-      <div id="hourly-chart-error" class="hourly-chart-error" hidden></div>
-      <section id="hourly-charts" class="hourly-charts" aria-live="polite"></section>
-      <details class="raw-data-panel">
-        <summary>View raw hourly data</summary>
+      <p id="hourly-meta" class="hourly-meta" aria-live="polite">Loading the hourly field report…</p>
+      <div id="hourly-error" class="hourly-error" role="alert" hidden></div>
+      <div id="hourly-chart-error" class="hourly-chart-error" role="alert" hidden></div>
+      <p id="hourly-narrative" class="hourly-narrative" aria-live="polite"></p>
+      <div class="hourly-view-tabs" role="tablist" aria-label="Hourly forecast layers">
+        <button id="hourly-tab-storm" type="button" role="tab" aria-selected="true" aria-controls="hourly-charts" tabindex="0" data-hourly-group="storm">Storm</button>
+        <button id="hourly-tab-wind" type="button" role="tab" aria-selected="false" aria-controls="hourly-charts" tabindex="-1" data-hourly-group="wind">Wind</button>
+        <button id="hourly-tab-visibility" type="button" role="tab" aria-selected="false" aria-controls="hourly-charts" tabindex="-1" data-hourly-group="visibility">Visibility &amp; depth</button>
+      </div>
+      <section id="hourly-charts" class="hourly-charts" role="tabpanel" aria-labelledby="hourly-tab-storm" tabindex="0" aria-live="polite"></section>
+      <details class="raw-data-panel" data-field-guide-disclosure>
+        <summary>Inspect complete hourly data</summary>
+        <p>Every hourly reading in the selected range is shown below using your chosen unit system.</p>
         <div class="table-wrap">
           <table id="hourly-table" class="hourly-table">
             <thead></thead>
@@ -84,8 +103,19 @@
         </div>
       </details>
     </section>
+
+    <section id="resort-airport-access-section" class="resort-airport-access-section field-guide-section" hidden>
+      <div class="section-heading">
+        <div>
+          <p class="eyebrow">Getting there</p>
+          <h2>Nearby airports</h2>
+          <p>Airports within roughly 250 miles, ordered from the mountain outward.</p>
+        </div>
+      </div>
+      <div id="resort-airport-access-root"></div>
+    </section>
   </main>
-  <footer class="page-footer"><strong>CloseSnow</strong> · Forecast data for better mountain days.</footer>
+  <footer class="page-footer"><strong>CloseSnow</strong><span>Forecast data translated for better mountain decisions.</span></footer>
   <script>
     window.CLOSESNOW_HOURLY_CONTEXT = {{hourly_context_json}};
   </script>

--- a/tests/frontend/test_resort_hourly_context.py
+++ b/tests/frontend/test_resort_hourly_context.py
@@ -11,6 +11,10 @@ def test_build_resort_daily_summary_context_includes_recent_history():
                 "query": "Snowbird, UT",
                 "display_name": "Snowbird, Utah",
                 "website": "https://example.com/snowbird",
+                "region": "west",
+                "admin1": "UT",
+                "country": "US",
+                "pass_types": ["ikon", "indy"],
                 "nearby_airports": [
                     {
                         "airport_id": "slc-salt-lake-city",
@@ -47,6 +51,10 @@ def test_build_resort_daily_summary_context_includes_recent_history():
 
     assert context is not None
     assert context["display_name"] == "Snowbird, Utah"
+    assert context["region"] == "west"
+    assert context["admin1"] == "UT"
+    assert context["country"] == "US"
+    assert context["pass_types"] == ["ikon", "indy"]
     assert context["nearbyAirports"][0]["iata_code"] == "SLC"
     assert [row["date"] for row in context["past14dDaily"]] == [
         "2026-03-01",

--- a/tests/frontend/test_static_site_pipeline.py
+++ b/tests/frontend/test_static_site_pipeline.py
@@ -70,6 +70,10 @@ def test_render_hourly_pages(tmp_path):
                 "resort_id": "snowbird-ut",
                 "query": "Snowbird, UT",
                 "display_name": "Snowbird, Utah",
+                "region": "west",
+                "admin1": "UT",
+                "country": "US",
+                "pass_types": ["ikon"],
                 "nearby_airports": [
                     {
                         "airport_id": "slc-salt-lake-city",
@@ -89,6 +93,8 @@ def test_render_hourly_pages(tmp_path):
                         "temperature_min_c": -5,
                         "snowfall_cm": 2.0,
                         "rain_mm": 0.0,
+                        "sunrise_local_hhmm": "07:24",
+                        "sunset_local_hhmm": "19:31",
                     }
                 ],
                 "past_14d_daily": [
@@ -129,13 +135,26 @@ def test_render_hourly_pages(tmp_path):
     assert html.index("../../assets/js/resort_hourly_metrics.js") < html.index("../../assets/js/resort_hourly.js")
     assert "../../assets/js/weather_code_emoji.js" not in html
     assert "data-field-guide-unit-toggle" in html
-    assert '<h1 id="hourly-title">Resort Forecast</h1>' in html
+    assert '<h1 id="hourly-title">Loading resort…</h1>' in html
+    assert 'class="resort-masthead"' in html
+    assert 'id="resort-context"' in html
+    assert 'id="resort-outlook"' in html
     assert 'id="resort-snapshot"' in html
+    assert 'id="resort-timeline-root"' in html
+    assert 'role="tablist" aria-label="Hourly forecast layers"' in html
+    assert 'data-hourly-group="storm"' in html
+    assert 'data-hourly-group="wind"' in html
+    assert 'data-hourly-group="visibility"' in html
+    assert 'id="hourly-narrative"' in html
     assert 'id="hourly-charts"' in html
     assert 'class="raw-data-panel"' in html
     context = _hourly_context_from_html(html)
     assert context["resortId"] == "snowbird-ut"
     assert context["dailySummary"]["display_name"] == "Snowbird, Utah"
+    assert context["dailySummary"]["region"] == "west"
+    assert context["dailySummary"]["admin1"] == "UT"
+    assert context["dailySummary"]["country"] == "US"
+    assert context["dailySummary"]["pass_types"] == ["ikon"]
     assert context["dailySummary"]["nearbyAirports"][0]["iata_code"] == "SLC"
     assert context["dailySummary"]["past14dDaily"][0]["date"] == "2026-03-01"
     assert context["dailySummary"]["past14dDaily"][-1]["date"] == "2026-03-14"

--- a/tests/frontend/test_styles_and_transform.py
+++ b/tests/frontend/test_styles_and_transform.py
@@ -432,3 +432,28 @@ def test_homepage_missing_and_no_results_copy_is_honest_and_readable():
     assert "Daily guidance is not available yet." in result["missing"]
     assert "No resorts match this view" in result["empty"]
     assert "Try clearing your filters." in result["empty"]
+
+
+def test_resort_field_guide_groups_hourly_weather_and_preserves_daily_detail():
+    js = (REPO_ROOT / "assets" / "js" / "resort_hourly.js").read_text(encoding="utf-8")
+    css = (REPO_ROOT / "assets" / "css" / "resort_hourly.css").read_text(encoding="utf-8")
+
+    assert "HOURLY_GROUPS" in js
+    assert 'metrics: Object.freeze(["snowfall", "rain", "precipitation_probability"])' in js
+    assert 'metrics: Object.freeze(["wind_speed_10m", "wind_direction_10m"])' in js
+    assert 'metrics: Object.freeze(["visibility", "snow_depth"])' in js
+    assert "renderHourlyNarrative" in js
+    assert "renderWindDirectionCard" in js
+    assert "fieldGuideWeather.iconHtml" in js
+    assert "data-timeline-today" in js
+    assert 'appendDefinition(daylight, "Sunrise"' in js
+    assert 'appendDefinition(daylight, "Sunset"' in js
+    assert "Resort Forecast:" not in js
+    assert "subtitle.textContent = `Unit:" not in js
+
+    assert ".resort-masthead" in css
+    assert ".field-guide-timeline-track" in css
+    assert '.timeline-day-card[data-phase="today"]' in css
+    assert ".hourly-view-tabs" in css
+    assert ".wind-direction-grid" in css
+    assert ".resort-hero-mountain" not in css


### PR DESCRIPTION
## What changed

- replaces the oversized resort hero and dense daily table with a compact resort report and scrollable Past / Today / Forecast cards
- turns seven equal-weight hourly charts into focused Storm, Wind, and Visibility & depth layers with plain-language timing summaries
- uses semantic snowfall/rain bars, probability areas, wind-direction arrows, shared SVG weather icons, and a complete expandable hourly table
- applies the shared Metric / Imperial preference to the masthead, daily timeline, hourly charts/table, and airport distances
- preserves resort coordinates, correction links, website/map actions, all daily values, full hourly values, and nearby airports

## Validation

- `python3 -m pytest -q` — 268 passed
- `python3 -m ruff check .` — passed
- `python3 scripts/lint_assets.py` — passed
- all-resort static build — 125 resort pages and hourly artifacts
- browser QA at 1440×1000, 768×1024, and 390×844
- checked both rain-heavy Snowbird and snow-heavy Valle Nevado data, all three hourly layers, raw-data disclosure, and global unit switching
