### PR TITLE
Refactor forecast UI around mountain decisions

### DIFF
--- a/assets/css/field_guide_foundation.css
+++ b/assets/css/field_guide_foundation.css
@@ -137,6 +137,7 @@ a {
 
 .brand {
   min-width: 0;
+  min-height: 44px;
   display: inline-flex;
   align-items: center;
   gap: 0.625rem;
@@ -224,7 +225,7 @@ a {
 }
 
 .field-guide-unit-switch {
-  min-height: 34px;
+  min-height: 44px;
   padding: 0.375rem 0.625rem;
   border: 1px solid rgba(255, 255, 255, 0.28);
   border-radius: var(--fg-radius-md);
@@ -255,7 +256,7 @@ a {
 }
 
 .fg-button {
-  min-height: 40px;
+  min-height: 44px;
   padding: 0.625rem 0.875rem;
   border: 1px solid var(--fg-line-strong);
   border-radius: var(--fg-radius-md);
@@ -316,7 +317,7 @@ a {
 
 .fg-tab,
 [data-field-guide-tab] {
-  min-height: 36px;
+  min-height: 44px;
   padding: 0.5rem 0.75rem;
   border: 0;
   border-radius: var(--fg-radius-sm);

--- a/assets/css/resort_hourly.css
+++ b/assets/css/resort_hourly.css
@@ -1516,6 +1516,13 @@
   }
 }
 
+@media (min-width: 701px) and (max-width: 820px) {
+  .timeline-day-card {
+    grid-template-columns: minmax(7rem, 1fr) minmax(7.5rem, 1.1fr) minmax(5.2rem, 0.7fr) minmax(7.25rem, 1fr) minmax(7.25rem, 1fr);
+    gap: 0.4rem;
+  }
+}
+
 @media (max-width: 820px) {
   .resort-masthead-grid {
     grid-template-columns: 1fr;

--- a/assets/css/resort_hourly.css
+++ b/assets/css/resort_hourly.css
@@ -1067,3 +1067,699 @@
     scroll-behavior: auto;
   }
 }
+
+/* Compact information architecture: decisions first, depth on demand. */
+.resort-field-guide {
+  padding-top: 1rem;
+}
+
+.resort-masthead {
+  padding: 0.9rem 1rem;
+}
+
+.resort-masthead-topline {
+  padding-bottom: 0.45rem;
+}
+
+.back-link {
+  min-height: 44px;
+}
+
+.resort-masthead-grid {
+  padding-top: 0.75rem;
+  grid-template-columns: minmax(18rem, 0.9fr) minmax(0, 1.35fr);
+  align-items: start;
+  gap: 1rem;
+}
+
+.resort-intro {
+  align-self: start;
+}
+
+.resort-intro h1 {
+  max-width: none;
+  font-size: clamp(2rem, 3.4vw, 3rem);
+  line-height: 1;
+}
+
+.resort-context {
+  margin-top: 0.35rem;
+}
+
+.resort-outlook {
+  max-width: none;
+  margin-top: 0.55rem;
+  padding: 0.58rem 0.7rem;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: baseline;
+  gap: 0.5rem;
+  font-size: 0.8rem;
+  line-height: 1.38;
+}
+
+.resort-outlook strong {
+  font-size: 0.82rem;
+  line-height: 1.38;
+}
+
+.resort-identity-meta {
+  margin-top: 0;
+  padding: 0.45rem;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.35rem;
+}
+
+.resort-identity-meta p {
+  min-height: 28px;
+  padding: 0.28rem 0.48rem;
+  font-size: 0.7rem;
+}
+
+.resort-identity-meta a {
+  min-width: 44px;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+}
+
+.resort-identity-disclosure,
+.hourly-meta-disclosure {
+  margin-top: 0.55rem;
+  border: 1px solid var(--fg-line, #d8e1dd);
+  border-radius: var(--fg-radius-md, 8px);
+  background: rgba(255, 255, 255, 0.7);
+}
+
+.resort-identity-disclosure > summary,
+.hourly-meta-disclosure > summary {
+  min-height: 44px;
+  padding: 0.55rem 0.7rem;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  color: var(--fg-ink-muted, #526671);
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.resort-identity-disclosure[open] > summary,
+.hourly-meta-disclosure[open] > summary {
+  border-bottom: 1px solid var(--fg-line, #d8e1dd);
+}
+
+.resort-snapshot {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.45rem;
+}
+
+.snapshot-card,
+.snapshot-card[data-priority="primary"] {
+  min-height: 80px;
+  padding: 0.6rem;
+  grid-column: auto;
+  grid-template-columns: 30px minmax(0, 1fr);
+  gap: 0.5rem;
+  border-color: var(--fg-line, #d8e1dd);
+  color: var(--fg-ink, #17252e);
+  background: var(--fg-surface, #fff);
+  box-shadow: none;
+}
+
+.snapshot-card[data-priority="primary"] {
+  border-color: color-mix(in srgb, var(--fg-glacier, #167a9b) 55%, var(--fg-line, #d8e1dd));
+  box-shadow: inset 3px 0 var(--fg-glacier, #167a9b);
+}
+
+.snapshot-icon,
+.snapshot-card[data-priority="primary"] .snapshot-icon {
+  width: 30px;
+  height: 30px;
+  color: var(--fg-glacier, #167a9b);
+  background: var(--fg-glacier-soft, #dceff5);
+  font-size: 1.15rem;
+}
+
+.snapshot-icon-rain,
+.snapshot-card[data-priority="primary"] .snapshot-icon-rain {
+  color: var(--fg-pine, #16705d);
+  background: var(--fg-pine-soft, #dcefe9);
+}
+
+.snapshot-card small,
+.snapshot-card em,
+.snapshot-card[data-priority="primary"] small,
+.snapshot-card[data-priority="primary"] em {
+  color: var(--fg-ink-subtle, #5f737d);
+  font-size: 0.64rem;
+}
+
+.snapshot-card strong,
+.snapshot-card[data-priority="primary"] strong {
+  color: var(--fg-ink, #17252e);
+  font-size: clamp(1rem, 1.7vw, 1.3rem);
+}
+
+.field-guide-section {
+  margin-top: 1rem;
+  padding: 0.9rem 1rem;
+}
+
+#resort-timeline-section,
+.hourly-workspace {
+  box-shadow: var(--fg-shadow-card);
+}
+
+.section-heading,
+.hourly-workspace-heading {
+  margin-bottom: 0.65rem;
+}
+
+.section-heading h2,
+.hourly-section-title {
+  font-size: clamp(1.2rem, 1.8vw, 1.55rem);
+}
+
+.section-heading p:not(.eyebrow),
+.hourly-workspace-heading p:not(.eyebrow) {
+  margin-top: 0.25rem;
+  font-size: 0.78rem;
+}
+
+.field-guide-timeline {
+  width: 100%;
+  padding: 0;
+  overflow: visible;
+}
+
+.field-guide-timeline-track {
+  width: 100%;
+  display: grid;
+  grid-auto-flow: row;
+  grid-auto-columns: auto;
+  gap: 0.35rem;
+}
+
+.timeline-day-card {
+  min-height: 0;
+  padding: 0.55rem 0.65rem;
+  display: grid;
+  grid-template-columns: minmax(8rem, 1.05fr) minmax(9rem, 1.35fr) minmax(6.5rem, 0.72fr) minmax(9rem, 1fr) minmax(9rem, 1fr);
+  align-items: center;
+  gap: 0.65rem;
+  scroll-snap-align: none;
+  box-shadow: none;
+}
+
+.timeline-day-card[data-phase="today"] {
+  border-width: 1px 1px 1px 4px;
+  box-shadow: none;
+}
+
+.timeline-day-card[data-weather-signal="snow"]:not([data-phase="today"]),
+.timeline-day-card[data-weather-signal="rain"]:not([data-phase="today"]) {
+  box-shadow: none;
+}
+
+.timeline-card-topline {
+  justify-content: flex-start;
+  gap: 0.5rem;
+}
+
+.timeline-date {
+  font-size: 0.76rem;
+  text-align: left;
+}
+
+.timeline-condition {
+  margin: 0;
+  grid-template-columns: 28px minmax(0, 1fr);
+  gap: 0.4rem;
+}
+
+.timeline-condition .field-guide-weather-icon {
+  width: 28px;
+  height: 28px;
+}
+
+.timeline-condition strong {
+  font-size: 0.76rem;
+}
+
+.timeline-temperature {
+  margin: 0;
+  gap: 0;
+}
+
+.timeline-temperature strong {
+  font-size: 1rem;
+}
+
+.timeline-temperature span {
+  font-size: 0.67rem;
+}
+
+.timeline-metrics,
+.timeline-daylight {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.35rem;
+}
+
+.timeline-metrics dt,
+.timeline-daylight dt {
+  font-size: 0.625rem;
+}
+
+.timeline-metrics dd,
+.timeline-daylight dd {
+  margin-top: 0;
+  font-size: 0.75rem;
+  white-space: nowrap;
+}
+
+.timeline-disclosure {
+  margin-top: 0.5rem;
+  border: 1px solid var(--fg-line, #d8e1dd);
+  border-radius: var(--fg-radius-md, 8px);
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.timeline-disclosure > summary {
+  min-height: 44px;
+  padding: 0.55rem 0.7rem;
+  cursor: pointer;
+  color: var(--fg-ink-muted, #526671);
+  font-size: 0.76rem;
+  font-weight: 800;
+}
+
+.timeline-disclosure[open] > summary {
+  border-bottom: 1px solid var(--fg-line, #d8e1dd);
+}
+
+.timeline-disclosure > .field-guide-timeline-track {
+  padding: 0.45rem;
+}
+
+.hourly-workspace-heading {
+  align-items: center;
+}
+
+.hourly-controls {
+  min-width: 300px;
+  padding: 0.25rem;
+}
+
+.hourly-controls select,
+.hourly-controls button {
+  min-height: 44px;
+  padding-block: 0.35rem;
+}
+
+.hourly-meta {
+  min-height: 0;
+  margin: 0;
+  padding: 0.48rem 0.65rem;
+  font-size: 0.68rem;
+}
+
+.hourly-meta a {
+  min-width: 44px;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+}
+
+.hourly-narrative {
+  min-height: 0;
+  margin-top: 0.55rem;
+  padding: 0.62rem 0.75rem;
+  border-left-width: 3px;
+  box-shadow: none;
+  font-size: 0.8rem;
+}
+
+.hourly-narrative::before {
+  margin-bottom: 0.12rem;
+  font-size: 0.6rem;
+}
+
+.hourly-view-tabs {
+  margin-top: 0.55rem;
+}
+
+.hourly-view-tabs button {
+  min-height: 44px;
+  padding: 0.45rem 0.7rem;
+}
+
+.hourly-charts,
+.hourly-charts[data-hourly-group="storm"] {
+  margin-top: 0.6rem;
+  gap: 0.55rem;
+}
+
+.hourly-charts {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.hourly-charts[data-hourly-group="storm"] {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.chart-card {
+  padding: 0.65rem;
+  box-shadow: none;
+}
+
+.chart-card[data-priority="primary"] {
+  box-shadow: none;
+}
+
+.chart-title {
+  font-size: 0.86rem;
+}
+
+.chart-subtitle {
+  font-size: 0.63rem;
+}
+
+.chart-summary-value {
+  font-size: clamp(1rem, 1.5vw, 1.3rem);
+}
+
+.chart-svg-wrap {
+  margin-top: 0.35rem;
+}
+
+.chart-svg {
+  min-width: 280px;
+}
+
+.chart-empty,
+.chart-empty-zero {
+  min-height: 190px;
+}
+
+.raw-data-panel {
+  margin-top: 0.65rem;
+}
+
+.raw-data-panel > summary {
+  min-height: 44px;
+}
+
+#resort-airport-access-section {
+  padding: 0;
+  background: var(--fg-surface-muted, #f1f5f3);
+}
+
+#resort-airport-access-section > summary {
+  min-height: 58px;
+  padding: 0.7rem 0.9rem;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+}
+
+.airport-disclosure-copy {
+  display: grid;
+  gap: 0.1rem;
+}
+
+.airport-disclosure-copy .eyebrow {
+  margin: 0;
+  font-size: 0.62rem;
+}
+
+.airport-disclosure-copy strong {
+  color: var(--fg-ink, #17252e);
+  font-size: 0.95rem;
+}
+
+.airport-disclosure-copy > span:last-child {
+  color: var(--fg-ink-muted, #526671);
+  font-size: 0.7rem;
+}
+
+#resort-airport-access-root {
+  padding: 0 0.9rem 0.9rem;
+}
+
+@media (min-width: 701px) and (max-width: 980px) {
+  .hourly-charts[data-hourly-group="storm"] {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 820px) {
+  .resort-masthead-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 700px) {
+  .resort-field-guide {
+    padding: 0.65rem 0.625rem 1.5rem;
+  }
+
+  .resort-masthead,
+  .field-guide-section {
+    padding: 0.65rem;
+  }
+
+  .resort-masthead-topline {
+    padding-bottom: 0.25rem;
+  }
+
+  .resort-masthead-grid {
+    padding-top: 0.4rem;
+    gap: 0.45rem;
+  }
+
+  .resort-intro > .eyebrow {
+    display: none;
+  }
+
+  .resort-intro h1 {
+    font-size: clamp(1.65rem, 8.2vw, 2rem);
+    line-height: 1.05;
+  }
+
+  .resort-context {
+    margin-top: 0.2rem;
+    font-size: 0.62rem;
+    overflow-wrap: anywhere;
+  }
+
+  .resort-outlook {
+    margin-top: 0.38rem;
+    padding: 0.4rem 0.5rem;
+    display: block;
+    font-size: 0.7rem;
+  }
+
+  .resort-outlook-label {
+    display: block;
+    margin-bottom: 0.12rem;
+    font-size: 0.58rem;
+  }
+
+  .resort-outlook strong {
+    display: block;
+    font-size: 0.7rem;
+    line-height: 1.3;
+  }
+
+  .resort-identity-meta {
+    margin-top: 0;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.25rem;
+  }
+
+  .resort-identity-meta p {
+    width: auto;
+    min-height: 25px;
+    padding: 0.22rem 0.36rem;
+    font-size: 0.62rem;
+    overflow-wrap: anywhere;
+  }
+
+  #resort-local-time {
+    grid-column: 1 / -1;
+  }
+
+  .resort-identity-disclosure {
+    margin-top: 0.4rem;
+  }
+
+  .resort-snapshot {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.25rem;
+  }
+
+  .snapshot-card,
+  .snapshot-card[data-priority="primary"] {
+    min-height: 56px;
+    padding: 0.32rem 0.38rem;
+    display: block;
+  }
+
+  .snapshot-icon,
+  .snapshot-card[data-priority="primary"] .snapshot-icon {
+    display: none;
+  }
+
+  .snapshot-card > span:last-child {
+    gap: 0.04rem;
+  }
+
+  .snapshot-card small,
+  .snapshot-card em,
+  .snapshot-card[data-priority="primary"] small,
+  .snapshot-card[data-priority="primary"] em {
+    font-size: 0.625rem;
+    overflow-wrap: anywhere;
+  }
+
+  .snapshot-card strong,
+  .snapshot-card[data-priority="primary"] strong {
+    font-size: clamp(0.78rem, 3.4vw, 0.92rem);
+    overflow-wrap: anywhere;
+  }
+
+  .field-guide-section {
+    margin-top: 0.75rem;
+  }
+
+  .section-heading,
+  .hourly-workspace-heading {
+    margin-bottom: 0.5rem;
+    gap: 0.45rem;
+  }
+
+  .section-heading h2,
+  .hourly-section-title {
+    font-size: 1.08rem;
+  }
+
+  .section-heading p:not(.eyebrow),
+  .hourly-workspace-heading p:not(.eyebrow) {
+    font-size: 0.68rem;
+    line-height: 1.35;
+  }
+
+  .timeline-day-card {
+    padding: 0.5rem;
+    grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+    grid-template-areas:
+      "topline topline"
+      "condition temperature"
+      "metrics daylight";
+    gap: 0.38rem 0.55rem;
+  }
+
+  .timeline-card-topline {
+    grid-area: topline;
+  }
+
+  .timeline-condition {
+    grid-area: condition;
+  }
+
+  .timeline-temperature {
+    grid-area: temperature;
+    align-items: end;
+    text-align: right;
+  }
+
+  .timeline-metrics {
+    grid-area: metrics;
+  }
+
+  .timeline-daylight {
+    grid-area: daylight;
+  }
+
+  .timeline-condition .field-guide-weather-icon {
+    width: 24px;
+    height: 24px;
+  }
+
+  .timeline-condition strong {
+    font-size: 0.7rem;
+  }
+
+  .timeline-temperature strong {
+    font-size: 0.9rem;
+  }
+
+  .timeline-metrics dt,
+  .timeline-daylight dt {
+    font-size: 0.625rem;
+  }
+
+  .timeline-metrics dd,
+  .timeline-daylight dd {
+    font-size: 0.66rem;
+  }
+
+  .hourly-controls {
+    min-width: 0;
+    padding: 0.2rem;
+  }
+
+  .hourly-meta {
+    font-size: 0.62rem;
+  }
+
+  .hourly-narrative {
+    margin-top: 0.45rem;
+    padding: 0.52rem 0.6rem;
+    font-size: 0.72rem;
+  }
+
+  .hourly-view-tabs {
+    margin-top: 0.45rem;
+  }
+
+  .hourly-view-tabs button {
+    min-height: 44px;
+    padding: 0.4rem 0.6rem;
+    font-size: 0.7rem;
+  }
+
+  .hourly-charts,
+  .hourly-charts[data-hourly-group="storm"] {
+    padding: 0 0.1rem 0.35rem;
+    display: flex;
+    gap: 0.55rem;
+    overflow-x: auto;
+    overscroll-behavior-inline: contain;
+    scroll-snap-type: x mandatory;
+    scrollbar-width: thin;
+  }
+
+  .chart-card {
+    flex: 0 0 calc(100% - 1.4rem);
+    scroll-snap-align: start;
+  }
+
+  .chart-card-header {
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .wind-direction-grid {
+    grid-template-columns: repeat(3, minmax(72px, 1fr));
+  }
+
+  #resort-airport-access-section {
+    padding: 0;
+  }
+}

--- a/assets/css/weather_page.css
+++ b/assets/css/weather_page.css
@@ -1591,3 +1591,760 @@ body.filter-sheet-open {
     animation-iteration-count: 1 !important;
   }
 }
+
+/* Compact comparison workbench: the directory is the homepage's primary task. */
+body {
+  background: #f5f8f6;
+}
+
+.field-guide-home {
+  padding-top: 0.85rem;
+  padding-bottom: 2.5rem;
+}
+
+.report-overview {
+  min-width: 0;
+  margin-bottom: 0.7rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--fg-line);
+  border-radius: var(--fg-radius-lg);
+  display: grid;
+  grid-template-columns: minmax(19rem, 1fr) auto;
+  align-items: center;
+  gap: 1rem;
+  background: var(--fg-surface);
+  box-shadow: 0 1px 2px rgba(18, 43, 54, 0.04);
+}
+
+.report-overview__copy {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: baseline;
+  gap: 0.1rem 0.85rem;
+}
+
+.report-overview__copy .section-kicker {
+  grid-column: 1 / -1;
+  margin-bottom: 0.15rem;
+}
+
+.report-overview h1 {
+  margin: 0;
+  color: var(--fg-header);
+  font-size: clamp(1.25rem, 2vw, 1.55rem);
+  font-weight: 790;
+  letter-spacing: -0.035em;
+  line-height: 1.12;
+  white-space: nowrap;
+}
+
+.report-overview__copy > p:last-child {
+  min-width: 0;
+  margin: 0;
+  overflow: hidden;
+  color: var(--fg-ink-muted);
+  font-size: 0.76rem;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.report-meta {
+  min-width: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(5rem, auto));
+  align-items: center;
+}
+
+.report-meta > div {
+  min-width: 0;
+  padding: 0.1rem 0.75rem;
+  border-left: 1px solid var(--fg-line);
+}
+
+.report-meta > div:first-child {
+  border-left: 0;
+}
+
+.report-meta dt {
+  color: var(--fg-ink-subtle);
+  font-size: 0.625rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.report-meta dd {
+  max-width: 11rem;
+  margin: 0.12rem 0 0;
+  overflow: hidden;
+  color: var(--fg-ink);
+  font-size: 0.7rem;
+  font-weight: 720;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.forecast-toolbar {
+  margin: 0 0 0.85rem;
+  padding: 0.7rem 0.8rem;
+  display: grid;
+  grid-template-columns: minmax(10.5rem, auto) minmax(0, 1fr);
+  align-items: center;
+  gap: 0.8rem;
+  border-radius: var(--fg-radius-lg);
+  box-shadow: 0 1px 2px rgba(18, 43, 54, 0.04);
+}
+
+.forecast-toolbar__heading {
+  margin: 0;
+  display: grid;
+  align-items: start;
+  gap: 0.08rem;
+}
+
+.forecast-toolbar__heading h2 {
+  font-size: 0.92rem;
+}
+
+.forecast-toolbar__heading .section-kicker {
+  display: none;
+}
+
+.filter-summary {
+  width: 100%;
+  max-width: 17rem;
+  font-size: 0.65rem;
+  text-align: left;
+}
+
+.resort-controls {
+  grid-template-columns: minmax(14rem, 1fr) auto auto;
+  gap: 0.5rem;
+}
+
+.resort-search input,
+#filter-open-btn {
+  height: 44px;
+  min-height: 44px;
+}
+
+.resort-search-toggle span {
+  min-height: 44px;
+}
+
+.resort-search > button,
+.filter-check-list label,
+.filter-option-grid label,
+.filter-group select {
+  min-height: 44px;
+}
+
+.filter-close-btn {
+  width: 44px;
+  height: 44px;
+}
+
+.forecast-loading-overview {
+  display: none;
+}
+
+.forecast-results {
+  min-width: 0;
+}
+
+.results-heading {
+  min-height: 2.7rem;
+  margin-bottom: 0.35rem;
+  padding: 0 0.75rem;
+  align-items: center;
+}
+
+.results-heading .section-kicker {
+  margin-bottom: 0.1rem;
+  font-size: 0.625rem;
+}
+
+.results-heading h2 {
+  font-size: 1.15rem;
+  letter-spacing: -0.025em;
+}
+
+.results-heading > p {
+  font-size: 0.68rem;
+}
+
+.result-column-headings,
+.resort-forecast-card {
+  display: grid;
+  grid-template-columns: 2.75rem minmax(12rem, 2fr) minmax(10rem, 1.35fr) minmax(8rem, 0.9fr) minmax(11rem, 1.2fr) 6.2rem;
+  align-items: center;
+  column-gap: 0.75rem;
+}
+
+.result-column-headings {
+  min-width: 0;
+  min-height: 1.75rem;
+  padding: 0 0.75rem;
+  color: var(--fg-ink-subtle);
+  font-size: 0.625rem;
+  font-weight: 800;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.resort-card-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0.45rem;
+}
+
+.resort-forecast-card {
+  width: 100%;
+  height: 96px;
+  min-height: 0;
+  padding: 0.65rem 0.75rem;
+  border: 1px solid var(--fg-line);
+  border-left: 3px solid var(--fg-line-strong);
+  border-top-width: 1px;
+  border-radius: var(--fg-radius-md);
+  overflow: visible;
+  background: var(--fg-surface);
+  box-shadow: 0 1px 2px rgba(18, 43, 54, 0.035);
+}
+
+.resort-forecast-card[data-signal="snow"] {
+  border-top-color: var(--fg-line);
+  border-left-color: var(--fg-glacier);
+}
+
+.resort-forecast-card[data-signal="rain"] {
+  border-top-color: var(--fg-line);
+  border-left-color: var(--fg-pine);
+}
+
+.resort-forecast-card[data-signal="unavailable"] {
+  border-left-style: dashed;
+}
+
+.resort-forecast-card:hover,
+.resort-forecast-card:focus-within {
+  border-color: #aabdb6;
+  border-left-color: var(--fg-glacier);
+  box-shadow: 0 4px 14px rgba(18, 43, 54, 0.08);
+}
+
+.resort-favorite-cell {
+  min-width: 0;
+  display: grid;
+  place-items: center;
+}
+
+.favorite-btn {
+  width: 44px;
+  height: 44px;
+  flex-basis: 44px;
+  border-radius: var(--fg-radius-md);
+  background: transparent;
+}
+
+.favorite-btn svg {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.resort-identity {
+  min-width: 0;
+}
+
+.resort-identity h3 {
+  margin: 0;
+  font-size: 0.98rem;
+  letter-spacing: -0.02em;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+}
+
+.resort-identity h3:focus-visible {
+  outline: 3px solid var(--fg-focus);
+  outline-offset: 3px;
+}
+
+.resort-card-link {
+  color: var(--fg-ink);
+  font-weight: 790;
+  text-decoration: none;
+}
+
+.resort-card-link:hover {
+  color: var(--fg-glacier);
+  text-decoration: underline;
+}
+
+.resort-identity-meta {
+  min-width: 0;
+  margin-top: 0.28rem;
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.resort-location {
+  min-width: 0;
+  color: var(--fg-ink-subtle);
+  font-size: 0.68rem;
+  font-weight: 620;
+  line-height: 1.2;
+  overflow-wrap: anywhere;
+}
+
+.resort-tags {
+  min-height: 0;
+  margin: 0;
+  flex: 0 0 auto;
+  flex-wrap: nowrap;
+}
+
+.resort-tag {
+  padding: 0.12rem 0.3rem;
+  font-size: 0.625rem;
+}
+
+.resort-today {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.resort-today-icon.field-guide-weather-icon {
+  width: 2rem;
+  height: 2rem;
+  flex: 0 0 2rem;
+}
+
+.resort-today > div {
+  min-width: 0;
+  display: grid;
+  gap: 0.02rem;
+}
+
+.resort-today span,
+.resort-primary-signal dt,
+.resort-supporting-signal span {
+  color: var(--fg-ink-subtle);
+  font-size: 0.625rem;
+  font-weight: 760;
+  line-height: 1.2;
+}
+
+.resort-today strong {
+  color: var(--fg-ink);
+  font-size: 0.76rem;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+}
+
+.resort-today small {
+  color: var(--fg-ink-muted);
+  font-size: 0.66rem;
+  font-weight: 680;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+}
+
+.resort-primary-signal {
+  min-width: 0;
+  margin: 0;
+  padding-left: 0.75rem;
+  border-left: 1px solid var(--fg-line);
+}
+
+.resort-primary-signal dt {
+  display: flex;
+  align-items: center;
+  gap: 0.32rem;
+}
+
+.signal-dot {
+  width: 0.42rem;
+  height: 0.42rem;
+  border-radius: 50%;
+  background: var(--fg-line-strong);
+}
+
+.resort-primary-signal[data-metric-kind="snow"] .signal-dot {
+  background: var(--fg-glacier);
+}
+
+.resort-primary-signal[data-metric-kind="rain"] .signal-dot {
+  background: var(--fg-pine);
+}
+
+.resort-primary-signal dd {
+  margin: 0.2rem 0 0;
+  color: var(--fg-header);
+  font-size: 1.02rem;
+  font-weight: 830;
+  letter-spacing: -0.035em;
+  line-height: 1.12;
+  overflow-wrap: anywhere;
+}
+
+.resort-supporting-signal {
+  min-width: 0;
+  display: grid;
+  gap: 0.22rem;
+}
+
+.resort-supporting-signal > div {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: baseline;
+  gap: 0.35rem;
+}
+
+.resort-supporting-signal strong {
+  color: var(--fg-ink);
+  font-size: 0.7rem;
+  line-height: 1.2;
+}
+
+.resort-detail-link {
+  width: 100%;
+  max-width: none;
+  min-height: 44px;
+  margin: 0;
+  padding: 0.45rem 0.55rem;
+  border: 1px solid var(--fg-line-strong);
+  border-radius: var(--fg-radius-md);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3rem;
+  color: var(--fg-glacier);
+  background: var(--fg-surface-muted);
+  font-size: 0.68rem;
+  font-weight: 800;
+  line-height: 1;
+  text-decoration: none;
+}
+
+.resort-detail-link:hover {
+  border-color: var(--fg-glacier);
+  color: #ffffff;
+  background: var(--fg-glacier);
+}
+
+.resort-detail-link svg {
+  width: 0.85rem;
+  height: 0.85rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.8;
+}
+
+.resort-detail-link--disabled {
+  color: var(--fg-ink-subtle);
+  cursor: default;
+}
+
+.results-pagination {
+  padding: 1rem 0 0;
+  display: flex;
+  justify-content: center;
+}
+
+.results-pagination .fg-button {
+  min-width: 10rem;
+  background: var(--fg-surface);
+}
+
+.results-empty-state {
+  padding: 2rem 1.25rem;
+}
+
+.skeleton-resort-card {
+  height: 96px;
+}
+
+@media (max-width: 1180px) {
+  .report-overview {
+    grid-template-columns: minmax(17rem, 1fr) auto;
+  }
+
+  .report-overview__copy > p:last-child {
+    display: none;
+  }
+
+  .report-overview__copy {
+    display: block;
+  }
+
+  .report-meta {
+    grid-template-columns: repeat(2, minmax(7rem, auto));
+    row-gap: 0.25rem;
+  }
+
+  .result-column-headings,
+  .resort-forecast-card {
+    grid-template-columns: 2.75rem minmax(11rem, 1.8fr) minmax(9rem, 1.2fr) minmax(7.5rem, 0.85fr) minmax(9rem, 1fr) 5.4rem;
+    column-gap: 0.55rem;
+  }
+
+  .resort-detail-link {
+    padding-inline: 0.35rem;
+  }
+}
+
+@media (max-width: 900px) {
+  .report-overview {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0.65rem;
+  }
+
+  .report-meta {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .report-meta > div:first-child {
+    border-left: 0;
+  }
+
+  .forecast-toolbar {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0.55rem;
+  }
+
+  .forecast-toolbar__heading {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: baseline;
+    gap: 0.75rem;
+  }
+
+  .filter-summary {
+    max-width: none;
+    text-align: right;
+  }
+
+  .result-column-headings {
+    display: none;
+  }
+
+  .resort-forecast-card {
+    height: auto;
+    min-height: 164px;
+    padding: 0.7rem;
+    grid-template-columns: 2.75rem minmax(0, 1fr) 5.5rem;
+    grid-template-areas:
+      "favorite identity detail"
+      "today today primary"
+      "supporting supporting supporting";
+    grid-template-rows: auto auto auto;
+    align-items: center;
+    gap: 0.55rem 0.6rem;
+  }
+
+  .resort-favorite-cell { grid-area: favorite; }
+  .resort-identity { grid-area: identity; }
+  .resort-today { grid-area: today; }
+  .resort-primary-signal { grid-area: primary; }
+  .resort-supporting-signal { grid-area: supporting; }
+  .resort-detail-link { grid-area: detail; }
+
+  .resort-primary-signal {
+    padding-left: 0.55rem;
+  }
+
+  .resort-primary-signal dd {
+    font-size: 0.92rem;
+  }
+
+  .resort-supporting-signal {
+    padding-top: 0.45rem;
+    border-top: 1px solid var(--fg-line);
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem;
+  }
+}
+
+@media (min-width: 701px) and (max-width: 900px) {
+  .resort-forecast-card {
+    height: 118px;
+    min-height: 118px;
+    grid-template-columns: 2.75rem minmax(10rem, 1.5fr) minmax(9rem, 1.1fr) minmax(7.5rem, 0.85fr) 5.5rem;
+    grid-template-areas:
+      "favorite identity today primary detail"
+      ". supporting supporting supporting .";
+    grid-template-rows: 3.15rem auto;
+    gap: 0.25rem 0.55rem;
+  }
+
+  .resort-supporting-signal {
+    padding-top: 0.25rem;
+  }
+}
+
+@media (max-width: 700px) {
+  .field-guide-home {
+    padding-top: 0.45rem;
+  }
+
+  .report-overview {
+    margin-bottom: 0.5rem;
+    padding: 0.5rem 0.8rem;
+    gap: 0.35rem;
+  }
+
+  .report-overview h1 {
+    white-space: normal;
+  }
+
+  .report-meta {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.45rem 0;
+  }
+
+  .report-meta > div:nth-child(odd) {
+    border-left: 0;
+  }
+
+  .report-meta dd {
+    max-width: none;
+  }
+
+  .forecast-toolbar {
+    margin-bottom: 0.65rem;
+    padding: 0.55rem 0.65rem;
+  }
+
+  .forecast-toolbar__heading {
+    display: flex;
+    margin-bottom: 0;
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.1rem;
+  }
+
+  .filter-summary {
+    text-align: left;
+  }
+
+  .resort-controls {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .resort-search-options {
+    grid-column: 1;
+  }
+
+  #filter-open-btn {
+    grid-column: 2;
+    grid-row: 2;
+    width: 44px;
+  }
+
+  .results-heading {
+    min-height: 0;
+    margin-bottom: 0.35rem;
+    padding: 0 0.15rem;
+    flex-direction: row;
+    align-items: end;
+  }
+
+  .results-heading > p {
+    margin-left: auto;
+    text-align: right;
+  }
+}
+
+.page-footer a {
+  min-width: 44px;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+}
+
+@media (max-width: 390px) {
+  .report-overview__copy .section-kicker {
+    display: none;
+  }
+
+  .report-overview h1 {
+    font-size: 1.18rem;
+  }
+
+  .report-overview__copy > p:last-child {
+    display: none;
+  }
+
+  .report-meta > div {
+    padding-inline: 0.45rem;
+  }
+
+  .report-meta dt {
+    font-size: 0.625rem;
+  }
+
+  .report-meta dd {
+    font-size: 0.63rem;
+  }
+
+  .resort-detail-link {
+    width: 44px;
+    min-height: 44px;
+    margin-left: auto;
+    padding: 0;
+  }
+
+  .resort-detail-link span {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+  }
+
+  .resort-identity h3 {
+    font-size: 0.9rem;
+  }
+
+  .resort-location {
+    max-width: 10.5rem;
+  }
+
+  .resort-supporting-signal {
+    gap: 0.45rem;
+  }
+
+  .resort-supporting-signal > div {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0.05rem;
+  }
+
+  .resort-supporting-signal strong {
+    font-size: 0.68rem;
+  }
+}
+
+@media (forced-colors: active) {
+  .resort-forecast-card[data-signal],
+  .resort-primary-signal,
+  .favorite-btn[data-favorite-active="1"] {
+    border: 2px solid CanvasText;
+  }
+
+  .signal-dot {
+    border: 1px solid CanvasText;
+  }
+}

--- a/assets/js/field_guide_homepage.js
+++ b/assets/js/field_guide_homepage.js
@@ -81,14 +81,6 @@
     ? weather.iconHtml(code, { className })
     : `<span class="condition-icon-fallback" aria-hidden="true">—</span>`);
 
-  const sumDays = (report, key, count = 7) => {
-    const values = safeDaily(report).slice(0, count)
-      .map((day) => asFiniteNumber(day[key]))
-      .filter((value) => value !== null);
-    if (!values.length) return null;
-    return values.reduce((total, value) => total + value, 0);
-  };
-
   const reportTotal = (report, key, dailyKey, start, end) => {
     const direct = asFiniteNumber(report?.[key]);
     if (direct !== null) return direct;
@@ -99,7 +91,6 @@
   };
 
   const weekOneSnow = (report) => reportTotal(report, "week1_total_snowfall_cm", "snowfall_cm", 0, 7);
-  const weekTwoSnow = (report) => reportTotal(report, "week2_total_snowfall_cm", "snowfall_cm", 7, 14);
   const weekOneRain = (report) => reportTotal(report, "week1_total_rain_mm", "rain_mm", 0, 7);
 
   const strongestDay = (report, key, count = 7) => {
@@ -112,131 +103,18 @@
     return winner;
   };
 
-  const rankCandidates = (reports, limit = 3) => {
-    const safeReports = (Array.isArray(reports) ? reports : []).filter((report) => report && typeof report === "object");
-    const snowLed = safeReports.some((report) => (weekOneSnow(report) || 0) > 0);
-    const activeReports = safeReports.filter((report) => (
-      snowLed ? (weekOneSnow(report) || 0) > 0 : (weekOneRain(report) || 0) > 0
-    ));
-    return [...activeReports]
-      .sort((a, b) => {
-        const primaryA = snowLed ? (weekOneSnow(a) || 0) : (weekOneRain(a) || 0);
-        const primaryB = snowLed ? (weekOneSnow(b) || 0) : (weekOneRain(b) || 0);
-        if (primaryB !== primaryA) return primaryB - primaryA;
-        const secondaryDelta = (weekOneSnow(b) || 0) - (weekOneSnow(a) || 0);
-        if (secondaryDelta !== 0) return secondaryDelta;
-        return displayName(a).localeCompare(displayName(b));
-      })
-      .slice(0, Math.max(0, Number(limit) || 0))
-      .map((report) => ({ report, signal: snowLed ? "snow" : "rain" }));
-  };
-
-  const temperatureSentence = (day, mode) => {
-    const high = asFiniteNumber(day?.temperature_max_c);
-    const low = asFiniteNumber(day?.temperature_min_c);
-    if (high === null && low === null) return "Temperature guidance is not available.";
-    if (high === null) return `Today's low is near ${formatMeasure("temperature", low, mode)}.`;
-    if (low === null) return `Today's high is near ${formatMeasure("temperature", high, mode)}.`;
-    return `Today ranges from ${formatMeasure("temperature", low, mode)} to ${formatMeasure("temperature", high, mode)}.`;
-  };
-
-  const rankingExplanation = (report, signal, mode) => {
-    const snow = weekOneSnow(report);
-    const rain = weekOneRain(report);
-    const key = signal === "snow" ? "snowfall_cm" : "rain_mm";
-    const strongest = strongestDay(report, key);
-    const signalText = signal === "snow"
-      ? (snow === null ? "Seven-day snow guidance is not available." : `${formatMeasure("snow", snow, mode)} of snow is forecast over seven days.`)
-      : (rain === null ? "Seven-day rain guidance is not available." : `${formatMeasure("rain", rain, mode)} of rain is forecast over seven days.`);
-    let bestDayText = "No accumulating snow or rain is currently forecast.";
-    if (strongest && strongest.value > 0) {
-      const label = dateParts(strongest.day.date, strongest.index).compact;
-      const measure = formatMeasure(signal === "snow" ? "snow" : "rain", strongest.value, mode);
-      bestDayText = `${label} has the strongest ${signal} signal at ${measure}.`;
-    }
-    return `${signalText} ${bestDayText} ${temperatureSentence(dailyAt(report, 0), mode)}`;
-  };
-
   const resortHref = (report) => {
     const id = String(report?.resort_id || "").trim();
     return id ? `resort/${encodeURIComponent(id)}` : "";
   };
 
-  const resortLink = (report, className = "") => {
-    const name = escapeHtml(displayName(report));
-    const href = resortHref(report);
-    return href ? `<a class="${escapeHtml(className)}" href="${escapeHtml(href)}">${name}</a>` : `<span class="${escapeHtml(className)}">${name}</span>`;
-  };
-
-  const renderInsightCard = (entry, index, mode) => {
-    const { report, signal } = entry;
-    const today = dailyAt(report, 0);
-    const signalKind = signal === "snow" ? "snow" : "rain";
-    const signalValue = signalKind === "snow" ? weekOneSnow(report) : weekOneRain(report);
-    const strongest = strongestDay(report, signalKind === "snow" ? "snowfall_cm" : "rain_mm");
-    const peakCopy = strongest && strongest.value > 0
-      ? `Peak ${dateParts(strongest.day.date, strongest.index).compact} · ${formatMeasure(signalKind, strongest.value, mode)}`
-      : "No accumulating precipitation in this window";
-    return `
-      <article class="insight-card" data-rank="${index + 1}" data-signal="${signalKind}">
-        <div class="insight-card__topline">
-          <span class="insight-rank"><span class="sr-only">Rank </span>${index + 1}</span>
-          ${conditionIcon(today.weather_code, "insight-weather-icon")}
-        </div>
-        <p class="insight-kicker">${signalKind === "snow" ? "Snow signal" : "Storm signal"}</p>
-        <h3>${resortLink(report, "insight-resort-link")}</h3>
-        <p class="insight-location">${escapeHtml(locationLabel(report))}</p>
-        <div class="insight-signal" aria-label="${signalKind === "snow" ? "Seven-day snowfall" : "Seven-day rainfall"}: ${escapeHtml(formatMeasure(signalKind, signalValue, mode))}">
-          <span>${signalKind === "snow" ? "7-day snow" : "7-day rain"}</span>
-          <strong data-field-guide-number>${escapeHtml(formatMeasure(signalKind, signalValue, mode))}</strong>
-          <small>${escapeHtml(peakCopy)}</small>
-        </div>
-        <p class="insight-explanation">${escapeHtml(rankingExplanation(report, signal, mode))}</p>
-      </article>`;
-  };
-
-  const renderInsightBoard = (reports, mode) => {
-    const entries = rankCandidates(reports, 3);
-    if (!entries.length) {
-      const safeReports = (Array.isArray(reports) ? reports : []).filter((report) => report && typeof report === "object");
-      const hasReports = safeReports.length > 0;
-      const hasCompletePrecipitationGuidance = hasReports && safeReports.every((report) => (
-        weekOneSnow(report) !== null && weekOneRain(report) !== null
-      ));
-      const emptyTitle = hasCompletePrecipitationGuidance
-        ? "No active weather to rank"
-        : (hasReports ? "Forecast signal unavailable" : "Nothing to rank yet");
-      const emptyCopy = hasCompletePrecipitationGuidance
-        ? "The current seven-day guidance shows no accumulating snow or rain across this view."
-        : (hasReports
-          ? "Seven-day snow or rain guidance is not complete enough to rank these resorts yet."
-          : "Change the search or filters to bring mountain guidance back into view.");
-      return `
-        <section class="insight-board insight-board--empty" aria-labelledby="insight-title">
-          <div><p class="section-kicker">Morning picks</p><h2 id="insight-title">${emptyTitle}</h2></div>
-          <p>${emptyCopy}</p>
-        </section>`;
-    }
-    const signal = entries[0].signal;
-    return `
-      <section class="insight-board" aria-labelledby="insight-title">
-        <div class="section-heading">
-          <div>
-            <p class="section-kicker">Morning picks</p>
-            <h2 id="insight-title">${signal === "snow" ? "Where the snow signal is strongest" : "Where weather is most active"}</h2>
-          </div>
-          <p>${signal === "snow" ? "Ranked by seven-day snowfall" : "No accumulating snow in view; ranked by seven-day rain"}</p>
-        </div>
-        <div class="insight-grid">${entries.map((entry, index) => renderInsightCard(entry, index, mode)).join("")}</div>
-      </section>`;
-  };
-
   const favoriteButton = (report, active) => {
     const resortId = String(report?.resort_id || "").trim();
     if (!resortId) return "";
-    const label = active ? "Remove resort from favorites" : "Add resort to favorites";
+    const resortName = displayName(report);
+    const label = active ? `Remove ${resortName} from favorites` : `Add ${resortName} to favorites`;
     return `
-      <button type="button" class="favorite-btn" data-resort-id="${escapeHtml(resortId)}" data-favorite-active="${active ? "1" : "0"}" aria-pressed="${active ? "true" : "false"}" aria-label="${label}">
+      <button type="button" class="favorite-btn" data-resort-id="${escapeHtml(resortId)}" data-favorite-active="${active ? "1" : "0"}" aria-pressed="${active ? "true" : "false"}" aria-label="${escapeHtml(label)}">
         <svg aria-hidden="true" viewBox="0 0 24 24"><path d="M12 20.4S3.4 15.7 3.4 9.1A4.7 4.7 0 0 1 12 6.5a4.7 4.7 0 0 1 8.6 2.6c0 6.6-8.6 11.3-8.6 11.3Z"></path></svg>
       </button>`;
   };
@@ -248,72 +126,41 @@
       .join("");
   };
 
-  const metricBlock = (label, value, kind, mode, options = {}) => {
-    const numeric = asFiniteNumber(value);
-    const noSnow = kind === "snow" && numeric === 0 && options.zeroCopy;
-    const rendered = noSnow ? options.zeroCopy : formatMeasure(kind, value, mode);
-    return `<div class="resort-metric" data-metric-kind="${escapeHtml(kind)}"${options.primary ? ' data-priority="primary"' : ""}><dt>${escapeHtml(label)}</dt><dd data-field-guide-number>${escapeHtml(rendered)}</dd></div>`;
+  const highLowText = (day, mode) => {
+    const high = asFiniteNumber(day?.temperature_max_c);
+    const low = asFiniteNumber(day?.temperature_min_c);
+    if (high === null && low === null) return "High / low unavailable";
+    return `${formatMeasure("temperature", high, mode)} / ${formatMeasure("temperature", low, mode)}`;
   };
 
-  const renderNearTermDay = (day, index, mode) => {
-    const label = dateParts(day?.date, index).compact;
-    const condition = conditionName(day?.weather_code);
-    return `
-      <li class="near-day">
-        <span class="near-day__date">${escapeHtml(label)}</span>
-        <span class="near-day__condition">${conditionIcon(day?.weather_code)}<span>${escapeHtml(condition)}</span></span>
-        <span class="near-day__temp" data-field-guide-number>${escapeHtml(formatMeasure("temperature", day?.temperature_max_c, mode))}</span>
-        <span class="near-day__snow" data-field-guide-number>${escapeHtml(formatMeasure("snow", day?.snowfall_cm, mode))} snow</span>
-      </li>`;
-  };
-
-  const localTime = (day, kind) => {
-    const localKey = `${kind}_local_hhmm`;
-    const isoKey = `${kind}_iso`;
-    const local = String(day?.[localKey] || "").trim();
-    if (/^\d{2}:\d{2}$/.test(local)) return local;
-    const iso = String(day?.[isoKey] || "").trim();
-    const match = /T(\d{2}:\d{2})/.exec(iso);
-    return match ? match[1] : "Not available";
-  };
-
-  const renderDailyDetail = (day, index, mode) => {
-    const date = dateParts(day?.date, index).full;
-    const condition = conditionName(day?.weather_code);
-    return `
-      <article class="daily-detail-card">
-        <header>
-          <div><p>${escapeHtml(date)}</p><h4>${escapeHtml(condition)}</h4></div>
-          ${conditionIcon(day?.weather_code, "daily-detail-icon")}
-        </header>
-        <dl class="daily-detail-metrics">
-          <div><dt>High / low</dt><dd data-field-guide-number>${escapeHtml(formatMeasure("temperature", day?.temperature_max_c, mode))} / ${escapeHtml(formatMeasure("temperature", day?.temperature_min_c, mode))}</dd></div>
-          <div><dt>Snow</dt><dd data-field-guide-number>${escapeHtml(formatMeasure("snow", day?.snowfall_cm, mode))}</dd></div>
-          <div><dt>Rain</dt><dd data-field-guide-number>${escapeHtml(formatMeasure("rain", day?.rain_mm, mode))}</dd></div>
-          <div><dt>Daylight</dt><dd data-field-guide-number>${escapeHtml(localTime(day, "sunrise"))}–${escapeHtml(localTime(day, "sunset"))}</dd></div>
-        </dl>
-      </article>`;
-  };
-
-  const outlookParts = (report, mode) => {
-    const days = safeDaily(report).slice(0, 3);
-    if (!days.length) return {
-      lead: "Forecast details are not available for this resort yet.",
-      detail: "Check back after the next model update.",
-    };
-    const today = days[0];
-    const condition = conditionName(today.weather_code);
-    const snow = sumDays({ daily: days }, "snowfall_cm", 3);
-    const rain = sumDays({ daily: days }, "rain_mm", 3);
-    const precipitation = [];
-    if (snow !== null && snow > 0) precipitation.push(`${formatMeasure("snow", snow, mode)} snow`);
-    if (rain !== null && rain > 0) precipitation.push(`${formatMeasure("rain", rain, mode)} rain`);
-    const precipText = precipitation.length
-      ? `${precipitation.join(" and ")} over the next three days.`
-      : "Little to no snow or rain is expected over the next three days.";
+  const compactSignal = (report, mode) => {
+    const snow = weekOneSnow(report);
+    const rain = weekOneRain(report);
+    const signal = (snow || 0) > 0
+      ? "snow"
+      : ((rain || 0) > 0
+        ? "rain"
+        : (snow === null || rain === null ? "unavailable" : "quiet"));
+    const kind = signal === "rain" ? "rain" : "snow";
+    const value = signal === "rain" ? rain : snow;
+    const peak = strongestDay(report, kind === "rain" ? "rain_mm" : "snowfall_cm");
+    const hasPeak = peak && peak.value > 0;
+    const peakLabel = hasPeak ? `Peak ${dateParts(peak.day.date, peak.index).compact.split(" · ")[0]}` : "Peak day";
+    const peakValue = hasPeak ? formatMeasure(kind, peak.value, mode) : (signal === "quiet" ? "No accumulation" : "Not available");
+    const secondary = signal === "rain"
+      ? { label: "7-day snow", value: formatMeasure("snow", snow, mode) }
+      : { label: "7-day rain", value: formatMeasure("rain", rain, mode) };
     return {
-      lead: `${condition} today.`,
-      detail: `${precipText} ${temperatureSentence(today, mode)}`,
+      kind,
+      signal,
+      signalLabel: signal === "snow" ? "Snow" : (signal === "rain" ? "Rain" : (signal === "quiet" ? "Quiet" : "Pending")),
+      primaryLabel: signal === "rain"
+        ? "7-day rain"
+        : (signal === "unavailable" ? "Pending · 7-day forecast" : (signal === "quiet" ? "Quiet · 7-day snow" : "7-day snow")),
+      primaryValue: signal === "unavailable" ? "Not available" : formatMeasure(kind, value, mode),
+      peakLabel,
+      peakValue,
+      secondary,
     };
   };
 
@@ -321,84 +168,59 @@
     const mode = normalizeMode(options.mode);
     const active = Boolean(options.favorite);
     const today = dailyAt(report, 0);
-    const days = safeDaily(report);
     const resortId = String(report?.resort_id || "").trim();
-    const detailsId = `forecast-${resortId || options.index || "resort"}`.replace(/[^a-zA-Z0-9_-]/g, "-");
-    const weekOne = weekOneSnow(report);
-    const weekTwo = weekTwoSnow(report);
-    const rain = weekOneRain(report);
-    const signal = (asFiniteNumber(weekOne) || 0) > 0
-      ? "snow"
-      : ((asFiniteNumber(rain) || 0) > 0
-        ? "rain"
-        : (weekOne === null || rain === null ? "unavailable" : "quiet"));
-    const signalLabel = signal === "snow"
-      ? "Snow signal"
-      : (signal === "rain"
-        ? "Rain signal"
-        : (signal === "quiet" ? "Quiet pattern" : "Forecast pending"));
-    const outlook = outlookParts(report, mode);
-    const metricBlocks = signal === "rain"
-      ? [
-        metricBlock("7-day rain", rain, "rain", mode, { primary: true }),
-        metricBlock("Week 1 snow", weekOne, "snow", mode, { zeroCopy: "No snow forecast" }),
-        metricBlock("Week 2 snow", weekTwo, "snow", mode, { zeroCopy: "No snow forecast" }),
-      ]
-      : signal === "unavailable"
-        ? [
-          metricBlock("Week 1 snow", weekOne, "snow", mode, { zeroCopy: "No snow forecast" }),
-          metricBlock("Week 2 snow", weekTwo, "snow", mode, { zeroCopy: "No snow forecast" }),
-          metricBlock("7-day rain", rain, "rain", mode),
-        ]
-      : [
-        metricBlock("Week 1 snow", weekOne, "snow", mode, { primary: true, zeroCopy: "No snow forecast" }),
-        metricBlock("Week 2 snow", weekTwo, "snow", mode, { zeroCopy: "No snow forecast" }),
-        metricBlock("7-day rain", rain, "rain", mode),
-      ];
-    const dailyHtml = days.length
-      ? days.map((day, index) => renderDailyDetail(day, index, mode)).join("")
-      : `<p class="forecast-missing-state">Daily guidance is not available yet. Check back after the next model update.</p>`;
+    const summary = compactSignal(report, mode);
+    const href = resortHref(report);
+    const name = displayName(report);
+    const detailLink = href
+      ? `<a class="resort-detail-link" href="${escapeHtml(href)}" aria-label="Open the complete forecast for ${escapeHtml(name)}"><span>Forecast</span><svg aria-hidden="true" viewBox="0 0 20 20"><path d="m7 4 6 6-6 6"></path></svg></a>`
+      : `<span class="resort-detail-link resort-detail-link--disabled">Unavailable</span>`;
     return `
-      <article class="resort-forecast-card" data-resort-card="${escapeHtml(resortId)}" data-signal="${signal}">
-        <header class="resort-card-heading">
-          <div class="resort-card-title">
-            <p>${escapeHtml(locationLabel(report))}</p>
-            <h3>${resortLink(report, "resort-card-link")}</h3>
-            <div class="resort-tags">${passesHtml(report)}<span class="resort-signal-label" data-signal="${signal}">${signalLabel}</span></div>
-          </div>
+      <article class="resort-forecast-card" data-resort-card="${escapeHtml(resortId)}" data-result-index="${Number(options.index) || 0}" data-signal="${summary.signal}">
+        <div class="resort-favorite-cell">
           ${favoriteButton(report, active)}
-        </header>
-        <p class="resort-outlook"><strong>${escapeHtml(outlook.lead)}</strong><span>${escapeHtml(outlook.detail)}</span></p>
-        <div class="today-brief">
-          ${conditionIcon(today.weather_code, "today-brief-icon")}
-          <div><span>Today at a glance</span><strong>${escapeHtml(conditionName(today.weather_code))}</strong></div>
-          <span class="today-temperature" data-field-guide-number>${escapeHtml(formatMeasure("temperature", today.temperature_max_c, mode))} / ${escapeHtml(formatMeasure("temperature", today.temperature_min_c, mode))}</span>
         </div>
-        <dl class="resort-metric-grid">
-          ${metricBlocks.join("")}
+        <div class="resort-identity">
+          <h3 tabindex="-1">${escapeHtml(name)}</h3>
+          <div class="resort-identity-meta">
+            <span class="resort-location">${escapeHtml(locationLabel(report))}</span>
+            <span class="resort-tags">${passesHtml(report)}</span>
+          </div>
+        </div>
+        <div class="resort-today">
+          ${conditionIcon(today.weather_code, "resort-today-icon")}
+          <div>
+            <span>Today</span>
+            <strong>${escapeHtml(conditionName(today.weather_code))}</strong>
+            <small data-field-guide-number>${escapeHtml(highLowText(today, mode))}</small>
+          </div>
+        </div>
+        <dl class="resort-primary-signal" data-metric-kind="${summary.kind}"${["snow", "rain"].includes(summary.signal) ? ' data-priority="primary"' : ""}>
+          <dt><span class="signal-dot" aria-hidden="true"></span>${escapeHtml(summary.primaryLabel)}</dt>
+          <dd data-field-guide-number>${escapeHtml(summary.primaryValue)}</dd>
         </dl>
-        <ol class="near-term-list" aria-label="Three-day preview">
-          ${days.slice(0, 3).map((day, index) => renderNearTermDay(day, index, mode)).join("") || `<li class="forecast-missing-state">Near-term guidance is not available.</li>`}
-        </ol>
-        <details class="resort-day-disclosure" data-field-guide-disclosure data-resort-disclosure="${escapeHtml(resortId)}">
-          <summary aria-controls="${escapeHtml(detailsId)}">
-            <span>Full ${days.length || 14}-day forecast</span>
-            <span class="disclosure-hint">Weather, temperatures, snow, rain &amp; daylight</span>
-          </summary>
-          <div class="daily-detail-grid" id="${escapeHtml(detailsId)}">${dailyHtml}</div>
-          ${resortHref(report) ? `<a class="resort-detail-link fg-button" href="${escapeHtml(resortHref(report))}">Open resort forecast</a>` : ""}
-        </details>
+        <div class="resort-supporting-signal">
+          <div><span>${escapeHtml(summary.peakLabel)}</span><strong data-field-guide-number>${escapeHtml(summary.peakValue)}</strong></div>
+          <div><span>${escapeHtml(summary.secondary.label)}</span><strong data-field-guide-number>${escapeHtml(summary.secondary.value)}</strong></div>
+        </div>
+        ${detailLink}
       </article>`;
   };
 
   const renderResults = (reports, options = {}) => {
     const mode = normalizeMode(options.mode);
     const favorites = options.favorites instanceof Set ? options.favorites : new Set(options.favorites || []);
-    const cards = reports.map((report, index) => renderResortCard(report, {
+    const requestedLimit = Number(options.limit);
+    const limit = Number.isFinite(requestedLimit) && requestedLimit > 0 ? Math.floor(requestedLimit) : 12;
+    const visibleReports = reports.slice(0, limit);
+    const cards = visibleReports.map((report, index) => renderResortCard(report, {
       mode,
       index,
       favorite: favorites.has(String(report?.resort_id || "").trim()),
     })).join("");
+    const shownCount = visibleReports.length;
+    const remainingCount = Math.max(0, reports.length - shownCount);
+    const nextCount = Math.min(12, remainingCount);
     const empty = `
       <div class="results-empty-state">
         <span class="results-empty-icon" aria-hidden="true">×</span>
@@ -408,27 +230,25 @@
     return `
       <section class="forecast-results" aria-labelledby="results-title">
         <div class="section-heading results-heading">
-          <div><p class="section-kicker">Forecast directory</p><h2 id="results-title">Mountain-by-mountain outlook</h2></div>
-          <p>${reports.length} resort${reports.length === 1 ? "" : "s"} in this view · Select a resort to reveal every forecast day.</p>
+          <div><p class="section-kicker">Forecast directory</p><h2 id="results-title">Compare resorts</h2></div>
+          <p id="results-count" role="status">Showing ${shownCount} of ${reports.length} resort${reports.length === 1 ? "" : "s"}</p>
         </div>
+        <div class="result-column-headings" aria-hidden="true"><span></span><span>Resort</span><span>Today</span><span>7-day signal</span><span>Peak / secondary</span><span></span></div>
         <div class="resort-card-grid">${cards || empty}</div>
+        ${remainingCount ? `<div class="results-pagination"><button id="show-more-resorts" class="fg-button" type="button" data-show-more-results aria-describedby="results-count" aria-label="Show ${nextCount} more resorts; ${shownCount} of ${reports.length} currently shown">Show ${nextCount} more</button></div>` : ""}
       </section>`;
   };
 
   const render = (reports, options = {}) => {
     const safeReports = (Array.isArray(reports) ? reports : []).filter((report) => report && typeof report === "object");
-    return `${renderInsightBoard(safeReports, options.mode)}${renderResults(safeReports, options)}`;
+    return renderResults(safeReports, options);
   };
 
   window.CloseSnowFieldGuideHomepage = Object.freeze({
     escapeHtml,
-    rankCandidates,
-    rankingExplanation,
     render,
-    renderDailyDetail,
     renderResortCard,
     weekOneRain,
     weekOneSnow,
-    weekTwoSnow,
   });
 }());

--- a/assets/js/resort_hourly.js
+++ b/assets/js/resort_hourly.js
@@ -1105,12 +1105,27 @@ const renderHourlyNarrative = (payload) => {
   if (activeHourlyGroup === "storm") {
     const snow = finiteSeries(Array.isArray(hourly.snowfall) ? hourly.snowfall : []);
     const rain = finiteSeries(Array.isArray(hourly.rain) ? hourly.rain : []);
-    const snowTotal = snow.reduce((sum, value) => sum + (value || 0), 0);
-    const rainTotal = rain.reduce((sum, value) => sum + (value || 0), 0);
+    const snowReadings = snow.filter((value) => value !== null);
+    const rainReadings = rain.filter((value) => value !== null);
+    const snowTotal = snowReadings.length ? snowReadings.reduce((sum, value) => sum + value, 0) : null;
+    const rainTotal = rainReadings.length ? rainReadings.reduce((sum, value) => sum + value, 0) : null;
     const probability = extremeIndex(Array.isArray(hourly.precipitation_probability) ? hourly.precipitation_probability : []);
-    const accumulation = snowTotal > 0 || rainTotal > 0
-      ? `the model shows ${formatMetricValue("snowfall", snowTotal)} of snow and ${formatMetricValue("rain", rainTotal)} of rain.`
-      : "no accumulating snow or rain is currently modelled.";
+    let accumulation;
+    if (snowTotal === null && rainTotal === null) {
+      accumulation = "snow and rain accumulation readings are unavailable.";
+    } else if (snowTotal === 0 && rainTotal === 0) {
+      accumulation = "no accumulating snow or rain is currently modelled.";
+    } else {
+      const measured = [];
+      const missing = [];
+      if (snowTotal === null) missing.push("snow accumulation");
+      else measured.push(`${formatMetricValue("snowfall", snowTotal)} of snow`);
+      if (rainTotal === null) missing.push("rain accumulation");
+      else measured.push(`${formatMetricValue("rain", rainTotal)} of rain`);
+      const measuredCopy = measured.length ? `the model shows ${measured.join(" and ")}.` : "";
+      const missingCopy = missing.length ? `${missing.join(" and ")} readings are unavailable.` : "";
+      accumulation = `${measuredCopy} ${missingCopy}`.trim();
+    }
     const chance = probability.value === null
       ? "Precipitation probability is unavailable."
       : `The highest precipitation chance is ${Math.round(probability.value)}% around ${friendlyHour(times[probability.index])}.`;

--- a/assets/js/resort_hourly.js
+++ b/assets/js/resort_hourly.js
@@ -32,7 +32,6 @@ const thead = table ? table.querySelector("thead") : null;
 const tbody = table ? table.querySelector("tbody") : null;
 let metaState = null;
 let localTimeTimerId = null;
-let timelineAutoCentered = false;
 let lastHourlyPayload = null;
 let chartResizeRafId = null;
 let activeHourlyGroup = "storm";
@@ -41,7 +40,7 @@ const metricDefs = Array.isArray(hourlyMetricHelpers.metricDefs) ? hourlyMetricH
 const trimHourlyPayload = hourlyMetricHelpers.trimHourlyPayload;
 const HOURLY_GROUPS = Object.freeze({
   storm: Object.freeze({
-    label: "Storm",
+    label: "Precipitation",
     metrics: Object.freeze(["snowfall", "rain", "precipitation_probability"]),
   }),
   wind: Object.freeze({
@@ -80,6 +79,13 @@ const formatValue = (value) => {
     return value.toFixed(1);
   }
   return String(value);
+};
+
+const sevenDayMetricTotal = (daily, key) => {
+  const values = (Array.isArray(daily) ? daily : []).slice(0, 7)
+    .map((day) => toFiniteNumber(day?.[key]))
+    .filter((value) => value !== null);
+  return values.length ? values.reduce((sum, value) => sum + value, 0) : null;
 };
 
 const currentUnitMode = () => (fieldGuideUnits.readPreference
@@ -148,24 +154,29 @@ const strongestDailySignal = (daily, unitMode) => {
   let snowDay = null;
   let rainDay = null;
   days.forEach((day) => {
-    const snow = toFiniteNumber(day?.snowfall_cm) || 0;
-    const rain = toFiniteNumber(day?.rain_mm) || 0;
-    if (!snowDay || snow > snowDay.value) snowDay = { day, value: snow };
-    if (!rainDay || rain > rainDay.value) rainDay = { day, value: rain };
+    const snow = toFiniteNumber(day?.snowfall_cm);
+    const rain = toFiniteNumber(day?.rain_mm);
+    if (snow !== null && (!snowDay || snow > snowDay.value)) snowDay = { day, value: snow };
+    if (rain !== null && (!rainDay || rain > rainDay.value)) rainDay = { day, value: rain };
   });
+  const missingNote = !snowDay && !rainDay
+    ? "Snow and rain estimates are not available yet."
+    : (!snowDay ? "Snow estimates are not available yet." : (!rainDay ? "Rain estimates are not available yet." : ""));
   if (snowDay && snowDay.value > 0) {
     const amount = fieldGuideUnits.formatSnow
       ? fieldGuideUnits.formatSnow(snowDay.value, unitMode)
       : `${snowDay.value.toFixed(1)} cm`;
-    return `The strongest snow signal is ${amount} on ${friendlyDate(snowDay.day?.date, "the leading forecast day")}.`;
+    return `The strongest snow signal is ${amount} on ${friendlyDate(snowDay.day?.date, "the leading forecast day")}. ${missingNote}`.trim();
   }
   if (rainDay && rainDay.value > 0) {
     const amount = fieldGuideUnits.formatRain
       ? fieldGuideUnits.formatRain(rainDay.value, unitMode)
       : `${rainDay.value.toFixed(1)} mm`;
-    return `The wettest signal is ${amount} on ${friendlyDate(rainDay.day?.date, "the leading forecast day")}.`;
+    return `The wettest signal is ${amount} on ${friendlyDate(rainDay.day?.date, "the leading forecast day")}. ${missingNote}`.trim();
   }
-  return "No meaningful snow or rain signal stands out in the next seven days.";
+  if (!snowDay && !rainDay) return missingNote;
+  const availableSignals = [snowDay ? "snow" : "", rainDay ? "rain" : ""].filter(Boolean).join(" or ");
+  return `No meaningful ${availableSignals} signal stands out in the next seven days. ${missingNote}`.trim();
 };
 
 const renderResortOutlook = () => {
@@ -538,8 +549,8 @@ const renderResortSnapshot = () => {
   }
   const high = toFiniteNumber(today.temperature_max_c);
   const low = toFiniteNumber(today.temperature_min_c);
-  const snow = daily.slice(0, 7).reduce((sum, day) => sum + (toFiniteNumber(day?.snowfall_cm) || 0), 0);
-  const rain = daily.slice(0, 7).reduce((sum, day) => sum + (toFiniteNumber(day?.rain_mm) || 0), 0);
+  const snow = sevenDayMetricTotal(daily, "snowfall_cm");
+  const rain = sevenDayMetricTotal(daily, "rain_mm");
   const weatherCode = today.weather_code;
   const conditionName = fieldGuideWeather.conditionName
     ? fieldGuideWeather.conditionName(weatherCode)
@@ -562,32 +573,32 @@ const renderResortSnapshot = () => {
     : (fieldGuideUnits.formatTemperature
       ? fieldGuideUnits.formatTemperature(low, unitMode, { withUnit: false, digits: 0 })
       : String(Math.round(low)));
-  const temperature = `${formattedHigh} / ${formattedLow} ${temperatureUnit}`;
-  const snowValue = fieldGuideUnits.formatSnow ? fieldGuideUnits.formatSnow(snow, unitMode) : `${snow.toFixed(1)} cm`;
-  const rainValue = fieldGuideUnits.formatRain ? fieldGuideUnits.formatRain(rain, unitMode) : `${rain.toFixed(1)} mm`;
+  const temperature = high === null && low === null ? "Not available" : `${formattedHigh} / ${formattedLow} ${temperatureUnit}`;
+  const snowValue = snow === null
+    ? "Not available"
+    : (fieldGuideUnits.formatSnow ? fieldGuideUnits.formatSnow(snow, unitMode) : `${snow.toFixed(1)} cm`);
+  const rainValue = rain === null
+    ? "Not available"
+    : (fieldGuideUnits.formatRain ? fieldGuideUnits.formatRain(rain, unitMode) : `${rain.toFixed(1)} mm`);
   const outlook = fieldGuideCopy.dailyOutlook ? fieldGuideCopy.dailyOutlook(daily, { mode: unitMode }) : "";
-  const priority = snow > 0 ? "snow" : (rain > 0 ? "rain" : "weather");
+  const priority = snow !== null && snow > 0 ? "snow" : (rain !== null && rain > 0 ? "rain" : "weather");
   const primaryAttribute = (kind) => (priority === kind ? ' data-priority="primary"' : "");
-  const primaryLabel = (kind, fallback) => (priority === kind ? `Primary signal · ${fallback}` : fallback);
   const cards = {
     weather: `<article class="snapshot-card snapshot-card-weather" data-snapshot-kind="weather"${primaryAttribute("weather")}>
       <span class="snapshot-icon">${weatherIcon}</span>
-      <span><small>${primaryLabel("weather", "Today")}</small><strong>${temperature}</strong><em>${conditionName}</em></span>
+      <span><small>Today</small><strong>${temperature}</strong><em>${conditionName}</em></span>
     </article>`,
     snow: `<article class="snapshot-card" data-snapshot-kind="snow"${primaryAttribute("snow")}>
       <span class="snapshot-icon snapshot-icon-snow">${metricIcon("snow", "Snowfall")}</span>
-      <span><small>${primaryLabel("snow", "Next 7 days")}</small><strong>${snowValue}</strong><em>Forecast snow</em></span>
+      <span><small>7-day snow</small><strong>${snowValue}</strong><em>${snow === null ? "Awaiting model data" : "Forecast total"}</em></span>
     </article>`,
     rain: `<article class="snapshot-card" data-snapshot-kind="rain"${primaryAttribute("rain")}>
       <span class="snapshot-icon snapshot-icon-rain">${metricIcon("rain", "Rainfall")}</span>
-      <span><small>${primaryLabel("rain", "Next 7 days")}</small><strong>${rainValue}</strong><em>Forecast rain</em></span>
+      <span><small>7-day rain</small><strong>${rainValue}</strong><em>${rain === null ? "Awaiting model data" : "Forecast total"}</em></span>
     </article>`,
   };
-  const orderedKinds = priority === "weather"
-    ? ["weather", "snow", "rain"]
-    : [priority, "weather", priority === "snow" ? "rain" : "snow"];
   snapshotEl.dataset.primarySignal = priority;
-  snapshotEl.innerHTML = orderedKinds.map((kind) => cards[kind]).join("");
+  snapshotEl.innerHTML = ["weather", "snow", "rain"].map((kind) => cards[kind]).join("");
   if (outlook) snapshotEl.setAttribute("aria-label", outlook);
   snapshotEl.hidden = false;
   renderResortOutlook();
@@ -808,12 +819,14 @@ const resolveChartWidth = () => {
   if (!chartsEl) return 720;
   const containerWidth = chartsEl.getBoundingClientRect().width || chartsEl.clientWidth || 720;
   const isSingleColumn = typeof window.matchMedia === "function"
+    && window.matchMedia("(max-width: 700px)").matches;
+  const isMediumWidth = typeof window.matchMedia === "function"
     && window.matchMedia("(max-width: 980px)").matches;
-  const columns = isSingleColumn ? 1 : (activeHourlyGroup === "storm" ? 3 : 2);
+  const columns = isSingleColumn ? 1 : (activeHourlyGroup === "storm" && !isMediumWidth ? 3 : 2);
   const gap = 12;
   const cardHorizontalPadding = 22;
   const rawCardWidth = (containerWidth - (gap * (columns - 1))) / columns;
-  return Math.max(320, Math.round(rawCardWidth - cardHorizontalPadding));
+  return Math.max(280, Math.round(rawCardWidth - cardHorizontalPadding));
 };
 
 const metricSummary = (metricKey, rawValues) => {
@@ -904,8 +917,8 @@ const renderMetricChartCard = (metricKey, times, rawValues, chartWidth) => {
     return card;
   }
 
-  const width = Math.max(320, Number(chartWidth) || 720);
-  const height = 220;
+  const width = Math.max(280, Number(chartWidth) || 720);
+  const height = 190;
   const padLeft = 44;
   const padRight = 16;
   const padTop = 12;
@@ -1141,8 +1154,11 @@ const renderHourlyCharts = (payload) => {
   const frag = document.createDocumentFragment();
   const group = HOURLY_GROUPS[activeHourlyGroup] || HOURLY_GROUPS.storm;
   const primaryMetric = primaryMetricForGroup(group, hourly);
+  const orderedMetrics = primaryMetric
+    ? [primaryMetric, ...group.metrics.filter((metricKey) => metricKey !== primaryMetric)]
+    : [...group.metrics];
   chartsEl.dataset.hourlyGroup = activeHourlyGroup;
-  group.metrics.forEach((metricKey) => {
+  orderedMetrics.forEach((metricKey) => {
     const rawValues = Array.isArray(hourly[metricKey]) ? hourly[metricKey] : [];
     const card = metricKey === "wind_direction_10m"
       ? renderWindDirectionCard(times, rawValues)
@@ -1195,17 +1211,6 @@ const buildMergedTimelineDays = () => {
   return merged;
 };
 
-const centerTimelineOnToday = () => {
-  if (!timelineRoot || timelineAutoCentered) return;
-  const wrap = timelineRoot.querySelector(".field-guide-timeline");
-  const todayCell = timelineRoot.querySelector("[data-timeline-today='1']");
-  if (!(wrap instanceof HTMLElement) || !(todayCell instanceof HTMLElement)) return;
-  const targetLeft = todayCell.offsetLeft + (todayCell.offsetWidth / 2) - (wrap.clientWidth / 2);
-  const maxScroll = Math.max(0, wrap.scrollWidth - wrap.clientWidth);
-  wrap.scrollLeft = Math.max(0, Math.min(maxScroll, targetLeft));
-  timelineAutoCentered = true;
-};
-
 const daylightValue = (day, key) => {
   const local = String(day?.[`${key}_local_hhmm`] || "").trim();
   if (local) return local;
@@ -1225,6 +1230,98 @@ const appendDefinition = (list, term, value) => {
   list.appendChild(wrapper);
 };
 
+const buildTimelineDayCard = (day, unitMode, temperatureUnit) => {
+  const isToday = Boolean(day.summary_is_today);
+  const phase = isToday ? "today" : (day.summary_phase === "history" ? "history" : "forecast");
+  const phaseLabel = isToday ? "Today" : (phase === "history" ? "Past" : "Forecast");
+  const card = document.createElement("article");
+  card.className = "timeline-day-card";
+  card.dataset.phase = phase;
+  const dailySnow = toFiniteNumber(day.snowfall_cm) || 0;
+  const dailyRain = toFiniteNumber(day.rain_mm) || 0;
+  card.dataset.weatherSignal = dailySnow > 0 ? "snow" : (dailyRain > 0 ? "rain" : "quiet");
+  if (isToday) card.setAttribute("data-timeline-today", "1");
+
+  const topline = document.createElement("div");
+  topline.className = "timeline-card-topline";
+  const phaseEl = document.createElement("span");
+  phaseEl.className = "timeline-phase";
+  phaseEl.textContent = phaseLabel;
+  const date = document.createElement("time");
+  date.className = "timeline-date";
+  date.dateTime = String(day.date || "");
+  date.textContent = friendlyDate(day.date, day.summary_label || phaseLabel);
+  topline.appendChild(phaseEl);
+  topline.appendChild(date);
+
+  const condition = document.createElement("div");
+  condition.className = "timeline-condition";
+  const icon = document.createElement("span");
+  icon.innerHTML = fieldGuideWeather.iconHtml
+    ? fieldGuideWeather.iconHtml(day.weather_code)
+    : '<span class="field-guide-weather-icon" role="img" aria-label="Conditions unavailable">?</span>';
+  const conditionName = document.createElement("strong");
+  conditionName.textContent = fieldGuideWeather.conditionName
+    ? fieldGuideWeather.conditionName(day.weather_code)
+    : "Conditions unavailable";
+  condition.appendChild(icon);
+  condition.appendChild(conditionName);
+
+  const temperature = document.createElement("div");
+  temperature.className = "timeline-temperature";
+  const high = document.createElement("strong");
+  const low = document.createElement("span");
+  const highValue = fieldGuideUnits.formatTemperature
+    ? fieldGuideUnits.formatTemperature(day.temperature_max_c, unitMode, { withUnit: false, digits: 0 })
+    : formatValue(day.temperature_max_c);
+  const lowValue = fieldGuideUnits.formatTemperature
+    ? fieldGuideUnits.formatTemperature(day.temperature_min_c, unitMode, { withUnit: false, digits: 0 })
+    : formatValue(day.temperature_min_c);
+  high.textContent = `${highValue} ${temperatureUnit}`;
+  low.textContent = `Low ${lowValue} ${temperatureUnit}`;
+  temperature.appendChild(high);
+  temperature.appendChild(low);
+
+  const metrics = document.createElement("dl");
+  metrics.className = "timeline-metrics";
+  appendDefinition(metrics, "Snow", fieldGuideUnits.formatSnow
+    ? fieldGuideUnits.formatSnow(day.snowfall_cm, unitMode)
+    : `${formatValue(day.snowfall_cm)} cm`);
+  appendDefinition(metrics, "Rain", fieldGuideUnits.formatRain
+    ? fieldGuideUnits.formatRain(day.rain_mm, unitMode)
+    : `${formatValue(day.rain_mm)} mm`);
+
+  const daylight = document.createElement("dl");
+  daylight.className = "timeline-daylight";
+  appendDefinition(daylight, "Sunrise", daylightValue(day, "sunrise"));
+  appendDefinition(daylight, "Sunset", daylightValue(day, "sunset"));
+
+  card.appendChild(topline);
+  card.appendChild(condition);
+  card.appendChild(temperature);
+  card.appendChild(metrics);
+  card.appendChild(daylight);
+  return card;
+};
+
+const buildTimelineDayList = (days, unitMode, temperatureUnit) => {
+  const list = document.createElement("div");
+  list.className = "field-guide-timeline-track";
+  days.forEach((day) => list.appendChild(buildTimelineDayCard(day, unitMode, temperatureUnit)));
+  return list;
+};
+
+const appendTimelineDisclosure = (parent, label, days, unitMode, temperatureUnit) => {
+  if (!days.length) return;
+  const details = document.createElement("details");
+  details.className = "timeline-disclosure";
+  const summary = document.createElement("summary");
+  summary.textContent = `${label} (${days.length})`;
+  details.appendChild(summary);
+  details.appendChild(buildTimelineDayList(days, unitMode, temperatureUnit));
+  parent.appendChild(details);
+};
+
 const renderTimelineSummary = () => {
   if (!timelineSection || !timelineRoot) return;
   const merged = buildMergedTimelineDays();
@@ -1236,89 +1333,19 @@ const renderTimelineSummary = () => {
   timelineRoot.textContent = "";
   const unitMode = currentUnitMode();
   const temperatureUnit = fieldGuideUnits.unitLabel ? fieldGuideUnits.unitLabel("temperature", unitMode) : "°C";
+  const forecastDays = merged.filter((day) => day.summary_phase === "forecast");
+  const historyDays = merged.filter((day) => day.summary_phase === "history");
+  const firstWeek = forecastDays.slice(0, 7);
+  const laterForecast = forecastDays.slice(7);
+  const laterForecastLabel = forecastDays.length > 14 ? `Days 8–${forecastDays.length}` : "Days 8–14";
   const wrap = document.createElement("div");
   wrap.className = "field-guide-timeline";
-  wrap.tabIndex = 0;
-  wrap.setAttribute("aria-label", "Recent conditions and daily forecast. Scroll horizontally for more dates.");
-  const track = document.createElement("div");
-  track.className = "field-guide-timeline-track";
-  merged.forEach((day) => {
-    const isToday = Boolean(day.summary_is_today);
-    const phase = isToday ? "today" : (day.summary_phase === "history" ? "history" : "forecast");
-    const phaseLabel = isToday ? "Today" : (phase === "history" ? "Past" : "Forecast");
-    const card = document.createElement("article");
-    card.className = "timeline-day-card";
-    card.dataset.phase = phase;
-    const dailySnow = toFiniteNumber(day.snowfall_cm) || 0;
-    const dailyRain = toFiniteNumber(day.rain_mm) || 0;
-    card.dataset.weatherSignal = dailySnow > 0 ? "snow" : (dailyRain > 0 ? "rain" : "quiet");
-    if (isToday) card.dataset.timelineToday = "1";
-
-    const topline = document.createElement("div");
-    topline.className = "timeline-card-topline";
-    const phaseEl = document.createElement("span");
-    phaseEl.className = "timeline-phase";
-    phaseEl.textContent = phaseLabel;
-    const date = document.createElement("time");
-    date.className = "timeline-date";
-    date.dateTime = String(day.date || "");
-    date.textContent = friendlyDate(day.date, day.summary_label || phaseLabel);
-    topline.appendChild(phaseEl);
-    topline.appendChild(date);
-
-    const condition = document.createElement("div");
-    condition.className = "timeline-condition";
-    const icon = document.createElement("span");
-    icon.innerHTML = fieldGuideWeather.iconHtml
-      ? fieldGuideWeather.iconHtml(day.weather_code)
-      : '<span class="field-guide-weather-icon" role="img" aria-label="Conditions unavailable">?</span>';
-    const conditionName = document.createElement("strong");
-    conditionName.textContent = fieldGuideWeather.conditionName
-      ? fieldGuideWeather.conditionName(day.weather_code)
-      : "Conditions unavailable";
-    condition.appendChild(icon);
-    condition.appendChild(conditionName);
-
-    const temperature = document.createElement("div");
-    temperature.className = "timeline-temperature";
-    const high = document.createElement("strong");
-    const low = document.createElement("span");
-    const highValue = fieldGuideUnits.formatTemperature
-      ? fieldGuideUnits.formatTemperature(day.temperature_max_c, unitMode, { withUnit: false, digits: 0 })
-      : formatValue(day.temperature_max_c);
-    const lowValue = fieldGuideUnits.formatTemperature
-      ? fieldGuideUnits.formatTemperature(day.temperature_min_c, unitMode, { withUnit: false, digits: 0 })
-      : formatValue(day.temperature_min_c);
-    high.textContent = `High ${highValue} ${temperatureUnit}`;
-    low.textContent = `Low ${lowValue} ${temperatureUnit}`;
-    temperature.appendChild(high);
-    temperature.appendChild(low);
-
-    const metrics = document.createElement("dl");
-    metrics.className = "timeline-metrics";
-    appendDefinition(metrics, "Snow", fieldGuideUnits.formatSnow
-      ? fieldGuideUnits.formatSnow(day.snowfall_cm, unitMode)
-      : `${formatValue(day.snowfall_cm)} cm`);
-    appendDefinition(metrics, "Rain", fieldGuideUnits.formatRain
-      ? fieldGuideUnits.formatRain(day.rain_mm, unitMode)
-      : `${formatValue(day.rain_mm)} mm`);
-
-    const daylight = document.createElement("dl");
-    daylight.className = "timeline-daylight";
-    appendDefinition(daylight, "Sunrise", daylightValue(day, "sunrise"));
-    appendDefinition(daylight, "Sunset", daylightValue(day, "sunset"));
-
-    card.appendChild(topline);
-    card.appendChild(condition);
-    card.appendChild(temperature);
-    card.appendChild(metrics);
-    card.appendChild(daylight);
-    track.appendChild(card);
-  });
-  wrap.appendChild(track);
+  wrap.setAttribute("aria-label", "Today and the next six forecast days");
+  wrap.appendChild(buildTimelineDayList(firstWeek, unitMode, temperatureUnit));
   timelineRoot.appendChild(wrap);
+  appendTimelineDisclosure(timelineRoot, laterForecastLabel, laterForecast, unitMode, temperatureUnit);
+  appendTimelineDisclosure(timelineRoot, "Past 14 days", historyDays, unitMode, temperatureUnit);
   timelineSection.hidden = false;
-  window.requestAnimationFrame(centerTimelineOnToday);
 };
 
 const renderHourlyTable = (payload) => {
@@ -1470,7 +1497,6 @@ hourlyTabButtons.forEach((button, buttonIndex) => {
 window.addEventListener("resize", rerenderChartsForResize);
 window.addEventListener("closesnow:unitschange", () => {
   renderResortSnapshot();
-  timelineAutoCentered = false;
   renderTimelineSummary();
   renderNearbyAirports(lastHourlyPayload);
   if (lastHourlyPayload) {

--- a/assets/js/weather_filter_state.js
+++ b/assets/js/weather_filter_state.js
@@ -31,7 +31,7 @@
     if (sortBy === "name") return "Resort Name (A-Z)";
     if (sortBy === "favorites") return "Favorites First";
     if (sortBy === "today_snow") return "Today's Snowfall";
-    if (sortBy === "week_snow") return "This Week's Snowfall";
+    if (sortBy === "week_snow") return "7-Day Weather Signal";
     if (sortBy === "next_week_snow") return "Next Week's Snowfall";
     if (sortBy === "two_week_snow") return "Two-Week Snowfall";
     return "State (A-Z)";

--- a/assets/js/weather_page.js
+++ b/assets/js/weather_page.js
@@ -426,7 +426,13 @@
       const selectorId = window.CSS?.escape ? window.CSS.escape(options.focusFavoriteId) : options.focusFavoriteId.replaceAll("\"", "\\\"");
       const favoriteTarget = pageContentRoot.querySelector(`.favorite-btn[data-resort-id="${selectorId}"]`);
       if (favoriteTarget) favoriteTarget.focus();
-      else if (appState.filterState.favoritesOnly) favoritesOnlyToggle?.focus();
+      else {
+        const fallbackTarget = appState.filterState.favoritesOnly
+          ? favoritesOnlyToggle
+          : pageContentRoot.querySelector(".resort-forecast-card h3");
+        fallbackTarget?.focus();
+        if (resultsAnnouncer) resultsAnnouncer.textContent = "Favorite updated. Results reordered.";
+      }
     }
     if (Number.isInteger(options.focusResultIndex)) {
       pageContentRoot.querySelector(`.resort-forecast-card[data-result-index="${options.focusResultIndex}"] h3`)?.focus();

--- a/assets/js/weather_page.js
+++ b/assets/js/weather_page.js
@@ -18,6 +18,7 @@
     : null;
 
   const pageContentRoot = document.getElementById("page-content-root");
+  const resultsAnnouncer = document.getElementById("results-announcer");
   const reportDateEl = document.getElementById("report-date");
   const reportModelEl = document.getElementById("report-model");
   const visibleResortCountEl = document.getElementById("visible-resort-count");
@@ -41,6 +42,8 @@
 
   const FILTER_STORAGE_KEY = "closesnow_filter_state_v1";
   const FAVORITES_STORAGE_KEY = "closesnow_favorite_resorts_v1";
+  const INITIAL_RESULT_LIMIT = 12;
+  const RESULT_PAGE_SIZE = 12;
   const DEFAULT_AVAILABLE_FILTERS = { pass_type: {}, region: {}, subregion: {} };
   const SUBREGION_OPTIONS = [
     { value: "rockies", label: "Rockies" },
@@ -81,6 +84,7 @@
       favoritesOnly: false,
     },
   };
+  let visibleResultLimit = INITIAL_RESULT_LIMIT;
 
   const displayName = (report) => String(report?.display_name || report?.query || "").trim();
   const asFiniteNumber = (value) => {
@@ -100,6 +104,14 @@
   };
 
   const weeklySnowfall = (report) => asFiniteNumber(report?.week1_total_snowfall_cm);
+  const weeklyRainfall = (report) => {
+    const direct = asFiniteNumber(report?.week1_total_rain_mm);
+    if (direct !== null) return direct;
+    const values = (Array.isArray(report?.daily) ? report.daily : []).slice(0, 7)
+      .map((day) => asFiniteNumber(day?.rain_mm))
+      .filter((value) => value !== null);
+    return values.length ? values.reduce((total, value) => total + value, 0) : null;
+  };
   const nextWeekSnowfall = (report) => asFiniteNumber(report?.week2_total_snowfall_cm);
   const twoWeekSnowfall = (report) => {
     const weekOne = weeklySnowfall(report);
@@ -311,6 +323,7 @@
     });
 
     const sortBy = appState.filterState.sortBy;
+    const hasPositiveWeeklySnow = reports.some((report) => (weeklySnowfall(report) || 0) > 0);
     reports.sort((a, b) => {
       if (sortBy === "favorites") {
         const favoriteDelta = Number(appState.favoriteResortIds.has(String(b.resort_id || "")))
@@ -322,8 +335,12 @@
         if (delta) return delta;
       }
       if (sortBy === "week_snow") {
-        const delta = compareDescending(a, b, weeklySnowfall);
-        if (delta) return delta;
+        if (hasPositiveWeeklySnow) {
+          const snowDelta = compareDescending(a, b, weeklySnowfall);
+          if (snowDelta) return snowDelta;
+        }
+        const rainDelta = compareDescending(a, b, weeklyRainfall);
+        if (rainDelta) return rainDelta;
       }
       if (sortBy === "next_week_snow") {
         const delta = compareDescending(a, b, nextWeekSnowfall);
@@ -383,16 +400,6 @@
     unitStatusEls.forEach((element) => { element.textContent = appState.unitMode === "imperial" ? "Imperial" : "Metric"; });
   };
 
-  const captureOpenDisclosures = () => new Set(Array.from(
-    pageContentRoot?.querySelectorAll("details[data-resort-disclosure][open]") || [],
-  ).map((details) => details.getAttribute("data-resort-disclosure")));
-
-  const restoreOpenDisclosures = (ids) => {
-    pageContentRoot?.querySelectorAll("details[data-resort-disclosure]").forEach((details) => {
-      if (ids.has(details.getAttribute("data-resort-disclosure"))) details.open = true;
-    });
-  };
-
   const emptyStateMessage = () => {
     if (appState.filterState.favoritesOnly && appState.favoriteResortIds.size === 0) {
       return "You have not saved any favorites yet. Turn off Favorites only, then use the heart button on a resort.";
@@ -403,14 +410,13 @@
 
   const renderPage = (options = {}) => {
     if (!pageContentRoot || !appState.payload || typeof homepage.render !== "function") return;
-    const openDisclosures = captureOpenDisclosures();
     const visibleReports = filteredReports();
     pageContentRoot.innerHTML = homepage.render(visibleReports, {
       mode: appState.unitMode,
       favorites: appState.favoriteResortIds,
       emptyMessage: emptyStateMessage(),
+      limit: visibleResultLimit,
     });
-    restoreOpenDisclosures(openDisclosures);
     pageContentRoot.removeAttribute("data-loading");
     pageContentRoot.setAttribute("aria-busy", "false");
     syncFilterSummary(visibleReports.length, payloadReports().length);
@@ -418,7 +424,16 @@
     document.body.classList.remove("units-pending");
     if (options.focusFavoriteId) {
       const selectorId = window.CSS?.escape ? window.CSS.escape(options.focusFavoriteId) : options.focusFavoriteId.replaceAll("\"", "\\\"");
-      pageContentRoot.querySelector(`.favorite-btn[data-resort-id="${selectorId}"]`)?.focus();
+      const favoriteTarget = pageContentRoot.querySelector(`.favorite-btn[data-resort-id="${selectorId}"]`);
+      if (favoriteTarget) favoriteTarget.focus();
+      else if (appState.filterState.favoritesOnly) favoritesOnlyToggle?.focus();
+    }
+    if (Number.isInteger(options.focusResultIndex)) {
+      pageContentRoot.querySelector(`.resort-forecast-card[data-result-index="${options.focusResultIndex}"] h3`)?.focus();
+    }
+    if (options.announceResults && resultsAnnouncer) {
+      const shownCount = Math.min(visibleResultLimit, visibleReports.length);
+      resultsAnnouncer.textContent = `Showing ${shownCount} of ${visibleReports.length} resorts.`;
     }
   };
 
@@ -426,7 +441,8 @@
     const scrollX = window.scrollX;
     const scrollY = window.scrollY;
     renderPage(options);
-    window.requestAnimationFrame(() => window.scrollTo(scrollX, scrollY));
+    const movedFocus = Boolean(options.focusFavoriteId) || Number.isInteger(options.focusResultIndex);
+    if (!movedFocus) window.requestAnimationFrame(() => window.scrollTo(scrollX, scrollY));
   };
 
   const renderSubregionOptions = () => {
@@ -532,6 +548,7 @@
   const applyFiltersImmediately = async () => {
     cancelScheduledFilterApply();
     applyFilterStateFromControls();
+    visibleResultLimit = INITIAL_RESULT_LIMIT;
     if (isDynamicApiDataUrl()) {
       try {
         await reloadDynamicPayloadForFilters();
@@ -607,11 +624,22 @@
       }
     });
     document.addEventListener("click", (event) => {
+      const showMoreButton = event.target.closest("[data-show-more-results]");
+      if (showMoreButton) {
+        event.preventDefault();
+        const firstNewResultIndex = visibleResultLimit;
+        visibleResultLimit += RESULT_PAGE_SIZE;
+        renderPage({ focusResultIndex: firstNewResultIndex, announceResults: true });
+        return;
+      }
       const button = event.target.closest(".favorite-btn[data-resort-id]");
       if (!button) return;
       event.preventDefault();
       const resortId = String(button.getAttribute("data-resort-id") || "");
       toggleFavorite(resortId);
+      if (appState.filterState.favoritesOnly || appState.filterState.sortBy === "favorites") {
+        visibleResultLimit = INITIAL_RESULT_LIMIT;
+      }
       renderPagePreservingPosition({ focusFavoriteId: resortId });
     });
   };

--- a/src/web/templates/resort_hourly_page.html
+++ b/src/web/templates/resort_hourly_page.html
@@ -37,39 +37,36 @@
           <h1 id="hourly-title">Loading resort…</h1>
           <p id="resort-context" class="resort-context"></p>
           <p id="resort-outlook" class="resort-outlook">Building the latest seven-day outlook.</p>
-          <div class="resort-identity-meta" aria-label="Resort details and actions">
-            <p id="resort-local-time" class="resort-local-time"></p>
-            <p id="resort-website-link" class="resort-website-link"></p>
-            <p id="resort-location-link" class="resort-location-link"></p>
-          </div>
         </div>
         <div id="resort-snapshot" class="resort-snapshot" aria-label="Resort forecast overview"></div>
       </div>
+      <details class="resort-identity-disclosure" data-field-guide-disclosure>
+        <summary>Resort links &amp; local time</summary>
+        <div class="resort-identity-meta" aria-label="Resort details and actions">
+          <p id="resort-local-time" class="resort-local-time"></p>
+          <p id="resort-website-link" class="resort-website-link"></p>
+          <p id="resort-location-link" class="resort-location-link"></p>
+        </div>
+      </details>
     </section>
 
     <section id="resort-timeline-section" class="resort-timeline-section field-guide-section" hidden>
       <div class="section-heading">
         <div>
-          <p class="eyebrow">Daily field guide</p>
-          <h2>Recent weather and 14-day outlook</h2>
-          <p>Every card keeps conditions, temperature, snow, rain, and daylight together.</p>
-        </div>
-        <div class="timeline-legend" aria-label="Timeline legend">
-          <span data-phase="history">Past</span>
-          <span data-phase="today">Today</span>
-          <span data-phase="forecast">Forecast</span>
+          <p class="eyebrow">Daily forecast</p>
+          <h2>Today and the next 14 days</h2>
+          <p>The first week stays in view. Later and past dates are available on demand.</p>
         </div>
       </div>
-      <div class="timeline-scroll-hint" aria-hidden="true">Scroll dates →</div>
       <div id="resort-timeline-root"></div>
     </section>
 
     <section class="hourly-workspace field-guide-section" aria-labelledby="hourly-section-title">
       <div class="hourly-workspace-heading">
         <div>
-          <p class="eyebrow">Weather, hour by hour</p>
-          <h2 id="hourly-section-title" class="hourly-section-title">Read the next weather window</h2>
-          <p>Choose a layer to focus on what changes mountain travel and visibility.</p>
+          <p class="eyebrow">Hour by hour</p>
+          <h2 id="hourly-section-title" class="hourly-section-title">Hourly forecast</h2>
+          <p>Focus on precipitation, wind, or mountain visibility.</p>
         </div>
         <div class="hourly-controls">
           <label for="hours-select">Forecast range</label>
@@ -82,16 +79,19 @@
           <button id="hours-refresh-btn" type="button">Refresh</button>
         </div>
       </div>
-      <p id="hourly-meta" class="hourly-meta" aria-live="polite">Loading the hourly field report…</p>
+      <details class="hourly-meta-disclosure" data-field-guide-disclosure>
+        <summary>Forecast source &amp; coordinates</summary>
+        <p id="hourly-meta" class="hourly-meta" aria-live="polite">Loading the hourly field report…</p>
+      </details>
       <div id="hourly-error" class="hourly-error" role="alert" hidden></div>
       <div id="hourly-chart-error" class="hourly-chart-error" role="alert" hidden></div>
       <p id="hourly-narrative" class="hourly-narrative" aria-live="polite"></p>
       <div class="hourly-view-tabs" role="tablist" aria-label="Hourly forecast layers">
-        <button id="hourly-tab-storm" type="button" role="tab" aria-selected="true" aria-controls="hourly-charts" tabindex="0" data-hourly-group="storm">Storm</button>
+        <button id="hourly-tab-storm" type="button" role="tab" aria-selected="true" aria-controls="hourly-charts" tabindex="0" data-hourly-group="storm">Precipitation</button>
         <button id="hourly-tab-wind" type="button" role="tab" aria-selected="false" aria-controls="hourly-charts" tabindex="-1" data-hourly-group="wind">Wind</button>
         <button id="hourly-tab-visibility" type="button" role="tab" aria-selected="false" aria-controls="hourly-charts" tabindex="-1" data-hourly-group="visibility">Visibility &amp; depth</button>
       </div>
-      <section id="hourly-charts" class="hourly-charts" role="tabpanel" aria-labelledby="hourly-tab-storm" tabindex="0" aria-live="polite"></section>
+      <section id="hourly-charts" class="hourly-charts" role="tabpanel" aria-labelledby="hourly-tab-storm" tabindex="0"></section>
       <details class="raw-data-panel" data-field-guide-disclosure>
         <summary>Inspect complete hourly data</summary>
         <p>Every hourly reading in the selected range is shown below using your chosen unit system.</p>
@@ -104,16 +104,16 @@
       </details>
     </section>
 
-    <section id="resort-airport-access-section" class="resort-airport-access-section field-guide-section" hidden>
-      <div class="section-heading">
-        <div>
-          <p class="eyebrow">Getting there</p>
-          <h2>Nearby airports</h2>
-          <p>Airports within roughly 250 miles, ordered from the mountain outward.</p>
-        </div>
-      </div>
+    <details id="resort-airport-access-section" class="resort-airport-access-section field-guide-section" hidden>
+      <summary>
+        <span class="airport-disclosure-copy">
+          <span class="eyebrow">Travel planning</span>
+          <strong>Nearby airports</strong>
+          <span>Airports within roughly 250 miles</span>
+        </span>
+      </summary>
       <div id="resort-airport-access-root"></div>
-    </section>
+    </details>
   </main>
   <footer class="page-footer"><strong>CloseSnow</strong><span>Forecast data translated for better mountain decisions.</span></footer>
   <script>

--- a/src/web/templates/weather_page.html
+++ b/src/web/templates/weather_page.html
@@ -33,13 +33,13 @@
   </header>
 
   <main class="field-guide-home">
-    <section class="morning-masthead" aria-labelledby="page-title">
-      <div class="morning-masthead__copy">
+    <section class="report-overview" aria-labelledby="page-title">
+      <div class="report-overview__copy">
         <p class="section-kicker">Mountain morning report</p>
-        <h1 id="page-title">Make the call before first chair.</h1>
-        <p>See where the useful weather is, why it matters, and what every forecast day looks like—without reading a spreadsheet.</p>
+        <h1 id="page-title">Compare mountain conditions</h1>
+        <p>Today and the next seven days, with complete detail one resort away.</p>
       </div>
-      <dl class="morning-meta" aria-label="Forecast report details">
+      <dl class="report-meta" aria-label="Forecast report details">
         <div>
           <dt>Updated</dt>
           <dd id="report-date" data-generated-utc="{{generated_utc_iso}}">Loading forecast time…</dd>
@@ -47,14 +47,6 @@
         <div>
           <dt>Model</dt>
           <dd id="report-model">ECMWF IFS 0.25</dd>
-        </div>
-        <div>
-          <dt>In view</dt>
-          <dd id="visible-resort-count">Loading resorts…</dd>
-        </div>
-        <div>
-          <dt>Units</dt>
-          <dd data-field-guide-unit-status>Metric</dd>
         </div>
       </dl>
     </section>
@@ -94,6 +86,7 @@
       </div>
     </section>
 
+    <p id="results-announcer" class="sr-only" aria-live="polite"></p>
     <div id="page-content-root" data-loading="1" aria-busy="true">
       {{page_shell_placeholder}}
     </div>
@@ -115,7 +108,7 @@
             <option value="name">Resort name (A–Z)</option>
             <option value="favorites">Favorites first</option>
             <option value="today_snow">Today's snowfall</option>
-            <option value="week_snow" selected>This week's snowfall</option>
+            <option value="week_snow" selected>7-day weather signal</option>
             <option value="next_week_snow">Next week's snowfall</option>
             <option value="two_week_snow">Two-week snowfall</option>
           </select>

--- a/src/web/weather_html_renderer.py
+++ b/src/web/weather_html_renderer.py
@@ -9,13 +9,14 @@ from typing import Any, Dict, List
 _PAGE_TEMPLATE = (Path(__file__).resolve().parent / "templates" / "weather_page.html").read_text(encoding="utf-8")
 
 _PAGE_SHELL_PLACEHOLDER = """
-    <section class="insight-board forecast-loading-overview" aria-hidden="true">
-      <div class="skeleton skeleton-heading"></div>
-      <div class="insight-grid loading-card-grid"><div class="skeleton skeleton-card"></div><div class="skeleton skeleton-card"></div><div class="skeleton skeleton-card"></div></div>
-    </section>
     <section class="forecast-results forecast-section-loading" aria-hidden="true">
       <div class="skeleton skeleton-heading"></div>
-      <div class="resort-card-grid"><div class="skeleton skeleton-resort-card"></div><div class="skeleton skeleton-resort-card"></div></div>
+      <div class="resort-card-grid">
+        <div class="skeleton skeleton-resort-card"></div>
+        <div class="skeleton skeleton-resort-card"></div>
+        <div class="skeleton skeleton-resort-card"></div>
+        <div class="skeleton skeleton-resort-card"></div>
+      </div>
       <p class="section-loading sr-only">Loading forecast...</p>
     </section>
 """

--- a/tests/frontend/test_renderers.py
+++ b/tests/frontend/test_renderers.py
@@ -244,13 +244,15 @@ def test_build_html_contains_meta_sections():
     assert "<!doctype html>" in html
     assert "CloseSnow Mountain Morning Report" in html
     assert "CloseSnow" in html
-    assert "Make the call before first chair." in html
-    assert "without reading a spreadsheet" in html
-    assert "forecast-loading-overview" in html
+    assert "Compare mountain conditions" in html
+    assert "Today and the next seven days" in html
+    assert 'class="report-overview"' in html
+    assert 'id="results-announcer"' in html
+    assert "forecast-section-loading" in html
     assert 'class="skeleton skeleton-resort-card"' in html
     assert "Loading forecast..." in html
     assert 'id="report-model"' in html
-    assert 'id="visible-resort-count"' in html
+    assert 'id="filter-summary"' in html
     assert "Mountain-by-mountain outlook" not in html
     assert 'href="assets/css/field_guide_foundation.css"' in html
     assert html.index('href="assets/css/field_guide_foundation.css"') < html.index('href="assets/css/weather_page.css"')

--- a/tests/frontend/test_static_site_pipeline.py
+++ b/tests/frontend/test_static_site_pipeline.py
@@ -143,9 +143,17 @@ def test_render_hourly_pages(tmp_path):
     assert 'data-hourly-group="storm"' in html
     assert 'data-hourly-group="wind"' in html
     assert 'data-hourly-group="visibility"' in html
+    assert ">Precipitation</button>" in html
+    assert ">Wind</button>" in html
+    assert ">Visibility &amp; depth</button>" in html
     assert 'id="hourly-narrative"' in html
     assert 'id="hourly-charts"' in html
+    hourly_charts_tag = html.split('id="hourly-charts"', 1)[1].split(">", 1)[0]
+    assert 'role="tabpanel"' in hourly_charts_tag
+    assert "aria-live" not in hourly_charts_tag
     assert 'class="raw-data-panel"' in html
+    assert '<details id="resort-airport-access-section"' in html
+    assert '<details class="raw-data-panel" data-field-guide-disclosure>' in html
     context = _hourly_context_from_html(html)
     assert context["resortId"] == "snowbird-ut"
     assert context["dailySummary"]["display_name"] == "Snowbird, Utah"

--- a/tests/frontend/test_styles_and_transform.py
+++ b/tests/frontend/test_styles_and_transform.py
@@ -488,6 +488,7 @@ def test_resort_field_guide_groups_hourly_weather_and_preserves_daily_detail():
     assert 'metrics: Object.freeze(["wind_speed_10m", "wind_direction_10m"])' in js
     assert 'metrics: Object.freeze(["visibility", "snow_depth"])' in js
     assert "renderHourlyNarrative" in js
+    assert "snow and rain accumulation readings are unavailable." in js
     assert "renderWindDirectionCard" in js
     assert 'label.textContent = "Bottom line"' in js
     assert "snapshotEl.dataset.primarySignal = priority" in js
@@ -557,5 +558,6 @@ def test_integration_removes_superseded_assets_and_defines_compact_results():
     assert "const weeklyRainfall" in weather_js
     assert "const hasPositiveWeeklySnow" in weather_js
     assert "compareDescending(a, b, weeklyRainfall)" in weather_js
+    assert "Favorite updated. Results reordered." in weather_js
     assert 'return "7-Day Weather Signal"' in filter_js
     assert ">7-day weather signal</option>" in template

--- a/tests/frontend/test_styles_and_transform.py
+++ b/tests/frontend/test_styles_and_transform.py
@@ -326,49 +326,10 @@ def test_field_guide_styles_define_shared_semantics_and_compact_header():
     assert "details[data-field-guide-disclosure]" in css
     assert "@media (forced-colors: active)" in css
     assert ".snapshot-card-weather .snapshot-icon {\n  color: var(--fg-glacier);" in css
+    assert css.count("min-height: 44px") >= 3
 
 
-def test_homepage_ranking_explains_signal_best_day_and_temperature_context():
-    result = _run_homepage_expression(
-        """(() => {
-  const homepage = window.CloseSnowFieldGuideHomepage;
-  const reports = [
-    {
-      resort_id: "quiet",
-      display_name: "Quiet Hill",
-      week1_total_snowfall_cm: 1,
-      week1_total_rain_mm: 0,
-      daily: [{ date: "2026-03-03", snowfall_cm: 1, rain_mm: 0, temperature_max_c: 2, temperature_min_c: -4 }],
-    },
-    {
-      resort_id: "deep",
-      display_name: "Deep Peak",
-      week1_total_snowfall_cm: 12,
-      week1_total_rain_mm: 1.2,
-      daily: [
-        { date: "2026-03-03", snowfall_cm: 2, rain_mm: 0, temperature_max_c: -1, temperature_min_c: -8 },
-        { date: "2026-03-04", snowfall_cm: 8, rain_mm: 0, temperature_max_c: 1, temperature_min_c: -5 },
-      ],
-    },
-  ];
-  const ranked = homepage.rankCandidates(reports, 2);
-  return {
-    order: ranked.map((entry) => entry.report.resort_id),
-    signal: ranked[0].signal,
-    explanation: homepage.rankingExplanation(ranked[0].report, ranked[0].signal, "metric"),
-  };
-})()"""
-    )
-
-    assert result["order"] == ["deep", "quiet"]
-    assert result["signal"] == "snow"
-    assert "12.0 cm of snow is forecast over seven days" in result["explanation"]
-    assert "Mar 4" in result["explanation"]
-    assert "8.0 cm" in result["explanation"]
-    assert "-8 °C to -1 °C" in result["explanation"]
-
-
-def test_homepage_card_discloses_every_daily_field_uses_global_units_and_escapes_content():
+def test_homepage_card_is_compact_uses_global_units_and_escapes_content():
     result = _run_homepage_expression(
         """(() => {
   const homepage = window.CloseSnowFieldGuideHomepage;
@@ -411,21 +372,21 @@ def test_homepage_card_discloses_every_daily_field_uses_global_units_and_escapes
     assert "State &lt;unsafe&gt;" in result
     assert "<script>alert(1)</script>" not in result
     assert 'aria-pressed="true"' in result
-    assert "Full 2-day forecast" in result
-    assert result.count('class="daily-detail-card"') == 2
-    assert "High / low" in result
-    assert ">Snow<" in result
-    assert ">Rain<" in result
-    assert ">Daylight<" in result
-    assert "32 °F" in result
+    assert "Today" in result
+    assert "Snow" in result
+    assert "32 °F / 14 °F" in result
+    assert "7-day snow" in result
     assert "1.0 in" in result
+    assert "7-day rain" in result
     assert "1.00 in" in result
-    assert "07:01–18:22" in result
-    assert "07:00–18:23" in result
-    assert "No snow forecast" in result
+    assert "Peak Today" in result
+    assert 'aria-label="Open the complete forecast for Peak &lt;script&gt;alert(1)&lt;/script&gt;"' in result
+    assert "Full 2-day forecast" not in result
+    assert "daily-detail-card" not in result
+    assert "data-resort-disclosure" not in result
 
 
-def test_homepage_visual_hierarchy_exposes_ranked_and_primary_weather_signals():
+def test_homepage_compact_signals_and_pagination_are_honest():
     result = _run_homepage_expression(
         """(() => {
   const homepage = window.CloseSnowFieldGuideHomepage;
@@ -452,19 +413,39 @@ def test_homepage_visual_hierarchy_exposes_ranked_and_primary_weather_signals():
   return {
     board: homepage.render([snowReport], { mode: "metric" }),
     rainCard: homepage.renderResortCard(rainReport, { mode: "metric" }),
+    paged: homepage.render(Array.from({ length: 13 }, (_, index) => ({
+      resort_id: `resort-${index}`,
+      display_name: `Resort ${index}`,
+      week1_total_snowfall_cm: index + 1,
+      week1_total_rain_mm: 0,
+      daily: [{ date: "2026-03-03", snowfall_cm: index + 1, rain_mm: 0 }],
+    })), { mode: "metric", limit: 12 }),
+    expanded: homepage.render(Array.from({ length: 13 }, (_, index) => ({
+      resort_id: `resort-${index}`,
+      display_name: `Resort ${index}`,
+      week1_total_snowfall_cm: index + 1,
+      week1_total_rain_mm: 0,
+      daily: [{ date: "2026-03-03", snowfall_cm: index + 1, rain_mm: 0 }],
+    })), { mode: "metric", limit: 13 }),
   };
 })()"""
     )
 
-    assert 'data-rank="1" data-signal="snow"' in result["board"]
-    assert 'class="insight-signal"' in result["board"]
+    assert 'data-signal="snow"' in result["board"]
     assert "7-day snow" in result["board"]
     assert "18.0 cm" in result["board"]
-    assert 'data-signal="snow"' in result["board"]
     assert 'data-priority="primary"' in result["board"]
     assert 'data-signal="rain"' in result["rainCard"]
-    assert "Rain signal" in result["rainCard"]
+    assert "7-day rain" in result["rainCard"]
+    assert "42.0 mm" in result["rainCard"]
     assert 'data-metric-kind="rain" data-priority="primary"' in result["rainCard"]
+    assert result["paged"].count('data-resort-card="') == 12
+    assert "data-show-more-results" in result["paged"]
+    assert "Show 1 more resorts; 12 of 13 currently shown" in result["paged"]
+    assert result["expanded"].count('data-resort-card="') == 13
+    assert "data-show-more-results" not in result["expanded"]
+    assert "insight-board" not in result["paged"]
+    assert "daily-detail-card" not in result["paged"]
 
 
 def test_homepage_missing_and_no_results_copy_is_honest_and_readable():
@@ -481,19 +462,18 @@ def test_homepage_missing_and_no_results_copy_is_honest_and_readable():
 })()"""
     )
 
-    assert "Forecast details are not available for this resort yet." in result["missing"]
-    assert "Daily guidance is not available yet." in result["missing"]
-    assert "Forecast pending" in result["missing"]
+    assert "Pending · 7-day forecast" in result["missing"]
+    assert "Not available" in result["missing"]
     assert "Quiet pattern" not in result["missing"]
     assert 'data-priority="primary"' not in result["missing"]
-    assert "Forecast pending" in result["partial"]
+    assert "Pending · 7-day forecast" in result["partial"]
     assert "Quiet pattern" not in result["partial"]
-    assert "Forecast signal unavailable" in result["inactiveBoard"]
-    assert "not complete enough to rank" in result["inactiveBoard"]
-    assert "shows no accumulating snow or rain" not in result["inactiveBoard"]
-    assert "Storm signal" not in result["inactiveBoard"]
-    assert "No active weather to rank" in result["quietBoard"]
-    assert "shows no accumulating snow or rain" in result["quietBoard"]
+    assert "Pending · 7-day forecast" in result["inactiveBoard"]
+    assert "insight-board" not in result["inactiveBoard"]
+    assert "Quiet · 7-day snow" in result["quietBoard"]
+    assert "7-day rain" in result["quietBoard"]
+    assert "0.0 cm" in result["quietBoard"]
+    assert "0.0 mm" in result["quietBoard"]
     assert "No resorts match this view" in result["empty"]
     assert "Try clearing your filters." in result["empty"]
 
@@ -501,6 +481,7 @@ def test_homepage_missing_and_no_results_copy_is_honest_and_readable():
 def test_resort_field_guide_groups_hourly_weather_and_preserves_daily_detail():
     js = (REPO_ROOT / "assets" / "js" / "resort_hourly.js").read_text(encoding="utf-8")
     css = (REPO_ROOT / "assets" / "css" / "resort_hourly.css").read_text(encoding="utf-8")
+    template = (REPO_ROOT / "src" / "web" / "templates" / "resort_hourly_page.html").read_text(encoding="utf-8")
 
     assert "HOURLY_GROUPS" in js
     assert 'metrics: Object.freeze(["snowfall", "rain", "precipitation_probability"])' in js
@@ -510,13 +491,25 @@ def test_resort_field_guide_groups_hourly_weather_and_preserves_daily_detail():
     assert "renderWindDirectionCard" in js
     assert 'label.textContent = "Bottom line"' in js
     assert "snapshotEl.dataset.primarySignal = priority" in js
+    assert "const sevenDayMetricTotal" in js
+    assert ".filter((value) => value !== null)" in js
+    assert 'snow === null ? "Awaiting model data"' in js
+    assert 'rain === null ? "Awaiting model data"' in js
     assert "card.dataset.weatherSignal" in js
     assert "primaryMetricForGroup" in js
+    assert "const orderedMetrics = primaryMetric" in js
+    assert ": [...group.metrics]" in js
+    assert "orderedMetrics.forEach" in js
     assert 'if (hasPositiveReading("snowfall")) return "snowfall"' in js
     assert 'if (hasPositiveReading("rain")) return "rain"' in js
     assert 'if (metricKey === primaryMetric) card.dataset.priority = "primary"' in js
     assert "fieldGuideWeather.iconHtml" in js
     assert "data-timeline-today" in js
+    assert "const firstWeek = forecastDays.slice(0, 7)" in js
+    assert "const laterForecast = forecastDays.slice(7)" in js
+    assert '"Days 8–14"' in js
+    assert "appendTimelineDisclosure(timelineRoot, laterForecastLabel" in js
+    assert 'appendTimelineDisclosure(timelineRoot, "Past 14 days"' in js
     assert 'appendDefinition(daylight, "Sunrise"' in js
     assert 'appendDefinition(daylight, "Sunset"' in js
     assert "Resort Forecast:" not in js
@@ -524,27 +517,45 @@ def test_resort_field_guide_groups_hourly_weather_and_preserves_daily_detail():
 
     assert ".resort-masthead" in css
     assert ".field-guide-timeline-track" in css
+    assert ".timeline-disclosure" in css
     assert '.timeline-day-card[data-phase="today"]' in css
     assert '.snapshot-card[data-priority="primary"]' in css
     assert '.chart-card[data-priority="primary"]' in css
-    assert ".hourly-narrative::before" in css
-    assert "opacity: 0.24" in css
     assert ".hourly-view-tabs" in css
+    assert "scroll-snap-type: x mandatory" in css
     assert ".wind-direction-grid" in css
     assert ".resort-hero-mountain" not in css
+    assert ">Precipitation</button>" in template
+    assert ">Wind</button>" in template
+    assert ">Visibility &amp; depth</button>" in template
+    hourly_charts_tag = template.split('id="hourly-charts"', 1)[1].split(">", 1)[0]
+    assert 'role="tabpanel"' in hourly_charts_tag
+    assert "aria-live" not in hourly_charts_tag
+    assert '<details id="resort-airport-access-section"' in template
+    assert '<details class="resort-identity-disclosure"' in template
+    assert '<details class="hourly-meta-disclosure"' in template
+    assert '<details class="raw-data-panel"' in template
 
 
-def test_integration_removes_superseded_frontend_assets_and_stacks_mobile_insights():
+def test_integration_removes_superseded_assets_and_defines_compact_results():
     manifest_paths = {asset.repository_path for asset in WEB_ASSET_MANIFEST}
     assert "assets/js/compact_daily_summary.js" not in manifest_paths
     assert "assets/js/weather_code_emoji.js" not in manifest_paths
     assert "assets/js/sticky_single_table_layout.js" not in manifest_paths
 
     homepage_css = (REPO_ROOT / "assets" / "css" / "weather_page.css").read_text(encoding="utf-8")
-    assert "grid-auto-flow: column" not in homepage_css
-    assert ".insight-grid," in homepage_css
-    assert "grid-template-columns: minmax(0, 1fr)" in homepage_css
-    assert '.insight-card[data-rank="1"]' in homepage_css
-    assert '.insight-card[data-rank="1"] .insight-resort-link:focus-visible' in homepage_css
-    assert "box-shadow: var(--fg-shadow-raised)" in homepage_css
+    assert ".report-overview" in homepage_css
+    assert ".result-column-headings" in homepage_css
+    assert "height: 96px" in homepage_css
+    assert "min-height: 164px" in homepage_css
+    assert ".results-pagination" in homepage_css
     assert "transform: translateY" not in homepage_css
+
+    weather_js = (REPO_ROOT / "assets" / "js" / "weather_page.js").read_text(encoding="utf-8")
+    filter_js = (REPO_ROOT / "assets" / "js" / "weather_filter_state.js").read_text(encoding="utf-8")
+    template = (REPO_ROOT / "src" / "web" / "templates" / "weather_page.html").read_text(encoding="utf-8")
+    assert "const weeklyRainfall" in weather_js
+    assert "const hasPositiveWeeklySnow" in weather_js
+    assert "compareDescending(a, b, weeklyRainfall)" in weather_js
+    assert 'return "7-Day Weather Signal"' in filter_js
+    assert ">7-day weather signal</option>" in template

--- a/tests/smoke/test_static_pipeline_smoke.py
+++ b/tests/smoke/test_static_pipeline_smoke.py
@@ -71,7 +71,8 @@ def test_static_split_pipeline_smoke(monkeypatch, tmp_path, valid_payload):
     html = Path(render_args.output_dir, "index.html").read_text(encoding="utf-8")
     assert "<!doctype html>" in html
     assert "CloseSnow Mountain Morning Report" in html
-    assert "Make the call before first chair." in html
+    assert "Compare mountain conditions" in html
+    assert "Make the call before first chair." not in html
     assert 'src="assets/js/field_guide_homepage.js"' in html
     assert "window.CLOSESNOW_INITIAL_PAYLOAD = {" in html
     assert "Snowbird, Utah" in html


### PR DESCRIPTION
## What changed
- rebuild the homepage as a compact resort comparison workspace with 12-result progressive loading
- prioritize the strongest 7-day weather signal and retain search, filters, favorites, and units
- rebuild resort pages around a compact bottom line, seven visible days, and on-demand deeper data
- add responsive 390px, 768px, and desktop layouts with accessible 44px controls
- preserve missing-value honesty and all 15 forecast days

## Verification
- 266 tests passed
- asset lint and Ruff passed
- generated 125 resort hourly artifacts and pages
- browser-tested pagination, search, favorites focus, units, ranges, disclosures, tabs, and responsive geometry